### PR TITLE
Fix unit exponent expressions

### DIFF
--- a/tests/parser/syntax/test_unit_exponents.py
+++ b/tests/parser/syntax/test_unit_exponents.py
@@ -1,0 +1,44 @@
+import pytest
+from pytest import raises
+
+from viper import compiler
+from viper.exceptions import TypeMismatchException
+
+fail_list = [
+    """
+@public
+def baa() -> decimal:
+    return 2.0 ** 2
+    """,
+    """
+@public
+def foo(a:num):
+    b:num(sec)
+    c:num(sec**2)
+    c = b ** a
+    """
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_exponent_fail(bad_code):
+
+    with raises(TypeMismatchException):
+        compiler.compile(bad_code)
+
+
+valid_list = [
+    """
+@public
+def foo():
+    a : num(wei)
+    b : num(wei**2)
+    a = 2
+    b = a**2
+    """,
+]
+
+
+@pytest.mark.parametrize('good_code', valid_list)
+def test_exponent_success(good_code):
+    assert compiler.compile(good_code) is not None

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -287,8 +287,12 @@ class Expr(object):
                 raise TypeMismatchException("Cannot use positional values as exponential arguments!", self.expr)
             if right.typ.unit:
                 raise TypeMismatchException("Cannot use unit values as exponents", self.expr)
-            new_unit = combine_units(left.typ.unit, right.typ.unit)
+            if  ltyp != 'num' and isinstance(self.expr.right, ast.Name):
+                raise TypeMismatchException("Cannot use dynamic values as exponents, for unit base types", self.expr)
             if ltyp == rtyp == 'num':
+                new_unit = left.typ.unit
+                if left.typ.unit and not isinstance(self.expr.right, ast.Name):
+                    new_unit = {left.typ.unit.copy().popitem()[0]:  self.expr.right.n}
                 o = LLLnode.from_list(['exp', left, right], typ=BaseType('num', new_unit), pos=getpos(self.expr))
             else:
                 raise TypeMismatchException('Only whole number exponents are supported', self.expr)


### PR DESCRIPTION
### - What I did

- Fixes #547.
- Correct builds unit type when using ` ** `.

### - How I did it

See changes on `Expr.arithmetic`.

### - How to verify it
```python
@public
def foo():
    a : num(wei)
    b : num(wei**2)
    a = 2
    b = a**2
````

### - Description for the changelog

N/A

### - Cute Animal Picture

![](https://i.pinimg.com/736x/c6/c3/52/c6c352f320db50488e7df23cf3f6d8fe--cute-cats-funny-kitten-funny.jpg)
  