### PR TITLE
Implement continue

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ Compatibility-breaking Changelog
 ********************************
 
 * **2017.12.25**: Change name from Viper to Vyper
+* **2017.12.22**: Add ``continue`` for loops
 * **2017.11.29**: ``@internal`` renamed to ``@private``.
 * **2017.11.15**: Functions require either ``@internal`` or ``@public`` decorators.
 * **2017.07.25**: The ``def foo() -> num(const): ...`` syntax no longer works; you now need to do ``def foo() -> num: ...`` with a ``@constant`` decorator on the previous line.

--- a/tests/parser/features/iteration/test_continue.py
+++ b/tests/parser/features/iteration/test_continue.py
@@ -1,0 +1,55 @@
+def test_continue1(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> bool:
+    for i in range(2):
+        continue
+        return False
+    return True
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == True
+
+
+def test_continue2(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num:
+    x = 0
+    for i in range(3):
+        x += 1
+        continue
+        x -= 1
+    return x
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 3
+
+
+def test_continue3(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num:
+    x = 0
+    for i in range(3):
+        x += i
+        continue
+    return x
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 3
+
+
+def test_continue4(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num:
+    x = 0
+    for i in range(6):
+        if i % 2 == 0:
+            continue
+        x += 1
+    return x
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 3

--- a/viper/opcodes.py
+++ b/viper/opcodes.py
@@ -79,6 +79,7 @@ pseudo_opcodes = {
     'ASSERT': [None, 1, 0, 85],
     'PASS': [None, 0, 0, 0],
     'BREAK': [None, 0, 0, 20],
+    'CONTINUE': [None, 0, 0, 20],
     'SHA3_32': [None, 1, 1, 72],
     'SLE': [None, 2, 1, 10],
     'SGE': [None, 2, 1, 10],

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -53,6 +53,7 @@ class Stmt(object):
             ast.For: self.parse_for,
             ast.AugAssign: self.aug_assign,
             ast.Break: self.parse_break,
+            ast.Continue: self.parse_continue,
             ast.Return: self.parse_return,
         }
         stmt_type = self.stmt.__class__
@@ -305,6 +306,9 @@ class Stmt(object):
             o = Expr.parse_value_expr(ast.BinOp(left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
                                     right=sub, op=self.stmt.op, lineno=self.stmt.lineno, col_offset=self.stmt.col_offset), self.context)
             return LLLnode.from_list(['with', '_mloc', target, ['mstore', '_mloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(self.stmt))
+
+    def parse_continue(self):
+        return LLLnode.from_list('continue', typ=None, pos=getpos(self.stmt))
 
     def parse_break(self):
         return LLLnode.from_list('break', typ=None, pos=getpos(self.stmt))


### PR DESCRIPTION
### - What I did
Implement `continue` which skips to the end of an iteration in a `for` loop.

### - How I did it
Looked at how `break` works and added `continue`.
Added a `JUMPDEST` to where `continue` skips to.

### - How to verify it
Look at the tests I created.

### - Description for the changelog
Implement `continue`
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/34333579-d860cd42-e970-11e7-8067-f379bf667410.png)


