### PR TITLE
Improve as wei value

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,8 @@ Compatibility-breaking Changelog
 
 * **2018.01.11**: Change version from 0.0.2 to 0.0.3
 * **2018.01.04**: Types need to be specified on assignment (`VIP545 <https://github.com/ethereum/vyper/issues/545>`_).
-* **2017.12.25**: Change name from Viper to Vyper
+* **2017.01.2** Change ``as_wei_value`` to use quotes for units.
+* **2017.12.25**: Change name from Viper to Vyper.
 * **2017.12.22**: Add ``continue`` for loops
 * **2017.11.29**: ``@internal`` renamed to ``@private``.
 * **2017.11.15**: Functions require either ``@internal`` or ``@public`` decorators.

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -60,17 +60,17 @@ def foo():
     """
 @public
 def foo():
-    x = as_wei_value(5.1824, ada)
+    x = as_wei_value(5.1824, "ada")
     """,
     """
 @public
 def foo():
-    x = as_wei_value(0x05, ada)
+    x = as_wei_value(0x05, "ada")
     """,
     """
 @public
 def foo():
-    x = as_wei_value(5, vader)
+    x = as_wei_value(5, "vader")
     """,
     """
 @public

--- a/tests/parser/functions/rlp/test_rlp_list.py
+++ b/tests/parser/functions/rlp/test_rlp_list.py
@@ -1,7 +1,7 @@
 import rlp
 
 
-def test_rlp_decoder_code(assert_tx_failed, get_contract_with_gas_estimation, fake_tx):
+def test_rlp_decoder_code(t, assert_tx_failed, get_contract_with_gas_estimation, fake_tx):
     fake_tx()
 
     rlp_decoder_code = """
@@ -75,6 +75,11 @@ def loo(inp: bytes <= 1024) -> num:
 def woo(inp: bytes <= 1024) -> bytes <= 15360:
     x = RLPList(inp, [bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes])
     return concat(x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14])
+
+@public
+def yolo(raw_utxo: bytes <= 1024) -> (address, num, num):
+    utxo = RLPList(raw_utxo, [address, num, num])
+    return utxo[0], utxo[1], utxo[2]
     """
     c = get_contract_with_gas_estimation(rlp_decoder_code)
 
@@ -101,5 +106,5 @@ def woo(inp: bytes <= 1024) -> bytes <= 15360:
     assert_tx_failed(lambda: c.too(rlp.encode([b'\x00'])))
     assert c.loo(rlp.encode([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])) == 55
     assert c.woo(rlp.encode([b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'10', b'11', b'12', b'13', b'14', b'15'])) == b'123456789101112131415'
-
+    assert c.yolo(rlp.encode([t.a0, 1, 2])) == ['0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1', 1, 2]
     print('Passed RLP decoder tests')

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -35,7 +35,7 @@ w: public({
 
 @public
 def __init__():
-    self.x = as_wei_value(7, wei)
+    self.x = as_wei_value(7, "wei")
     self.y[1] = 9
     self.z = "cow"
     self.w[1].a = 11

--- a/tests/parser/syntax/test_as_wei_value.py
+++ b/tests/parser/syntax/test_as_wei_value.py
@@ -9,7 +9,7 @@ fail_list = [
     """
 @public
 def foo():
-    x: num(wei) = as_wei_value(5, 'szabo')
+    x: num(wei) = as_wei_value(5, szabo)
     """,
     """
 @public
@@ -22,7 +22,6 @@ def foo() -> num(wei):
 
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_as_wei_fail(bad_code):
-
     with raises(TypeMismatchException):
         compiler.compile(bad_code)
 
@@ -31,18 +30,18 @@ valid_list = [
     """
 @public
 def foo():
-    x: num(wei) = as_wei_value(5, finney) + as_wei_value(2, babbage) + as_wei_value(8, shannon)
+    x: num(wei) = as_wei_value(5, "finney") + as_wei_value(2, "babbage") + as_wei_value(8, "shannon")
     """,
     """
 @public
 def foo():
     z: num = 2 + 3
-    x: num(wei) = as_wei_value(2 + 3, finney)
+    x: num(wei) = as_wei_value(2 + 3, "finney")
     """,
     """
 @public
 def foo():
-    x: num(wei) = as_wei_value(5.182, ada)
+    x: num(wei) = as_wei_value(5.182, "ada")
     """,
     """
 @public

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -25,7 +25,7 @@ def foo() -> timedelta[2]:
     """
 @public
 def foo() -> num(wei / sec):
-    x: num(wei) = as_wei_value(5, finney)
+    x: num(wei) = as_wei_value(5, "finney")
     y: num = block.timestamp + 50
     return x / y
     """,
@@ -107,7 +107,7 @@ def add_record():
     """
 @public
 def foo() -> num(wei / sec):
-    x: num(wei) = as_wei_value(5, finney)
+    x: num(wei) = as_wei_value(5, "finney")
     y: num(sec) = block.timestamp + 50 - block.timestamp
     return x / y
     """,

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -28,7 +28,7 @@ def foo():
     """
 @public
 def foo():
-    x: address = create_with_code_of(0x1234567890123456789012345678901234567890, value=as_wei_value(9, wei))
+    x: address = create_with_code_of(0x1234567890123456789012345678901234567890, value=as_wei_value(9, "wei"))
     """,
     """
 @public

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -44,7 +44,7 @@ def foo():
     """
 @public
 def foo():
-    x: bytes <= 9 = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757, value=as_wei_value(9, wei))
+    x: bytes <= 9 = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757, value=as_wei_value(9, "wei"))
     """,
     """
 @public

--- a/tests/parser/syntax/test_send.py
+++ b/tests/parser/syntax/test_send.py
@@ -69,7 +69,7 @@ x: decimal
 
 @public
 def foo():
-    send(0x1234567890123456789012345678901234567890, as_wei_value(floor(self.x), wei))
+    send(0x1234567890123456789012345678901234567890, as_wei_value(floor(self.x), "wei"))
     """,
     """
 x: wei_value

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -107,7 +107,7 @@ def harg() -> decimal:
 
 @public
 def iarg() -> wei_value:
-    x: wei_value = as_wei_value(7, wei)
+    x: wei_value = as_wei_value(7, "wei")
     x *= 2
     return x
     """

--- a/tests/parser/types/value/test_as_wei_value.py
+++ b/tests/parser/types/value/test_as_wei_value.py
@@ -2,23 +2,23 @@ def test_test_wei(get_contract_with_gas_estimation):
     test_wei = """
 @public
 def return_2_finney() -> wei_value:
-    return as_wei_value(2, finney)
+    return as_wei_value(2, "finney")
 
 @public
 def return_3_finney() -> wei_value:
-    return as_wei_value(2 + 1, finney)
+    return as_wei_value(2 + 1, "finney")
 
 @public
 def return_2p5_ether() -> wei_value:
-    return as_wei_value(2.5, ether)
+    return as_wei_value(2.5, "ether")
 
 @public
 def return_3p5_ether() -> wei_value:
-    return as_wei_value(2.5 + 1, ether)
+    return as_wei_value(2.5 + 1, "ether")
 
 @public
 def return_2pow64_wei() -> wei_value:
-    return as_wei_value(18446744.073709551616, szabo)
+    return as_wei_value(18446744.073709551616, "szabo")
     """
 
     c = get_contract_with_gas_estimation(test_wei)

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -438,22 +438,22 @@ def bytes_to_num(expr, args, kwargs, context):
     return byte_array_to_num(args[0], expr, 'num')
 
 
-@signature(('num_literal', 'num', 'decimal'), 'name_literal')
+@signature(('num_literal', 'num', 'decimal'), 'str_literal')
 def as_wei_value(expr, args, kwargs, context):
     # Denominations
-    if args[1] == "wei":
+    if args[1] == b"wei":
         denomination = 1
-    elif args[1] in ("kwei", "ada", "lovelace"):
+    elif args[1] in (b"kwei", b"ada", b"lovelace"):
         denomination = 10**3
-    elif args[1] == "babbage":
+    elif args[1] == b"babbage":
         denomination = 10**6
-    elif args[1] in ("shannon", "gwei"):
+    elif args[1] in (b"shannon", b"gwei"):
         denomination = 10**9
-    elif args[1] == "szabo":
+    elif args[1] == b"szabo":
         denomination = 10**12
-    elif args[1] == "finney":
+    elif args[1] == b"finney":
         denomination = 10**15
-    elif args[1] == "ether":
+    elif args[1] == b"ether":
         denomination = 10**18
     else:
         raise InvalidLiteralException("Invalid denomination: %s" % args[1], expr.args[1])


### PR DESCRIPTION
### - What I did
Change `as_wei_value` to accept `as_wei_value(num, "unit")` instead of `as_wei_value(num, unit)`.  Having the unit in quotes is clearer because perviously it was easy to mistake the unit for a variable.
In response to #595 

### - How I did it
Changed what `as_wei_value` acceptions in `functions.py`.

### - How to verify it
Look at the tests I changed.

### - Description for the changelog
Change ``as_wei_value`` to use quotes for units.

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/34474355-4cd7b196-efb0-11e7-95f3-759576115d2f.png)