### PR TITLE
Prevent mixed lists

### DIFF
--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -135,7 +135,7 @@ def foo() -> num:
 
 @public
 def goo() -> num:
-    self.pap = [[1, 2], [3, 4.0]]
+    self.pap = [[1, 2], [3, 4]]
     return floor(self.pap[0][0] + self.pap[0][1] * 10 + self.pap[1][0] * 100 + self.pap[1][1] * 1000)
     """
 

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -122,6 +122,12 @@ def foo()->bool[2]:
     a: bool[1000]
     a[0] = 1
     return a
+    """,
+    """
+@public
+def test() -> num:
+    a = [1, 2, 3.0]
+    return a[0]
     """
 ]
 
@@ -157,7 +163,7 @@ def foo() -> decimal[2][2]:
     """
 @public
 def foo() -> decimal[2][2]:
-    return [[1,2.0],[3.5,4]]
+    return [[1.0, 2.0], [3.5, 4.0]]
     """,
     """
 @public
@@ -201,7 +207,7 @@ def foo() -> num[2]:
 foo: decimal[3]
 @public
 def foo():
-    self.foo = [1, 2.1, 3]
+    self.foo = [1.0, 2.1, 3.0]
     """,
     """
 x: num[1][2][3][4][5]

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -128,6 +128,12 @@ def foo()->bool[2]:
 def test() -> num:
     a = [1, 2, 3.0]
     return a[0]
+    """,
+    """
+@public
+def test() -> num:
+    a = [1, 2, true]
+    return a[0]
     """
 ]
 

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -16,7 +16,7 @@ def foo():
 bar: num[3][3]
 @public
 def foo():
-    self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9.0]]
+    self.bar = [[1, 2, 3], [4, 5, 6], [7.0, 8.0, 9.0]]
     """,
     """
 @public
@@ -70,7 +70,7 @@ def foo():
 bar: decimal[3][3]
 @public
 def foo():
-    self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9.0]]
+    self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     """
 ]
 

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -81,7 +81,7 @@ def loo() -> num[2][2]:
 @public
 def moo() -> num[2][2]:
     x = [1,2]
-    return [x,[3,4]]
+    return [x, [3,4]]
 
 @public
 def noo(inp: num[2]) -> num[2]:

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -286,12 +286,12 @@ class Expr(object):
                 raise TypeMismatchException("Cannot use positional values as exponential arguments!", self.expr)
             if right.typ.unit:
                 raise TypeMismatchException("Cannot use unit values as exponents", self.expr)
-            if  ltyp != 'num' and isinstance(self.expr.right, ast.Name):
+            if ltyp != 'num' and isinstance(self.expr.right, ast.Name):
                 raise TypeMismatchException("Cannot use dynamic values as exponents, for unit base types", self.expr)
             if ltyp == rtyp == 'num':
                 new_unit = left.typ.unit
                 if left.typ.unit and not isinstance(self.expr.right, ast.Name):
-                    new_unit = {left.typ.unit.copy().popitem()[0]:  self.expr.right.n}
+                    new_unit = {left.typ.unit.copy().popitem()[0]: self.expr.right.n}
                 o = LLLnode.from_list(['exp', left, right], typ=BaseType('num', new_unit), pos=getpos(self.expr))
             else:
                 raise TypeMismatchException('Only whole number exponents are supported', self.expr)
@@ -499,7 +499,7 @@ class Expr(object):
                 out_type = o[-1].typ
             previous_type = o[-1].typ.subtype.typ if hasattr(o[-1].typ, 'subtype') else o[-1].typ
             current_type = out_type.subtype.typ if hasattr(out_type, 'subtype') else out_type
-            if len(o) > 1 and  previous_type != current_type:
+            if len(o) > 1 and previous_type != current_type:
                 raise TypeMismatchException("Lists may only contain one type", self.expr)
         return LLLnode.from_list(["multi"] + o, typ=ListType(out_type, len(o)), pos=getpos(self.expr))
 

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -29,7 +29,6 @@ from viper.types import (
     ByteArrayType,
     ListType,
     MappingType,
-    MixedType,
     NullType,
     StructType,
     TupleType,
@@ -498,8 +497,10 @@ class Expr(object):
             o.append(Expr(elt, self.context).lll_node)
             if not out_type:
                 out_type = o[-1].typ
-            elif len(o) > 1 and o[-1].typ != out_type:
-                out_type = MixedType()
+            previous_type = o[-1].typ.subtype.typ if hasattr(o[-1].typ, 'subtype') else o[-1].typ
+            current_type = out_type.subtype.typ if hasattr(out_type, 'subtype') else out_type
+            if len(o) > 1 and  previous_type != current_type:
+                raise TypeMismatchException("Lists may only contain one type", self.expr)
         return LLLnode.from_list(["multi"] + o, typ=ListType(out_type, len(o)), pos=getpos(self.expr))
 
     def struct_literals(self):

--- a/viper/types.py
+++ b/viper/types.py
@@ -134,12 +134,6 @@ class TupleType(NodeType):
         return '(' + ', '.join([repr(m) for m in self.members]) + ')'
 
 
-# Data structure for a "multi" object with a mixed type
-class MixedType(NodeType):
-    def __eq__(self, other):
-        return other.__class__ == MixedType
-
-
 # Data structure for the type used by None/null
 class NullType(NodeType):
     def __eq__(self, other):


### PR DESCRIPTION
### - What I did

Removes the possibility to create mixed lists.

### - How I did it

Removed MixedType and added an exception where it would usually be created.

### - How to verify it
```python
@public
def test():
    a = [1, 1.33]
```
should throw necessary exception.

### - Description for the changelog
Mixed list support removed.

### - Cute Animal Picture
![](https://img.buzzfeed.com/buzzfeed-static/static/enhanced/webdr06/2013/6/15/12/enhanced-buzz-4083-1371312587-10.jpg?downsize=715:*&output-format=auto&output-quality=auto)

