### PR TITLE
Add num256 modulo math checks

### DIFF
--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -59,6 +59,7 @@ def _num256_le(x: num256, y: num256) -> bool:
     assert c._num256_div(x, y) == x // y
     assert_tx_failed(lambda: c._num256_div(NUM256_MAX, 0))
     assert c._num256_div(y, x) == 0
+    assert_tx_failed(lambda: c._num256_div(x, 0))
     assert c._num256_gt(x, y) is True
     assert c._num256_ge(x, y) is True
     assert c._num256_le(x, y) is False
@@ -92,14 +93,17 @@ def _num256_mulmod(x: num256, y: num256, z: num256) -> num256:
 
     assert c._num256_mod(3, 2) == 1
     assert c._num256_mod(34, 32) == 2
+    assert_tx_failed(lambda: c._num256_mod(3, 0))
     assert c._num256_addmod(1, 2, 2) == 1
     assert c._num256_addmod(32, 2, 32) == 2
     assert c._num256_addmod((2**256) - 1, 0, 2) == 1
     assert_tx_failed(lambda: c._num256_addmod((2**256) - 1, 1, 1))
+    assert_tx_failed(lambda: c._num256_addmod(1, 2, 0))
     assert c._num256_mulmod(3, 1, 2) == 1
     assert c._num256_mulmod(200, 3, 601) == 600
     assert c._num256_mulmod(2**255, 1, 3) == 2
     assert_tx_failed(lambda: c._num256_mulmod(2**255, 2, 1))
+    assert_tx_failed(lambda: c._num256_mulmod(2, 2, 0))
 
 
 def test_num256_with_exponents(t, chain, assert_tx_failed, get_contract_with_gas_estimation):

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -691,12 +691,15 @@ def num256_exp(expr, args, kwargs, context):
 
 @signature('num256', 'num256')
 def num256_mod(expr, args, kwargs, context):
-    return LLLnode.from_list(['mod', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', args[1]],
+                                ['mod', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256', 'num256')
 def num256_addmod(expr, args, kwargs, context):
     return LLLnode.from_list(['seq',
+                                ['assert', args[2]],
                                 ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
                                 ['addmod', args[0], args[1], args[2]]], typ=BaseType('num256'), pos=getpos(expr))
 
@@ -704,6 +707,7 @@ def num256_addmod(expr, args, kwargs, context):
 @signature('num256', 'num256', 'num256')
 def num256_mulmod(expr, args, kwargs, context):
     return LLLnode.from_list(['seq',
+                                ['assert', args[2]],
                                 ['assert', ['or', ['iszero', args[0]],
                                 ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
                                 ['mulmod', args[0], args[1], args[2]]], typ=BaseType('num256'), pos=getpos(expr))


### PR DESCRIPTION
### - What I did
Add num256 modulo checks to make sure that `num%zero` throws.
Thanks @yzhang90 
### - How I did it
Added `assert_tx_failed` tests with `num%zero` and got them to throw.
### - How to verify it
Look at the tests I added
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33813697-d26b4e40-de25-11e7-8b08-7fef57a460bc.png)

