### PR TITLE
Update ERC20 tests for new Vyper type annotation requirements, clamp restrictions

### DIFF
--- a/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
+++ b/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
@@ -19,8 +19,8 @@ num_issued: num256
 @public
 @payable
 def deposit():
-    _value = as_num256(msg.value)
-    _sender = msg.sender
+    _value:num256 = as_num256(msg.value)
+    _sender:address = msg.sender
     self.balances[_sender] = num256_add(self.balances[_sender], _value)
     self.num_issued = num256_add(self.num_issued, _value)
     # Fire deposit event as transfer from 0x0
@@ -28,12 +28,12 @@ def deposit():
 
 @public
 def withdraw(_value : num256) -> bool:
-    _sender = msg.sender
+    _sender:address = msg.sender
     # Make sure sufficient funds are present, op will not underflow supply
     # implicitly through overflow protection
     self.balances[_sender] = num256_sub(self.balances[_sender], _value)
     self.num_issued = num256_sub(self.num_issued, _value)
-    send(_sender, as_wei_value(as_num128(_value), wei))
+    send(_sender, as_wei_value(as_num128(_value), "wei"))
     # Fire withdraw event as transfer to 0x0
     log.Transfer(_sender, 0x0000000000000000000000000000000000000000, _value)
     return true
@@ -50,7 +50,7 @@ def balanceOf(_owner : address) -> num256:
 
 @public
 def transfer(_to : address, _value : num256) -> bool:
-    _sender = msg.sender
+    _sender:address = msg.sender
     # Make sure sufficient funds are present implicitly through overflow protection
     self.balances[_sender] = num256_sub(self.balances[_sender], _value)
     self.balances[_to] = num256_add(self.balances[_to], _value)
@@ -60,8 +60,8 @@ def transfer(_to : address, _value : num256) -> bool:
 
 @public
 def transferFrom(_from : address, _to : address, _value : num256) -> bool:
-    _sender = msg.sender
-    allowance = self.allowances[_from][_sender]
+    _sender:address = msg.sender
+    allowance:num256 = self.allowances[_from][_sender]
     # Make sure sufficient funds/allowance are present implicitly through overflow protection
     self.balances[_from] = num256_sub(self.balances[_from], _value)
     self.balances[_to] = num256_add(self.balances[_to], _value)
@@ -72,7 +72,7 @@ def transferFrom(_from : address, _to : address, _value : num256) -> bool:
 
 @public
 def approve(_spender : address, _value : num256) -> bool:
-    _sender = msg.sender
+    _sender:address = msg.sender
     self.allowances[_sender][_spender] = _value
     # Fire approval event
     log.Approval(_sender, _spender, _value)

--- a/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_1.py
+++ b/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_1.py
@@ -173,8 +173,8 @@ class TestERC20(PyEthereumTestCase):
         # Check boundary conditions - a1 can deposit max amount
         # @TODO fix this, it's hacky and will cause divergences
         # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
-        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
-        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
+        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
         self.assertIsNone(self.c.deposit(value=1, sender=self.t.k1))
         self.assertEqual(initial_a1_balance - self.s.head_state.get_balance(self.t.a1), MAX_UINT256)
         self.assertEqual(self.c.balanceOf(self.t.a1), MAX_UINT256)
@@ -360,8 +360,8 @@ class TestViperERC20(TestERC20):
         # (bad contract is used or overflow checks on total supply would fail)
         # @TODO fix this, it's hacky and will cause divergences
         # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
-        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
-        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
         self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k1))
         self.assertIsNone(self.c_bad.deposit(value=3, sender=self.t.k2))
         self.assert_tx_failed(lambda: self.c_bad.transfer(self.t.a1, 3, sender=self.t.k2))
@@ -378,8 +378,8 @@ class TestViperERC20(TestERC20):
         # Ensure transferFrom fails if it would otherwise overflow balance
         # @TODO fix this, it's hacky and will cause divergences
         # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
-        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
-        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256 / 2) - 1, sender=self.t.k1))
         self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k1))
         self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k2))
         self.assertTrue(self.c_bad.approve(self.t.a1, 1, sender=self.t.k2))

--- a/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_1.py
+++ b/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_1.py
@@ -171,7 +171,11 @@ class TestERC20(PyEthereumTestCase):
     def test_maxInts(self):
         initial_a1_balance = self.s.head_state.get_balance(self.t.a1)
         # Check boundary conditions - a1 can deposit max amount
-        self.assertIsNone(self.c.deposit(value=MAX_UINT256, sender=self.t.k1))
+        # @TODO fix this, it's hacky and will cause divergences
+        # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
+        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c.deposit(value=1, sender=self.t.k1))
         self.assertEqual(initial_a1_balance - self.s.head_state.get_balance(self.t.a1), MAX_UINT256)
         self.assertEqual(self.c.balanceOf(self.t.a1), MAX_UINT256)
         self.assert_tx_failed(lambda: self.c.deposit(value=1, sender=self.t.k1))
@@ -341,7 +345,7 @@ class TestViperERC20(TestERC20):
         cls.c = cls.s.contract(contract_code, language='viper')
         # Bad version of contract where totalSupply / num_issued never gets updated after init
         # (required for full decision/branch coverage)
-        bad_code = contract_code.replace("self.num_issued = num256_add", "x = num256_add")
+        bad_code = contract_code.replace("self.num_issued = num256_add(self.num_issued, _value)", "p:num = 5")
         cls.c_bad = cls.s.contract(bad_code, language='viper')
 
         cls.initial_state = cls.s.snapshot()
@@ -354,10 +358,14 @@ class TestViperERC20(TestERC20):
     def test_bad_transfer(self):
         # Ensure transfer fails if it would otherwise overflow balance
         # (bad contract is used or overflow checks on total supply would fail)
-        self.assertIsNone(self.c_bad.deposit(value=MAX_UINT256, sender=self.t.k1))
-        self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k2))
-        self.assert_tx_failed(lambda: self.c_bad.transfer(self.t.a1, 1, sender=self.t.k2))
-        self.assertTrue(self.c_bad.transfer(self.t.a2, MAX_UINT256 - 1, sender=self.t.k1))
+        # @TODO fix this, it's hacky and will cause divergences
+        # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=3, sender=self.t.k2))
+        self.assert_tx_failed(lambda: self.c_bad.transfer(self.t.a1, 3, sender=self.t.k2))
+        self.assertTrue(self.c_bad.transfer(self.t.a2, MAX_UINT256 - 3, sender=self.t.k1))
 
     def test_bad_deposit(self):
         # Check that, in event when totalSupply is corrupted, it can't be underflowed
@@ -368,7 +376,11 @@ class TestViperERC20(TestERC20):
 
     def test_bad_transferFrom(self):
         # Ensure transferFrom fails if it would otherwise overflow balance
-        self.assertIsNone(self.c_bad.deposit(value=MAX_UINT256, sender=self.t.k1))
+        # @TODO fix this, it's hacky and will cause divergences
+        # we'd like to deposit MAX_UINT256: see https://github.com/ethereum/vyper/issues/653
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=int(MAX_UINT256/2)-1, sender=self.t.k1))
+        self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k1))
         self.assertIsNone(self.c_bad.deposit(value=1, sender=self.t.k2))
         self.assertTrue(self.c_bad.approve(self.t.a1, 1, sender=self.t.k2))
         self.assert_tx_failed(lambda: self.c_bad.transferFrom(self.t.a2, self.t.a1, 1, sender=self.t.k1))


### PR DESCRIPTION
### - What I did

Made the Solidity-compatible ERC20 tests pass again.

### - How I did it

Updated the contract and tests when necessary for:
- Function visibility modifier requirements
- Data type annotations
- The restriction described in #653

### - How to verify it

Follow the instructions to run the corresponding tests (`run_tests.py`).

### - Description for the changelog

Update Solidity-compatible ERC20 tests for new Vyper annotation requirements and clamp restrictions.

### - Cute Animal Picture

```
       __
 __   (__`\
(__`\   \\`\
 `\\`\   \\ \
   `\\`\  \\ \
     `\\`\#\\ \#
       \_ ##\_ |##
       (___)(___)##
        (0)  (0)`\##
         |~   ~ , \##
         |      |  \##
         |     /\   \##         __..---'''''-.._.._
         |     | \   `\##  _.--'                _  `.
         Y     |  \    `##'                     \`\  \
        /      |   \                             | `\ \
       /_...___|    \                            |   `\\
      /        `.    |                          /      ##
     |          |    |                         /      ####
     |          |    |                        /       ####
     | () ()    |     \     |          |  _.-'         ##
     `.        .'      `._. |______..| |-'|
       `------'           | | | |    | || |
                          | | | |    | || |
                          | | | |    | || |
                          | | | |    | || |     Joan Stark
                    _____ | | | |____| || |
               jgs /     `` |-`/     ` |` |
                   \________\__\_______\__\
```
