### PR TITLE
Fix example ERC20 token compilation

### DIFF
--- a/examples/tokens/ERC20.v.py
+++ b/examples/tokens/ERC20.v.py
@@ -19,6 +19,7 @@ balances: num[address]
 allowed: num[address][address]
 
 
+@public
 def __init__(_name: bytes32, _symbol: bytes32, _decimals: num, _initialSupply: num):
 
     self.name = _name
@@ -28,6 +29,7 @@ def __init__(_name: bytes32, _symbol: bytes32, _decimals: num, _initialSupply: n
     self.balances[msg.sender] = self.totalSupply
 
 
+@public
 @constant
 def symbol() -> bytes32:
 
@@ -35,6 +37,7 @@ def symbol() -> bytes32:
 
 
 # What is the balance of a particular account?
+@public
 @constant
 def balanceOf(_owner: address) -> num256:
 
@@ -42,6 +45,7 @@ def balanceOf(_owner: address) -> num256:
 
 
 # Return total supply of token.
+@public
 @constant
 def totalSupply() -> num256:
 
@@ -49,6 +53,7 @@ def totalSupply() -> num256:
 
 
 # Send `_value` tokens to `_to` from your account
+@public
 def transfer(_to: address, _amount: num(num256)) -> bool:
 
     if self.balances[msg.sender] >= _amount and \
@@ -64,6 +69,7 @@ def transfer(_to: address, _amount: num(num256)) -> bool:
 
 
 # Transfer allowed tokens from a specific account to another.
+@public
 def transferFrom(_from: address, _to: address, _value: num(num256)) -> bool:
 
     if _value <= self.allowed[_from][msg.sender] and \
@@ -81,6 +87,7 @@ def transferFrom(_from: address, _to: address, _value: num(num256)) -> bool:
 
 # Allow _spender to withdraw from your account, multiple times, up to the _value amount.
 # If this function is called again it overwrites the current allowance with _value.
+@public
 def approve(_spender: address, _amount: num(num256)) -> bool:
 
     self.allowed[msg.sender][_spender] = _amount
@@ -90,6 +97,7 @@ def approve(_spender: address, _amount: num(num256)) -> bool:
 
 
 # Get the allowence an address has to spend anothers' token.
+@public
 def allowance(_owner: address, _spender: address) -> num256:
 
     return as_num256(self.allowed[_owner][_spender])


### PR DESCRIPTION
Discovered that it doesn't compile by trying to compile all of the
example contracts in `examples/`. This fixes ERC20.v.py by resolving
compiler complaints.

### - What I did
Fixed compilation of `ERC20.v.py` in `examples/tokens`

### - How I did it
Addressed compiler complaints by adding `@public` to all the public functions (which was all of them).

### - How to verify it
The easy way:
```
viper examples/tokens/ERC20.v.py
```
Verify that all examples compile:
```
find examples/ -name "*.v.py" | parallel -j1 "viper {}"`
```

### - Description for the changelog
Fix example ERC20 token

### - Cute Animal Picture

> put a cute animal picture here.
