### PR TITLE
Remove as_num256 safety check for bytes32

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Viper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.01.11**: Change version from 0.0.2 to 0.0.3
 * **2017.12.25**: Change name from Viper to Vyper
 * **2017.12.22**: Add ``continue`` for loops
 * **2017.11.29**: ``@internal`` renamed to ``@private``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.3
 commit = True
 tag = True
 
@@ -16,10 +16,11 @@ testpaths = tests
 
 [flake8]
 exclude = docs
-ignore =
+ignore = 
 	E122
 	E124
 	E127
 	E128
 	E501
 	E731
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
     license = f.read()
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-version = '0.0.2'
+version = '0.0.3'
 
 setup(
     name='viper',

--- a/tests/parser/functions/test_as_num256.py
+++ b/tests/parser/functions/test_as_num256.py
@@ -15,3 +15,14 @@ def foo(x: num) -> num256:
 """
     c = get_contract_with_gas_estimation(code)
     assert_tx_failed(lambda: c.foo(-1))
+
+
+def test_as_num256_with_bytes32(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num256:
+    return as_num256(as_bytes32(-1))
+"""
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 2 ** 256 - 1

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -187,8 +187,10 @@ def as_num256(expr, args, kwargs, context):
         if not(0 <= args[0] <= 2**256 - 1):
             raise InvalidLiteralException("Number out of range: " + str(expr.args[0].n), expr.args[0])
         return LLLnode.from_list(args[0], typ=BaseType('num256'), pos=getpos(expr))
-    elif isinstance(args[0], LLLnode):
+    elif isinstance(args[0], LLLnode) and args[0].typ.typ in ('num', 'num_literal', 'address'):
         return LLLnode.from_list(['clampge', args[0], 0], typ=BaseType('num256'), pos=getpos(expr))
+    elif isinstance(args[0], LLLnode):
+        return LLLnode(value=args[0].value, args=args[0].args, typ=BaseType('num256'), pos=getpos(expr))
     else:
         raise InvalidLiteralException("Invalid input for num256: %r" % args[0], expr)
 

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -287,12 +287,12 @@ class Expr(object):
                 raise TypeMismatchException("Cannot use positional values as exponential arguments!", self.expr)
             if right.typ.unit:
                 raise TypeMismatchException("Cannot use unit values as exponents", self.expr)
-            if  ltyp != 'num' and isinstance(self.expr.right, ast.Name):
+            if ltyp != 'num' and isinstance(self.expr.right, ast.Name):
                 raise TypeMismatchException("Cannot use dynamic values as exponents, for unit base types", self.expr)
             if ltyp == rtyp == 'num':
                 new_unit = left.typ.unit
                 if left.typ.unit and not isinstance(self.expr.right, ast.Name):
-                    new_unit = {left.typ.unit.copy().popitem()[0]:  self.expr.right.n}
+                    new_unit = {left.typ.unit.copy().popitem()[0]: self.expr.right.n}
                 o = LLLnode.from_list(['exp', left, right], typ=BaseType('num', new_unit), pos=getpos(self.expr))
             else:
                 raise TypeMismatchException('Only whole number exponents are supported', self.expr)


### PR DESCRIPTION
### - What I did
Remove `as_num256` safety check for `bytes32` type.
Change version from 0.0.2 to 0.0.3
### - How I did it
Removed the  >= 0 clamp for `as_num256` with `bytes32`
### - How to verify it
Look at the test I added
### - Description for the changelog
Change version from `0.0.2` to `0.0.3`
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/34843301-48cdf340-f6cb-11e7-880b-27cdcbe03796.png)




