### PR TITLE
Add `.gitattributes` syntax highlighting trick

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vy linguist-language=Python

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To compile a contract, use:
 **Note: Since .vy is not official a language supported by any syntax highlights or linter,
 it is recommended to name your viper file into `.v.py` to have a python highlights.**
 
+**Alternative for GitHub syntax highlighting: Add a `.gitattributes` file with the line `*.vy linguist-language=Python`**
+
 There is also an [online compiler](https://viper.tools/) available you can use to experiment with
 the language and compile to ``bytecode`` and/or ``LLL``.
 


### PR DESCRIPTION
### - What I did

I added a small phrase in the README explaining how one can enable syntax highlighting for Vyper on GitHub using `.gitattributes`

### - How to verify it

1. Create a new repository
2. Create a `.gitattributes` file as explained in the phrase
3. Add a `.vy` file
4. Commit!

### - Cute Animal Picture

![A picture of a dik-dik](https://i.imgur.com/nHcLgXm.jpg)