### PR TITLE
Fix err msg for functions without enough arguments

### DIFF
--- a/tests/parser/exceptions/test_insufficient_arguments.py
+++ b/tests/parser/exceptions/test_insufficient_arguments.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest import raises
+
+from viper import compiler
+from viper.exceptions import StructureException
+
+fail_list = [
+    """
+@public
+def foo() -> num:
+    return as_wei_value(10)
+"""
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_insufficient_arguments(bad_code):
+    with raises(StructureException) as ex:
+        compiler.compile(bad_code)
+    assert "Not enough arguments for function: as_wei_value" in str(ex.value)

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -113,7 +113,10 @@ def signature(*argz, **kwargz):
                 elif isinstance(expected_arg, Optional):
                     subs.append(expected_arg.default)
                 else:
-                    raise StructureException("Not enough arguments for function %s", element)
+                    raise StructureException(
+                        "Not enough arguments for function: {}".format(element.func.id),
+                        element
+                    )
             kwsubs = {}
             element_kw = {k.arg: k.value for k in element.keywords}
             for k, expected_arg in kwargz.items():


### PR DESCRIPTION
### - What I did

Fixed the error message that is displayed when a Vyper function is called without enough arguments.

### - How I did it

Added a `%` so that the string formatting actually happens, and pulled the function name from the `ast.Call` object using `element.func.id` (assuming the inner part of the `Call` is a `Name(id=...)`).

### - How to verify it

Run the included test case in `tests/parser/exceptions/test_insufficient_arguments.py`, or compile the example Vyper program therein.

### - Description for the changelog

Fix the error message for functions called without enough arguments

### - Cute Animal Picture

A pademelon, from Australia :D

![Pademelon](http://www.parks.tas.gov.au/file.aspx?id=23602&mode=standard&sb=.jpg)
