### PR TITLE
edited travis script for flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - python setup.py test
-  - flake8 viper/, tests/
+  - flake8 viper/ tests/
 
 after_success:
 - coveralls


### PR DESCRIPTION
### - What I did
fixed syntax on flake8 script to run on travis
### - How I did it
- deleted comma between directories viper and tests
### - How to verify it
- [Flake8 Man](http://flake8.pycqa.org/en/latest/manpage.html)
- can also verify manually, by running
```python
flake8 viper/, scripts/, examples/
```
it will return only the last directory.

With fix (removing commas) it will return all requested directories. 

### - Description for the changelog
*pass*
### - Cute Animal Picture

![rattlesnake](https://media1.britannica.com/eb-media/94/147694-004-92EB8FB2.jpg)