### PR TITLE
Underdefined Paths in compiler, added Exceptions

### DIFF
--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -235,7 +235,7 @@ class Expr(object):
                 o = LLLnode.from_list([op, left, ['mul', right, DECIMAL_DIVISOR]],
                                       typ=BaseType('decimal', new_unit, new_positional), pos=getpos(self.expr))
             else:
-                raise Exception("How did I get here? %r %r" % (ltyp, rtyp))
+                raise Exception("Unsupported Operation '%r(%r, %r)'" % (op, ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Mult):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot multiply positional values!", self.expr)
@@ -254,6 +254,8 @@ class Expr(object):
                                             ['seq',
                                                 ['assert', ['or', ['eq', ['sdiv', 'ans', 'l'], 'r'], ['not', 'l']]],
                                                 'ans']]]], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
+            else:
+                raise Exception("Unsupported Operation 'mul(%r, %r)'" % (ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Div):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot divide positional values!", self.expr)
@@ -267,6 +269,8 @@ class Expr(object):
             elif ltyp == 'num' and rtyp == 'decimal':
                 o = LLLnode.from_list(['sdiv', ['mul', left, DECIMAL_DIVISOR ** 2], ['clamp_nonzero', right]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
+            else:
+                raise Exception("Unsupported Operation 'div(%r, %r)'" % (ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Mod):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot use positional values as modulus arguments!", self.expr)
@@ -281,6 +285,8 @@ class Expr(object):
             elif ltyp == 'num' and rtyp == 'decimal':
                 o = LLLnode.from_list(['smod', ['mul', left, DECIMAL_DIVISOR], ['clamp_nonzero', right]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
+            else:
+                raise Exception("Unsupported Operation 'mod(%r, %r)'" % (ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Pow):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot use positional values as exponential arguments!", self.expr)


### PR DESCRIPTION
### - What I did
Added some extra exceptions for paths in the compiler that would not produce a result when more types are added.

### - How I did it
Looked for underdefined paths in this specific function

### - How to verify it
No change to testing, would only appear when a new type is added. If not applied, then in the future when that type is added, compiler would give a very cryptic error that would be difficult to debug

Please feel free to change the exception types or messages as necessary

### - Cute Animal Picture
![sleeping giraffe](https://static.boredpanda.com/blog/wp-content/uploads/2015/06/sleeping-giraffes-fb__700.jpg)
