### PR TITLE
macOS library not found libyaml fix

### DIFF
--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -119,7 +119,7 @@ However, please keep in mind that Viper is still experimental and not ready for 
 
     Now you can run the install and test commands again:
     ::
-        make install
+        make
         make test
     
     If you get the error `ld: library not found for -lyaml` in the output of `make`, make sure `libyaml` is installed using `brew info libyaml`. If it is installed, add its location to the compile flags as well:

--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -121,6 +121,13 @@ However, please keep in mind that Viper is still experimental and not ready for 
     ::
         make install
         make test
+    
+    If you get the error `ld: library not found for -lyaml` in the output of `make`, make sure `libyaml` is installed using `brew info libyaml`. If it is installed, add its location to the compile flags as well:
+    ::
+        export CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libyaml)/include"
+        export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libyaml)/lib"
+        
+    You can then run `make` and `make test` again.
 ******
 Docker
 ******


### PR DESCRIPTION
### What I did

When running `make` for the installation of Viper, I got the following error:

```
clang -bundle -undefined dynamic_lookup -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include build/temp.macosx-10.13-x86_64-3.6/ext/_yaml.o -lyaml -o build/lib.macosx-10.13-x86_64-3.6/_yaml.cpython-36m-darwin.so
    ld: library not found for -lyaml
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    error: command 'clang' failed with exit status 1
```

This is clearly caused by the YAML library (libyaml) not being found on macOS.

### How I did it

I checked whether `libyaml` was installed correctly using `brew info libyaml`: it was. I just changed the suggested compile flags from [here](https://vyper.readthedocs.io/en/latest/installing-viper.html#installation) to:
```
export CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libyaml)/include"
export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libyaml)/lib"
```

The `make` and `make test` commands then worked as expected.

### - How to verify it

Just try the installation on a mac.

### - Description for the changelog

I added the solution for the error and additionally changed an older `make install` command to normal `make`.