### PR TITLE
Change get var to var

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Viper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.01.27**: Change getter from get_var to var.
 * **2018.01.11**: Change version from 0.0.2 to 0.0.3
 * **2018.01.04**: Types need to be specified on assignment (`VIP545 <https://github.com/ethereum/vyper/issues/545>`_).
 * **2017.01.2** Change ``as_wei_value`` to use quotes for units.

--- a/examples/auctions/simple_open_auction.v.py
+++ b/examples/auctions/simple_open_auction.v.py
@@ -43,7 +43,7 @@ def bid():
 # End the auction and send the highest bid
 # to the beneficiary.
 @public
-def auction_end():
+def end_auction():
     # It is a good guideline to structure functions that interact
     # with other contracts (i.e. they call functions or send Ether)
     # into three phases:

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -15,17 +15,17 @@ def auction_tester(t):
 
 def test_initial_state(auction_tester):
     # Check beneficiary is correct
-    assert utils.remove_0x_head(auction_tester.c.get_beneficiary()) == auction_tester.accounts[0].hex()
+    assert utils.remove_0x_head(auction_tester.c.beneficiary()) == auction_tester.accounts[0].hex()
     # Check bidding time is 5 days
-    assert auction_tester.c.get_auction_end() == auction_tester.s.head_state.timestamp + 432000
+    assert auction_tester.c.auction_end() == auction_tester.s.head_state.timestamp + 432000
     # Check start time is current block timestamp
-    assert auction_tester.c.get_auction_start() == auction_tester.s.head_state.timestamp
+    assert auction_tester.c.auction_start() == auction_tester.s.head_state.timestamp
     # Check auction has not ended
-    assert not auction_tester.c.get_ended()
+    assert auction_tester.c.ended() == False
     # Check highest bidder is empty
-    assert auction_tester.c.get_highest_bidder() == '0x0000000000000000000000000000000000000000'
+    assert auction_tester.c.highest_bidder() == '0x0000000000000000000000000000000000000000'
     # Check highest bid is 0
-    assert auction_tester.c.get_highest_bid() == 0
+    assert auction_tester.c.highest_bid() == 0
 
 
 def test_bid(auction_tester, assert_tx_failed):
@@ -35,22 +35,22 @@ def test_bid(auction_tester, assert_tx_failed):
     # Bidder can bid
     auction_tester.c.bid(value=1, sender=auction_tester.k1)
     # Check that higest bidder and highest bid have changed accordingly
-    assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[1].hex()
-    assert auction_tester.c.get_highest_bid() == 1
+    assert utils.remove_0x_head(auction_tester.c.highest_bidder()) == auction_tester.accounts[1].hex()
+    assert auction_tester.c.highest_bid() == 1
     # Bidder bid cannot equal current highest bid
     assert_tx_failed(lambda: auction_tester.c.bid(value=1, sender=auction_tester.k1))
     # Higher bid can replace current highest bid
     auction_tester.c.bid(value=2, sender=auction_tester.k2)
     # Check that higest bidder and highest bid have changed accordingly
-    assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[2].hex()
-    assert auction_tester.c.get_highest_bid() == 2
+    assert utils.remove_0x_head(auction_tester.c.highest_bidder()) == auction_tester.accounts[2].hex()
+    assert auction_tester.c.highest_bid() == 2
     # Multiple bidders can bid
     auction_tester.c.bid(value=3, sender=auction_tester.k3)
     auction_tester.c.bid(value=4, sender=auction_tester.k4)
     auction_tester.c.bid(value=5, sender=auction_tester.k5)
     # Check that higest bidder and highest bid have changed accordingly
-    assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[5].hex()
-    assert auction_tester.c.get_highest_bid() == 5
+    assert utils.remove_0x_head(auction_tester.c.highest_bidder()) == auction_tester.accounts[5].hex()
+    assert auction_tester.c.highest_bid() == 5
     auction_tester.c.bid(value=1 * 10**10, sender=auction_tester.k1)
     balance_before_out_bid = auction_tester.s.head_state.get_balance(auction_tester.accounts[1])
     auction_tester.c.bid(value=2 * 10**10, sender=auction_tester.k2)
@@ -59,19 +59,19 @@ def test_bid(auction_tester, assert_tx_failed):
     assert balance_after_out_bid > balance_before_out_bid
 
 
-def test_auction_end(auction_tester, assert_tx_failed):
+def test_end_auction(auction_tester, assert_tx_failed):
     auction_tester.s.mine()
     # Fails if auction end time has not been reached
-    assert_tx_failed(lambda: auction_tester.c.auction_end())
+    assert_tx_failed(lambda: auction_tester.c.end_auction())
     auction_tester.c.bid(value=1 * 10**10, sender=auction_tester.k2)
     # Move block timestamp foreward to reach auction end time
     auction_tester.s.head_state.timestamp += FIVE_DAYS
     balance_before_end = auction_tester.s.head_state.get_balance(auction_tester.accounts[0])
-    auction_tester.c.auction_end(sender=auction_tester.k2)
+    auction_tester.c.end_auction(sender=auction_tester.k2)
     balance_after_end = auction_tester.s.head_state.get_balance(auction_tester.accounts[0])
     # Beneficiary receives the highest bid
     assert balance_after_end == balance_before_end + 1 * 10 ** 10
     # Bidder cannot bid after auction end time has been reached
     assert_tx_failed(lambda: auction_tester.c.bid(value=10, sender=auction_tester.k1))
     # Auction cannot be ended twice
-    assert_tx_failed(lambda: auction_tester.c.auction_end())
+    assert_tx_failed(lambda: auction_tester.c.end_auction())

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -21,7 +21,7 @@ def test_initial_state(auction_tester):
     # Check start time is current block timestamp
     assert auction_tester.c.auction_start() == auction_tester.s.head_state.timestamp
     # Check auction has not ended
-    assert auction_tester.c.ended() == False
+    assert auction_tester.c.ended() is False
     # Check highest bidder is empty
     assert auction_tester.c.highest_bidder() == '0x0000000000000000000000000000000000000000'
     # Check highest bid is 0

--- a/tests/examples/company/test_company.py
+++ b/tests/examples/company/test_company.py
@@ -21,13 +21,13 @@ def tester():
 
 def test_overbuy(tester, assert_tx_failed):
     # If all the stock has been bought, no one can buy more
-    test_shares = int(tester.c.get_total_shares() / 2)
-    test_value = int(test_shares * tester.c.get_price())
+    test_shares = int(tester.c.total_shares() / 2)
+    test_value = int(test_shares * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert tester.c.stock_available() == 0
     assert tester.c.get_holding(t.a1) == (test_shares * 2)
-    one_stock = tester.c.get_price()
+    one_stock = tester.c.price()
     assert_tx_failed(lambda: tester.c.buy_stock(sender=t.k1, value=one_stock))
     assert_tx_failed(lambda: tester.c.buy_stock(sender=t.k2, value=one_stock))
 
@@ -39,8 +39,8 @@ def test_sell_without_stock(tester, assert_tx_failed):
     # Negative stock doesn't work either
     assert_tx_failed(lambda: tester.c.sell_stock(-1, sender=t.k1))
     # But if you do, you can!
-    test_shares = int(tester.c.get_total_shares())
-    test_value = int(test_shares * tester.c.get_price())
+    test_shares = int(tester.c.total_shares())
+    test_value = int(test_shares * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert tester.c.get_holding(t.a1) == test_shares
     tester.c.sell_stock(test_shares, sender=t.k1)
@@ -50,8 +50,8 @@ def test_sell_without_stock(tester, assert_tx_failed):
 
 def test_oversell(tester, assert_tx_failed):
     # You can't sell more than you own
-    test_shares = int(tester.c.get_total_shares())
-    test_value = int(test_shares * tester.c.get_price())
+    test_shares = int(tester.c.total_shares())
+    test_value = int(test_shares * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert_tx_failed(lambda: tester.c.sell_stock(test_shares + 1, sender=t.k1))
 
@@ -63,8 +63,8 @@ def test_transfer(tester, assert_tx_failed):
     # You can't do negative transfers to gain stock
     assert_tx_failed(lambda: tester.c.transfer_stock(t.a2, -1, sender=t.k1))
     # If you transfer, you don't have the stock anymore
-    test_shares = int(tester.c.get_total_shares())
-    test_value = int(test_shares * tester.c.get_price())
+    test_shares = int(tester.c.total_shares())
+    test_value = int(test_shares * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert tester.c.get_holding(t.a1) == test_shares
     tester.c.transfer_stock(t.a2, test_shares, sender=t.k1)
@@ -79,7 +79,7 @@ def test_paybill(tester, assert_tx_failed):
     # A company can only pay someone if it has the money
     assert_tx_failed(lambda: tester.c.pay_bill(t.a2, 1, sender=t.k0))
     # If it has the money, it can pay someone
-    test_value = int(tester.c.get_total_shares() * tester.c.get_price())
+    test_value = int(tester.c.total_shares() * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     tester.c.pay_bill(t.a2, test_value, sender=t.k0)
     # Until it runs out of money
@@ -91,14 +91,14 @@ def test_paybill(tester, assert_tx_failed):
 def test_valuation(tester):
     # Valuation is number of shares held times price
     assert tester.c.debt() == 0
-    test_value = int(tester.c.get_total_shares() * tester.c.get_price())
+    test_value = int(tester.c.total_shares() * tester.c.price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert tester.c.debt() == test_value
 
 
 def test_logs(tester, get_logs):
     # Buy is logged
-    tester.c.buy_stock(sender=t.k1, value=7 * tester.c.get_price())
+    tester.c.buy_stock(sender=t.k1, value=7 * tester.c.price())
     receipt = tester.s.head_state.receipts[-1]
     logs = get_logs(receipt, tester.c)
     assert len(logs) == 1

--- a/tests/examples/market_maker/test_on_chain_market_maker.py
+++ b/tests/examples/market_maker/test_on_chain_market_maker.py
@@ -24,19 +24,19 @@ def erc20(t, chain):
 
 
 def test_initial_statet(market_maker, utils):
-    assert market_maker.get_total_eth_qty() == 0
-    assert market_maker.get_total_token_qty() == 0
-    assert market_maker.get_invariant() == 0
-    assert utils.remove_0x_head(market_maker.get_owner()) == '0000000000000000000000000000000000000000'
+    assert market_maker.total_eth_qty() == 0
+    assert market_maker.total_token_qty() == 0
+    assert market_maker.invariant() == 0
+    assert utils.remove_0x_head(market_maker.owner()) == '0000000000000000000000000000000000000000'
 
 
 def test_initiate(t, chain, utils, market_maker, erc20, assert_tx_failed):
-    erc20.approve(market_maker.address, 2 * 10 ** 18)
-    market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18)
-    assert market_maker.get_total_eth_qty() == 2 * 10 ** 18
-    assert market_maker.get_total_token_qty() == 1 * 10 ** 18
-    assert market_maker.get_invariant() == 2 * 10 ** 36
-    assert utils.remove_0x_head(market_maker.get_owner()) == t.a0.hex()
+    erc20.approve(market_maker.address, 2*10**18)
+    market_maker.initiate(erc20.address, 1*10**18, value=2*10**18)
+    assert market_maker.total_eth_qty() == 2*10**18
+    assert market_maker.total_token_qty() == 1*10**18
+    assert market_maker.invariant() == 2*10**36
+    assert utils.remove_0x_head(market_maker.owner()) == t.a0.hex()
     t.s = chain
     # Initiate cannot be called twice
     assert_tx_failed(lambda: market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18))
@@ -47,38 +47,38 @@ def test_eth_to_tokens(t, market_maker, erc20):
     market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18)
     assert erc20.balanceOf(market_maker.address) == 1000000000000000000
     assert erc20.balanceOf(t.a1) == 0
-    assert market_maker.get_total_token_qty() == 1000000000000000000
-    assert market_maker.get_total_eth_qty() == 2000000000000000000
+    assert market_maker.total_token_qty() == 1000000000000000000
+    assert market_maker.total_eth_qty() == 2000000000000000000
     market_maker.eth_to_tokens(value=100, sender=t.k1)
     assert erc20.balanceOf(market_maker.address) == 999999999999999950
     assert erc20.balanceOf(t.a1) == 50
-    assert market_maker.get_total_token_qty() == 999999999999999950
-    assert market_maker.get_total_eth_qty() == 2000000000000000100
+    assert market_maker.total_token_qty() == 999999999999999950
+    assert market_maker.total_eth_qty() == 2000000000000000100
 
 
 def test_tokens_to_eth(t, chain, market_maker, erc20):
-    erc20.transfer(t.a1, 1 * 10 ** 18)
-    erc20.approve(market_maker.address, 2 * 10 ** 18)
-    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10 ** 18)
+    erc20.transfer(t.a1, 2 * 10 ** 18)
+    erc20.approve(market_maker.address, 2 * 10 ** 18, sender=t.k1)
+    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10 ** 18, sender=t.k1)
     assert chain.head_state.get_balance(market_maker.address) == 2000000000000000000
-    assert chain.head_state.get_balance(t.a1) == 999999999999999999999900
-    assert market_maker.get_total_token_qty() == 1000000000000000000
+    assert chain.head_state.get_balance(t.a1) == 999997999999999999999900
+    assert market_maker.total_token_qty() == 1000000000000000000
     erc20.approve(market_maker.address, 1 * 10 ** 18, sender=t.k1)
     market_maker.tokens_to_eth(1 * 10 ** 18, sender=t.k1)
     assert chain.head_state.get_balance(market_maker.address) == 1000000000000000000
-    assert chain.head_state.get_balance(t.a1) == 1000000999999999999999900
-    assert market_maker.get_total_token_qty() == 2000000000000000000
-    assert market_maker.get_total_eth_qty() == 1000000000000000000
+    assert chain.head_state.get_balance(t.a1) == 999998999999999999999900
+    assert market_maker.total_token_qty() == 2000000000000000000
+    assert market_maker.total_eth_qty() == 1000000000000000000
 
 
 def test_owner_withdraw(t, chain, market_maker, erc20, assert_tx_failed):
     erc20.approve(market_maker.address, 2 * 10 ** 18)
     market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18)
-    assert chain.head_state.get_balance(t.a0) == 999992000000000000000000
+    assert chain.head_state.get_balance(t.a0) == 999994000000000000000000
     assert erc20.balanceOf(t.a0) == 20999999000000000000000000
     t.s = chain
     # Only owner can call owner_withdraw
     assert_tx_failed(lambda: market_maker.owner_withdraw(sender=t.k1))
     market_maker.owner_withdraw()
-    assert chain.head_state.get_balance(t.a0) == 999994000000000000000000
+    assert chain.head_state.get_balance(t.a0) == 999996000000000000000000
     assert erc20.balanceOf(t.a0) == 21000000000000000000000000

--- a/tests/examples/market_maker/test_on_chain_market_maker.py
+++ b/tests/examples/market_maker/test_on_chain_market_maker.py
@@ -31,20 +31,20 @@ def test_initial_statet(market_maker, utils):
 
 
 def test_initiate(t, chain, utils, market_maker, erc20, assert_tx_failed):
-    erc20.approve(market_maker.address, 2*10**18)
-    market_maker.initiate(erc20.address, 1*10**18, value=2*10**18)
-    assert market_maker.total_eth_qty() == 2*10**18
-    assert market_maker.total_token_qty() == 1*10**18
-    assert market_maker.invariant() == 2*10**36
+    erc20.approve(market_maker.address, 2 * 10**18)
+    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10**18)
+    assert market_maker.total_eth_qty() == 2 * 10**18
+    assert market_maker.total_token_qty() == 1 * 10**18
+    assert market_maker.invariant() == 2 * 10**36
     assert utils.remove_0x_head(market_maker.owner()) == t.a0.hex()
     t.s = chain
     # Initiate cannot be called twice
-    assert_tx_failed(lambda: market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18))
+    assert_tx_failed(lambda: market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10**18))
 
 
 def test_eth_to_tokens(t, market_maker, erc20):
-    erc20.approve(market_maker.address, 2 * 10 ** 18)
-    market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18)
+    erc20.approve(market_maker.address, 2 * 10**18)
+    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10**18)
     assert erc20.balanceOf(market_maker.address) == 1000000000000000000
     assert erc20.balanceOf(t.a1) == 0
     assert market_maker.total_token_qty() == 1000000000000000000
@@ -57,14 +57,14 @@ def test_eth_to_tokens(t, market_maker, erc20):
 
 
 def test_tokens_to_eth(t, chain, market_maker, erc20):
-    erc20.transfer(t.a1, 2 * 10 ** 18)
-    erc20.approve(market_maker.address, 2 * 10 ** 18, sender=t.k1)
-    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10 ** 18, sender=t.k1)
+    erc20.transfer(t.a1, 2 * 10**18)
+    erc20.approve(market_maker.address, 2 * 10**18, sender=t.k1)
+    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10**18, sender=t.k1)
     assert chain.head_state.get_balance(market_maker.address) == 2000000000000000000
     assert chain.head_state.get_balance(t.a1) == 999997999999999999999900
     assert market_maker.total_token_qty() == 1000000000000000000
-    erc20.approve(market_maker.address, 1 * 10 ** 18, sender=t.k1)
-    market_maker.tokens_to_eth(1 * 10 ** 18, sender=t.k1)
+    erc20.approve(market_maker.address, 1 * 10**18, sender=t.k1)
+    market_maker.tokens_to_eth(1 * 10**18, sender=t.k1)
     assert chain.head_state.get_balance(market_maker.address) == 1000000000000000000
     assert chain.head_state.get_balance(t.a1) == 999998999999999999999900
     assert market_maker.total_token_qty() == 2000000000000000000
@@ -72,8 +72,8 @@ def test_tokens_to_eth(t, chain, market_maker, erc20):
 
 
 def test_owner_withdraw(t, chain, market_maker, erc20, assert_tx_failed):
-    erc20.approve(market_maker.address, 2 * 10 ** 18)
-    market_maker.initiate(erc20.address, 1 * 10 ** 18, value=2 * 10 ** 18)
+    erc20.approve(market_maker.address, 2 * 10**18)
+    market_maker.initiate(erc20.address, 1 * 10**18, value=2 * 10**18)
     assert chain.head_state.get_balance(t.a0) == 999994000000000000000000
     assert erc20.balanceOf(t.a0) == 20999999000000000000000000
     t.s = chain

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -34,19 +34,18 @@ def check_balance(tester):
 
 def test_initial_state(srp_tester, assert_tx_failed):
     assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
-    # Inital deposit has to be divisible by two
-    assert_tx_failed(lambda: srp_tester.s.contract(contract_code, language="viper", args=[], value=1))
-    # Seller puts item up for sale
-    srp_tester.c = tester.s.contract(contract_code, language="viper", args=[], value=2)
-    # Check that the seller is set correctly
-    assert utils.remove_0x_head(srp_tester.c.get_seller()) == srp_tester.accounts[0].hex()
-    # Check if item value is set correctly (Half of deposit)
-    assert srp_tester.c.get_value() == 1
-    # Check if unlocked() works correctly after initialization
-    assert srp_tester.c.get_unlocked()
-    # Check that sellers (and buyers) balance is correct
-    assert check_balance(srp_tester) == [INIT_BAL - 2, INIT_BAL]
-
+    #Inital deposit has to be divisible by two
+    assert_tx_failed(lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
+    #Seller puts item up for sale
+    srp_tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    #Check that the seller is set correctly
+    assert utils.remove_0x_head(srp_tester.c.seller()) == srp_tester.accounts[0].hex()
+    #Check if item value is set correctly (Half of deposit)
+    assert srp_tester.c.value() == 1
+    #Check if unlocked() works correctly after initialization
+    assert srp_tester.c.unlocked() == True
+    #Check that sellers (and buyers) balance is correct
+    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL]
 
 def test_abort(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language="viper", args=[], value=2)
@@ -68,13 +67,13 @@ def test_purchase(srp_tester, assert_tx_failed):
     assert_tx_failed(lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k1))
     # Purchase for the correct price
     srp_tester.c.purchase(value=2, sender=srp_tester.k1)
-    # Check if buyer is set correctly
-    assert utils.remove_0x_head(srp_tester.c.get_buyer()) == srp_tester.accounts[1].hex()
-    # Check if contract is locked correctly, should return False
-    assert not srp_tester.c.get_unlocked()
-    # Check balances, both deposits should have been deducted
-    assert check_balance(srp_tester) == [INIT_BAL - 2, INIT_BAL - 2]
-    # Allow nobody else to purchase
+    #Check if buyer is set correctly
+    assert utils.remove_0x_head(srp_tester.c.buyer()) == srp_tester.accounts[1].hex()
+    #Check if contract is locked correctly
+    assert srp_tester.c.unlocked() == False
+    #Check balances, both deposits should have been deducted
+    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL-2]
+    #Allow nobody else to purchase
     assert_tx_failed(lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))
 
 

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -34,18 +34,19 @@ def check_balance(tester):
 
 def test_initial_state(srp_tester, assert_tx_failed):
     assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
-    #Inital deposit has to be divisible by two
-    assert_tx_failed(lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
-    #Seller puts item up for sale
-    srp_tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=2)
-    #Check that the seller is set correctly
+    # Inital deposit has to be divisible by two
+    assert_tx_failed(lambda: srp_tester.s.contract(contract_code, language="viper", args=[], value=1))
+    # Seller puts item up for sale
+    srp_tester.c = tester.s.contract(contract_code, language="viper", args=[], value=2)
+    # Check that the seller is set correctly
     assert utils.remove_0x_head(srp_tester.c.seller()) == srp_tester.accounts[0].hex()
-    #Check if item value is set correctly (Half of deposit)
+    # Check if item value is set correctly (Half of deposit)
     assert srp_tester.c.value() == 1
-    #Check if unlocked() works correctly after initialization
-    assert srp_tester.c.unlocked() == True
-    #Check that sellers (and buyers) balance is correct
-    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL]
+    # Check if unlocked() works correctly after initialization
+    assert srp_tester.c.unlocked() is True
+    # Check that sellers (and buyers) balance is correct
+    assert check_balance(srp_tester) == [INIT_BAL - 2, INIT_BAL]
+
 
 def test_abort(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language="viper", args=[], value=2)
@@ -67,13 +68,13 @@ def test_purchase(srp_tester, assert_tx_failed):
     assert_tx_failed(lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k1))
     # Purchase for the correct price
     srp_tester.c.purchase(value=2, sender=srp_tester.k1)
-    #Check if buyer is set correctly
+    # Check if buyer is set correctly
     assert utils.remove_0x_head(srp_tester.c.buyer()) == srp_tester.accounts[1].hex()
-    #Check if contract is locked correctly
-    assert srp_tester.c.unlocked() == False
-    #Check balances, both deposits should have been deducted
-    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL-2]
-    #Allow nobody else to purchase
+    # Check if contract is locked correctly
+    assert srp_tester.c.unlocked() is False
+    # Check balances, both deposits should have been deducted
+    assert check_balance(srp_tester) == [INIT_BAL - 2, INIT_BAL - 2]
+    # Allow nobody else to purchase
     assert_tx_failed(lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))
 
 

--- a/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_2.py
+++ b/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_2.py
@@ -32,12 +32,12 @@ class TestERC20Flo(PyEthereumTestCase):
         new_balance0 = self.s.head_state.get_balance(self.t.a0)
 
         self.assertEqual(self.c.totalSupply(), 1000, "Deposit not working")
-        self.assertEqual(self.c.balanceOf(self.t.a0), 1000,
+        self.assertEqual(self.c.get_balanceOf(self.t.a0), 1000,
                          "Deposit not working")
         self.assertEqual(new_balance0, orig_balance0 - 1000,
                          "Deposit did not use funds")
 
-        self.assertEqual(self.c.balanceOf(self.t.a1), 0,
+        self.assertEqual(self.c.get_balanceOf(self.t.a1), 0,
                          "Account balance not empty initially")
 
         # If this fails, transfer worked although funds were insufficient
@@ -50,9 +50,9 @@ class TestERC20Flo(PyEthereumTestCase):
                          bytes_to_int(self.t.a1)], int_to_bytes(500))
 
         self.assertEqual(self.c.totalSupply(), 1000, "Transfer changed balance")
-        self.assertEqual(self.c.balanceOf(self.t.a0), 500,
+        self.assertEqual(self.c.get_balanceOf(self.t.a0), 500,
                          "Transfer did not remove funds")
-        self.assertEqual(self.c.balanceOf(self.t.a1), 500,
+        self.assertEqual(self.c.get_balanceOf(self.t.a1), 500,
                          "Transfer did not add funds")
 
         self.assertTrue(self.c.approve(self.t.a0, 200, sender=self.t.k1),
@@ -91,7 +91,7 @@ class TestERC20Flo(PyEthereumTestCase):
         self.check_logs([log_sigs['Transfer'], bytes_to_int(self.t.a0), 0],
                         int_to_bytes(500))
 
-        self.assertEqual(self.c.balanceOf(self.t.a0), 100,
+        self.assertEqual(self.c.get_balanceOf(self.t.a0), 100,
                          "Withdraw did not reduce funds")
         new_balance0 = self.s.head_state.get_balance(self.t.a0)
         self.assertEqual(new_balance0, orig_balance0 - 500,

--- a/tests/examples/voting/test_ballot.py
+++ b/tests/examples/voting/test_ballot.py
@@ -24,46 +24,46 @@ class TestVoting(unittest.TestCase):
 
     def test_initial_state(self):
         # Check chairperson is msg.sender
-        self.assertEqual(utils.remove_0x_head(self.c.get_chairperson()), self.t.a0.hex())
+        self.assertEqual(utils.remove_0x_head(self.c.chairperson()), self.t.a0.hex())
         # Check propsal names are correct
-        self.assertEqual(self.c.get_proposals__name(0), b'Clinton\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-        self.assertEqual(self.c.get_proposals__name(1), b'Trump\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.assertEqual(self.c.proposals__name(0), b'Clinton\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.assertEqual(self.c.proposals__name(1), b'Trump\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
         # Check proposal vote_count is 0
-        self.assertEqual(self.c.get_proposals__vote_count(0), 0)
-        self.assertEqual(self.c.get_proposals__vote_count(1), 0)
+        self.assertEqual(self.c.proposals__vote_count(0), 0)
+        self.assertEqual(self.c.proposals__vote_count(1), 0)
         # Check voter_count is 0
-        self.assertEqual(self.c.get_voter_count(), 0)
+        self.assertEqual(self.c.voter_count(), 0)
         # Check voter starts empty
-        self.assertEqual(self.c.get_voters__delegate(), '0x0000000000000000000000000000000000000000')
-        self.assertEqual(self.c.get_voters__vote(), 0)
-        self.assertEqual(self.c.get_voters__voted(), False)
-        self.assertEqual(self.c.get_voters__weight(), 0)
+        self.assertEqual(self.c.voters__delegate(), '0x0000000000000000000000000000000000000000')
+        self.assertEqual(self.c.voters__vote(), 0)
+        self.assertEqual(self.c.voters__voted(), False)
+        self.assertEqual(self.c.voters__weight(), 0)
 
     def test_give_the_right_to_vote(self):
         self.c.give_right_to_vote(self.t.a1)
         # Check voter given right has weight of 1
-        self.assertEqual(self.c.get_voters__weight(self.t.a1), 1)
+        self.assertEqual(self.c.voters__weight(self.t.a1), 1)
         # Check no other voter attributes have changed
-        self.assertEqual(self.c.get_voters__delegate(self.t.a1), '0x0000000000000000000000000000000000000000')
-        self.assertEqual(self.c.get_voters__vote(self.t.a1), 0)
-        self.assertEqual(self.c.get_voters__voted(self.t.a1), False)
+        self.assertEqual(self.c.voters__delegate(self.t.a1), '0x0000000000000000000000000000000000000000')
+        self.assertEqual(self.c.voters__vote(self.t.a1), 0)
+        self.assertEqual(self.c.voters__voted(self.t.a1), False)
         # Chairperson can give themselves the right to vote
         self.c.give_right_to_vote(self.t.a0)
         # Check chairperson has weight of 1
-        self.assertEqual(self.c.get_voters__weight(self.t.a0), 1)
+        self.assertEqual(self.c.voters__weight(self.t.a0), 1)
         # Check voter_acount is 2
-        self.assertEqual(self.c.get_voter_count(), 2)
+        self.assertEqual(self.c.voter_count(), 2)
         # Check several giving rights to vote
         self.c.give_right_to_vote(self.t.a2)
         self.c.give_right_to_vote(self.t.a3)
         self.c.give_right_to_vote(self.t.a4)
         self.c.give_right_to_vote(self.t.a5)
         # Check voter_acount is now 6
-        self.assertEqual(self.c.get_voter_count(), 6)
+        self.assertEqual(self.c.voter_count(), 6)
         # Check chairperson cannot give the right to vote twice to the same voter
         assert_tx_failed(self, lambda: self.c.give_right_to_vote(self.t.a5))
         # Check voters weight didn't change
-        self.assertEqual(self.c.get_voters__weight(self.t.a5), 1)
+        self.assertEqual(self.c.voters__weight(self.t.a5), 1)
 
     def test_forward_weight(self):
         self.c.give_right_to_vote(self.t.a0)
@@ -83,51 +83,51 @@ class TestVoting(unittest.TestCase):
         # a1(0) -> a2(2)    a3(1)
         self.c.delegate(self.t.a3, sender=self.t.k2)
         # a1(0) -> a2(0) -> a3(3)
-        self.assertEqual(self.c.get_voters__weight(self.t.a1), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a2), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a3), 3)
+        self.assertEqual(self.c.voters__weight(self.t.a1), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a2), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a3), 3)
 
         self.c.delegate(self.t.a9, sender=self.t.k8)
         # a7(1)    a8(0) -> a9(2)
         self.c.delegate(self.t.a8, sender=self.t.k7)
         # a7(0) -> a8(0) -> a9(3)
-        self.assertEqual(self.c.get_voters__weight(self.t.a7), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a8), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 3)
+        self.assertEqual(self.c.voters__weight(self.t.a7), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a8), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 3)
         self.c.delegate(self.t.a7, sender=self.t.k6)
         self.c.delegate(self.t.a6, sender=self.t.k5)
         self.c.delegate(self.t.a5, sender=self.t.k4)
         # a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(0) -> a9(6)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 6)
-        self.assertEqual(self.c.get_voters__weight(self.t.a8), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 6)
+        self.assertEqual(self.c.voters__weight(self.t.a8), 0)
 
         # a3(3)    a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(0) -> a9(6)
         self.c.delegate(self.t.a4, sender=self.t.k3)
         # a3(0) -> a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(3) -> a9(6)
         # a3's vote weight of 3 only makes it to a8 in the delegation chain:
-        self.assertEqual(self.c.get_voters__weight(self.t.a8), 3)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 6)
+        self.assertEqual(self.c.voters__weight(self.t.a8), 3)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 6)
 
         # call forward_weight again to move the vote weight the
         # rest of the way:
         self.c.forward_weight(self.t.a8)
         # a3(0) -> a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(0) -> a9(9)
-        self.assertEqual(self.c.get_voters__weight(self.t.a8), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 9)
+        self.assertEqual(self.c.voters__weight(self.t.a8), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 9)
 
         # a0(1) -> a1(0) -> a2(0) -> a3(0) -> a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(0) -> a9(9)
         self.c.delegate(self.t.a1, sender=self.t.k0)
         # a0's vote weight of 1 only makes it to a5 in the delegation chain:
         # a0(0) -> a1(0) -> a2(0) -> a3(0) -> a4(0) -> a5(1) -> a6(0) -> a7(0) -> a8(0) -> a9(9)
-        self.assertEqual(self.c.get_voters__weight(self.t.a5), 1)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 9)
+        self.assertEqual(self.c.voters__weight(self.t.a5), 1)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 9)
 
         # once again call forward_weight to move the vote weight the
         # rest of the way:
         self.c.forward_weight(self.t.a5)
         # a0(0) -> a1(0) -> a2(0) -> a3(0) -> a4(0) -> a5(0) -> a6(0) -> a7(0) -> a8(0) -> a9(10)
-        self.assertEqual(self.c.get_voters__weight(self.t.a5), 0)
-        self.assertEqual(self.c.get_voters__weight(self.t.a9), 10)
+        self.assertEqual(self.c.voters__weight(self.t.a5), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a9), 10)
 
     def test_block_short_cycle(self):
         self.c.give_right_to_vote(self.t.a0)
@@ -156,15 +156,15 @@ class TestVoting(unittest.TestCase):
         self.c.give_right_to_vote(self.t.a2)
         self.c.give_right_to_vote(self.t.a3)
         # Voter's weight is 1
-        self.assertEqual(self.c.get_voters__weight(self.t.a1), 1)
+        self.assertEqual(self.c.voters__weight(self.t.a1), 1)
         # Voter can delegate: a1 -> a0
         self.c.delegate(self.t.a0, sender=self.t.k1)
         # Voter's weight is now 0
-        self.assertEqual(self.c.get_voters__weight(self.t.a1), 0)
+        self.assertEqual(self.c.voters__weight(self.t.a1), 0)
         # Voter has voted
-        self.assertEqual(self.c.get_voters__voted(self.t.a1), True)
+        self.assertEqual(self.c.voters__voted(self.t.a1), True)
         # Delegate's weight is 2
-        self.assertEqual(self.c.get_voters__weight(self.t.a0), 2)
+        self.assertEqual(self.c.voters__weight(self.t.a0), 2)
         # Voter cannot delegate twice
         assert_tx_failed(self, lambda: self.c.delegate(self.t.a2, sender=self.t.k1))
         # Voter cannot delegate to themselves
@@ -176,7 +176,7 @@ class TestVoting(unittest.TestCase):
         # a3 -> a1 -> a0
         self.c.delegate(self.t.a1, sender=self.t.k3)
         # Delegate's weight is 3
-        self.assertEqual(self.c.get_voters__weight(self.t.a0), 3)
+        self.assertEqual(self.c.voters__weight(self.t.a0), 3)
 
     def test_vote(self):
         self.c.give_right_to_vote(self.t.a0)
@@ -192,7 +192,7 @@ class TestVoting(unittest.TestCase):
         # Voter can vote
         self.c.vote(0)
         # Vote count changes based on voters weight
-        self.assertEqual(self.c.get_proposals__vote_count(0), 3)
+        self.assertEqual(self.c.proposals__vote_count(0), 3)
         # Voter cannot vote twice
         assert_tx_failed(self, lambda: self.c.vote(0))
         # Voter cannot vote if they've delegated
@@ -202,7 +202,7 @@ class TestVoting(unittest.TestCase):
         self.c.vote(1, sender=self.t.k2)
         self.c.vote(1, sender=self.t.k5)
         self.c.vote(1, sender=self.t.k6)
-        self.assertEqual(self.c.get_proposals__vote_count(1), 4)
+        self.assertEqual(self.c.proposals__vote_count(1), 4)
         # Can't vote on a non-proposal
         assert_tx_failed(self, lambda: self.c.vote(2, sender=self.t.k7))
 

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -103,9 +103,9 @@ def set_lucky(arg1: address, arg2: num):
     """
     c2 = get_contract(contract_2)
 
-    assert c.get_lucky() == 0
+    assert c.lucky() == 0
     c2.set_lucky(c.address, lucky_number)
-    assert c.get_lucky() == lucky_number
+    assert c.lucky() == lucky_number
     print('Successfully executed an external contract call state change')
 
 
@@ -179,8 +179,8 @@ def set_lucky(arg1: address, arg2: num):
 
     c3.set_lucky(c.address, lucky_number_1)
     c3.set_lucky(c2.address, lucky_number_2)
-    assert c.get_lucky() == lucky_number_1
-    assert c2.get_lucky() == lucky_number_2
+    assert c.lucky() == lucky_number_1
+    assert c2.lucky() == lucky_number_2
     print('Successfully executed multiple external contract calls to different contracts based on address')
 
 
@@ -198,11 +198,11 @@ def __init__(_lucky: num):
 
     contract_2 = """
 class Foo():
-    def get_lucky() -> num: pass
+    def lucky() -> num: pass
 
 @public
 def bar(arg1: address) -> num:
-    return Foo(arg1).get_lucky()
+    return Foo(arg1).lucky()
     """
     c2 = get_contract(contract_2)
 
@@ -224,29 +224,29 @@ def __init__(_lucky: num):
 
     contract_2 = """
 class Foo():
-    def get_lucky() -> num: pass
+    def lucky() -> num: pass
 
 magic_number: public(num)
 
 @public
 def __init__(arg1: address):
-    self.magic_number = Foo(arg1).get_lucky()
+    self.magic_number = Foo(arg1).lucky()
     """
 
     c2 = get_contract(contract_2, args=[c.address])
     contract_3 = """
 class Bar():
-    def get_magic_number() -> num: pass
+    def magic_number() -> num: pass
 
 best_number: public(num)
 
 @public
 def __init__(arg1: address):
-    self.best_number = Bar(arg1).get_magic_number()
+    self.best_number = Bar(arg1).magic_number()
     """
 
     c3 = get_contract(contract_3, args=[c2.address])
-    assert c3.get_best_number() == lucky_number
+    assert c3.best_number() == lucky_number
     print('Successfully executed a multiple external contract calls')
 
 
@@ -506,7 +506,7 @@ def get_bar() -> num:
     c1 = get_contract(contract_1)
     c2 = get_contract(contract_2)
     c2.foo(c1.address)
-    assert utils.remove_0x_head(c2.get_bar_contract()) == c1.address.hex()
+    assert utils.remove_0x_head(c2.bar_contract()) == c1.address.hex()
     assert c2.get_bar() == 1
 
 

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -68,4 +68,3 @@ def out_literals() -> (num, address, bytes <= 4):
 
     c = get_contract_with_gas_estimation(code)
     assert c.translator.function_data['out_literals']['decode_types'] == ['int128', 'address', 'bytes']
-

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -68,3 +68,4 @@ def out_literals() -> (num, address, bytes <= 4):
 
     c = get_contract_with_gas_estimation(code)
     assert c.translator.function_data['out_literals']['decode_types'] == ['int128', 'address', 'bytes']
+

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -48,15 +48,15 @@ def __init__():
     """
 
     c = get_contract_with_gas_estimation_for_constants(getter_code)
-    assert c.get_x() == 7
-    assert c.get_y(1) == 9
-    assert c.get_z() == b"cow"
-    assert c.get_w__a(1) == 11
-    assert c.get_w__b(1, 2) == 13
-    assert c.get_w__c(1) == b"horse"
-    assert c.get_w__d(1, "0x1234567890123456789012345678901234567890") == 15
-    assert c.get_w__e(2, 1, 2) == 17
-    assert c.get_w__f(3) == 750
-    assert c.get_w__g(3) == 751
+    assert c.x() == 7
+    assert c.y(1) == 9
+    assert c.z() == b"cow"
+    assert c.w__a(1) == 11
+    assert c.w__b(1, 2) == 13
+    assert c.w__c(1) == b"horse"
+    assert c.w__d(1, "0x1234567890123456789012345678901234567890") == 15
+    assert c.w__e(2, 1, 2) == 17
+    assert c.w__f(3) == 750
+    assert c.w__g(3) == 751
 
     print('Passed getter tests')

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -159,7 +159,7 @@ def _mk_getter_helper(typ, depth=0):
 # Make a list of getters for a given variable name with a given type
 def mk_getter(varname, typ):
     funs = _mk_getter_helper(typ)
-    return ["""@public\n@constant\ndef get_%s%s(%s) -> %s: return self.%s%s""" % (varname, funname, head.rstrip(', '), base, varname, tail)
+    return ["""@public\n@constant\ndef %s%s(%s) -> %s: return self.%s%s""" % (varname, funname, head.rstrip(', '), base, varname, tail)
             for (funname, head, tail, base) in funs]
 
 


### PR DESCRIPTION
### - What I did
Change `public` variable getters from `get_var` to `var`
Implement VIP #518
### - How I did it
Remove `get_` from the getter the compiler creates in `parser.py`
### - How to verify it
Look at the tests I changed.
### - Description for the changelog
Change getter from get_var to var.
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/35478668-a9fc3730-03a0-11e8-9dbc-e13a242fe022.png)

