### PR TITLE
fix-return-list-type

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -153,3 +153,32 @@ def test_array(x: num, y: num, z: num, w: num) -> num:
     c = get_contract_with_gas_estimation(two_d_array_accessor)
     assert c.test_array(2, 7, 1, 8) == 2718
     print('Passed complex array accessor test')
+
+
+def test_returns_lists():
+    code = """
+@public
+def test_array_num_return() -> num[2][2]:
+    a = [[1,2],[3,4]]
+    return a
+
+@public
+def test_array_decimal_return1() -> decimal[2][2]:
+    a = [[1.0,2.0],[3.0,4.0]]
+    return a
+
+@public
+def test_array_decimal_return2() -> decimal[2][2]:
+    return [[1,2],[3,4]]
+
+@public
+def test_array_decimal_return3() -> decimal[2][2]:
+    a = [[1,2],[3,4]]
+    return a
+"""
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.test_array_num_return() == [[1, 2], [3, 4]]
+    assert c.test_array_decimal_return1() == [[1.0, 2.0], [3.0, 4.0]]
+    assert c.test_array_decimal_return2() == [[1.0, 2.0], [3.0, 4.0]]
+    assert c.test_array_decimal_return3() == [[1.0, 2.0], [3.0, 4.0]]

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -363,14 +363,7 @@ class Stmt(object):
         elif isinstance(sub.typ, ListType):
             sub_base_type = re.split(r'\(|\[', str(sub.typ.subtype))[0]
             ret_base_type = re.split(r'\(|\[', str(self.context.return_type.subtype))[0]
-            if sub_base_type != ret_base_type and sub.value != 'multi':
-                raise TypeMismatchException(
-                    "List return type %r does not match specified return type, expecting %r" % (
-                        sub_base_type, ret_base_type
-                    ),
-                    self.stmt
-                )
-            if sub.location == "memory" and sub.value != "multi":
+            if sub_base_type == ret_base_type and sub.location == "memory" and sub.value != "multi":
                 return LLLnode.from_list(['return', sub, get_size_of_type(self.context.return_type) * 32],
                                             typ=None, pos=getpos(self.stmt))
             else:


### PR DESCRIPTION
### - What I did
Fix returns so that lists as input/assigned value can be returned.
Fixes #553 
### - How I did it
Changed a check for returns in `stmt.py` to check that return types are matching.

### - How to verify it
Look at the tests I added
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33746130-753dd81c-dbbb-11e7-80c0-4157384e33bc.png)

