### PR TITLE
Implement floor divide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Viper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.01.01**: Add ``//`` (floor and divide) to Vyper
 * **2017.12.25**: Change name from Viper to Vyper
 * **2017.12.22**: Add ``continue`` for loops
 * **2017.11.29**: ``@internal`` renamed to ``@private``.

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -121,3 +121,42 @@ def iarg() -> wei_value:
     assert c.iarg() == 14
 
     print('Passed fractional multiplication test')
+
+
+def test_divide_minus_modulo(get_contract_with_gas_estimation):
+    code = """
+a: decimal
+b: decimal
+
+@public
+def __init__():
+    self.a = 10.19
+    self.b = .1
+
+@public
+def decimal_literals() -> num:
+    return 3.5 // .3
+
+@public
+def decimal_memory(x: decimal, y: decimal) -> num:
+    return x // y
+
+@public
+def decimal_storage() -> num:
+    return self.a // self.b
+
+@public
+def num_decimal_memory(x: num, y: decimal) -> num:
+    return x // y
+
+@public
+def decimal_num_memory(x: decimal, y: num) -> num:
+    return x // y
+"""
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.decimal_literals()  == 11
+    assert c.decimal_memory(9, 3.5) == 2
+    assert c.decimal_storage() == 101
+    assert c.num_decimal_memory(10, 3.1) == 3
+    assert c.decimal_num_memory(7.5, 2) == 3

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -97,6 +97,35 @@ def _num_min() -> num:
     assert c._num_add3(NUM_MAX, -1, 1) == NUM_MAX
 
 
+def test_divide_minus_modulo(get_contract_with_gas_estimation):
+    code = """
+a: num
+b: num
+
+@public
+def __init__():
+    self.a = 5
+    self.b = 2
+
+@public
+def num_literals() -> num:
+    return 3 // 2
+
+@public
+def num_memory(x: num, y: num) -> num:
+    return x // y
+
+@public
+def num_storage() -> num:
+    return self.a // self.b
+
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.num_literals()  == 1
+    assert c.num_memory(9, 3) == 3
+    assert c.num_storage() == 2
+
+
 def test_invalid_unit_exponent(assert_compile_failed, get_contract_with_gas_estimation):
     code = """
 @public
@@ -106,4 +135,3 @@ def foo():
     c = a ** b
 """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatchException)
-


### PR DESCRIPTION
### - What I did
Implement `//` which is pythonic syntax for divide and floor

### - How I did it
Added support for `//` in `expr.py :: def arithmetic`

### - How to verify it
Look at the tests I added to `test_num.py` and `test_decimal.py`
### - Description for the changelog
Add support for divide and floor
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/34465915-614192de-eef5-11e7-8492-1711a6ccef7f.png)


