### PR TITLE
Add an error message for calls to undefined top-level functions

### DIFF
--- a/tests/parser/exceptions/test_undef_function.py
+++ b/tests/parser/exceptions/test_undef_function.py
@@ -1,0 +1,31 @@
+from pytest import raises
+
+from viper import compiler
+from viper.exceptions import StructureException
+
+
+def test_undef_toplevel():
+    code = """
+@public
+def foo():
+    x = bar(55)
+    """
+    with raises(StructureException) as ex:
+        compiler.compile(code)
+    assert "Not a top-level function: bar" in str(ex.value)
+
+
+def test_undef_suggestion():
+    code = """
+@public
+def bar(x: num) -> num:
+    return 3 * x
+
+@public
+def foo() -> num:
+    return bar(20)
+    """
+    with raises(StructureException) as ex:
+        compiler.compile(code)
+    assert "Not a top-level function: bar" in str(ex.value)
+    assert "Did you mean self.bar?" in str(ex.value)

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -440,8 +440,15 @@ class Expr(object):
         from viper.functions import (
             dispatch_table,
         )
-        if isinstance(self.expr.func, ast.Name) and self.expr.func.id in dispatch_table:
-            return dispatch_table[self.expr.func.id](self.expr, self.context)
+        if isinstance(self.expr.func, ast.Name):
+            function_name = self.expr.func.id
+            if function_name in dispatch_table:
+                return dispatch_table[function_name](self.expr, self.context)
+            else:
+                err_msg = "Not a top-level function: {}".format(function_name)
+                if function_name in self.context.sigs['self']:
+                    err_msg += ". Did you mean self.{}?".format(function_name)
+                raise StructureException(err_msg, self.expr)
         elif isinstance(self.expr.func, ast.Attribute) and isinstance(self.expr.func.value, ast.Name) and self.expr.func.value.id == "self":
             method_name = self.expr.func.attr
             if method_name not in self.context.sigs['self']:


### PR DESCRIPTION
### - What I did

Previously, the compiler would error ungracefully if an undefined top-level function was called, due to an unhandled case in `Expr.call`. I filled in the missing case so that an appropriate error is raised instead.

I also made it so that the compiler offers suggestions when a non-existent top-level function
is mistakenly called instead of a contract method, e.g. `bar(..)` instead of `self.bar(..)`.

### - How I did it

I modified the existing handling of top-level functions in `Expr.call` so that the case where the function name is _not_ in the `dispatch_table` is handled correctly.

### - How to verify it

Run the tests in `tests/parser/exceptions/test_undef_function.py`.

### - Description for the changelog

Add an error message for calls to undefined top-level functions

### - Cute Animal Picture

![Wombat Image](https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Vombatus_ursinus_-Maria_Island_National_Park.jpg/1200px-Vombatus_ursinus_-Maria_Island_National_Park.jpg)