### PR TITLE
Remove dead testing link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ be a bit behind the latest version found in the master branch of this repository
     python setup.py test
 ```
 
-For testing strategy, please see [Testing](no-link)
-
 # Contributing
 * See Issues tab, and feel free to submit your own issues 
 * Add PRs if you discover a solution to an existing issue


### PR DESCRIPTION
### - What I did

I removed a link that was leading to a 404 page.

### - How I did it

Just removed the line from the README file.

### - How to verify it

Open the readme and click the testing link.

### - Description for the changelog

Remove dead testing link from README

### - Cute Animal Picture

I have plants
![photo4949638119024601011](https://user-images.githubusercontent.com/617831/33140238-03ad4090-cf75-11e7-80ea-e932bf00cb7a.jpg)

