### PR TITLE
Fix function name global variable shadowing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.02.01**: Functions cannot have the same name as globals.
 * **2018.01.27**: Change getter from get_var to var.
 * **2018.01.11**: Change version from 0.0.2 to 0.0.3
 * **2018.01.04**: Types need to be specified on assignment (`VIP545 <https://github.com/ethereum/vyper/issues/545>`_).

--- a/examples/tokens/vypercoin.v.py
+++ b/examples/tokens/vypercoin.v.py
@@ -9,33 +9,21 @@ Approval: __log__({_owner: indexed(address), _spender: indexed(address), _value:
 
 
 # Variables of the token.
-name: bytes32
-symbol: bytes32
-totalSupply: num
-decimals: num
+name: public(bytes32)
+symbol: public(bytes32)
+totalSupply: public(num256)
+decimals: public(num256)
 balances: num[address]
 allowed: num[address][address]
 
 @public
-def __init__(_name: bytes32, _symbol: bytes32, _decimals: num, _initialSupply: num):
-
+def __init__(_name: bytes32, _symbol: bytes32, _decimals: num256, _initialSupply: num256):
+    
     self.name = _name
     self.symbol = _symbol
     self.decimals = _decimals
-    self.totalSupply = _initialSupply * 10 ** _decimals
-    self.balances[msg.sender] = self.totalSupply
-
-@public
-@constant
-def symbol() -> bytes32:
-
-    return self.symbol
-
-@public
-@constant
-def name() -> bytes32:
-
-    return self.name
+    self.totalSupply = num256_mul(_initialSupply, num256_exp(as_num256(10), _decimals))
+    self.balances[msg.sender] = as_num128(self.totalSupply)
 
 
 # What is the balance of a particular account?
@@ -44,14 +32,6 @@ def name() -> bytes32:
 def balanceOf(_owner: address) -> num256:
 
     return as_num256(self.balances[_owner])
-
-
-# Return total supply of token.
-@public
-@constant
-def totalSupply() -> num256:
-
-    return as_num256(self.totalSupply)
 
 
 # Send `_value` tokens to `_to` from your account

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -76,10 +76,10 @@ def foo() -> num:
     pass
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = []
+    self.bar = []
     """,
     """
 @public

--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -96,7 +96,14 @@ def foo():
     """,
     """
 num: num
+    """,
     """
+foo: num
+
+@public
+def foo():
+    pass
+    """,
 ]
 
 

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -1,11 +1,11 @@
 def test_multi_setter_test(get_contract_with_gas_estimation):
     multi_setter_test = """
-foo: num[3]
+dog: num[3]
 bar: num[3][3]
 @public
 def foo() -> num:
-    self.foo = [1, 2, 3]
-    return(self.foo[0] + self.foo[1] * 10 + self.foo[2] * 100)
+    self.dog = [1, 2, 3]
+    return(self.dog[0] + self.dog[1] * 10 + self.dog[2] * 100)
 
 @public
 def fop() -> num:
@@ -30,8 +30,8 @@ def gop() -> num: # Following a standard naming scheme; nothing to do with the U
 
 @public
 def hoo() -> num:
-    self.foo = None
-    return(self.foo[0] + self.foo[1] * 10 + self.foo[2] * 100)
+    self.dog = None
+    return(self.dog[0] + self.dog[1] * 10 + self.dog[2] * 100)
 
 @public
 def hop() -> num:
@@ -71,16 +71,16 @@ def jop() -> num:
 
 def test_multi_setter_struct_test(get_contract_with_gas_estimation):
     multi_setter_struct_test = """
-foo: {foo: num, bar: num}[3]
+dog: {foo: num, bar: num}[3]
 z: {foo: num[3], bar: {a: num, b: num}[2]}[2]
 
 @public
 def foo() -> num:
-    self.foo[0] = {foo: 1, bar: 2}
-    self.foo[1] = {foo: 3, bar: 4}
-    self.foo[2] = {foo: 5, bar: 6}
-    return self.foo[0].foo + self.foo[0].bar * 10 + self.foo[1].foo * 100 + \
-        self.foo[1].bar * 1000 + self.foo[2].foo * 10000 + self.foo[2].bar * 100000
+    self.dog[0] = {foo: 1, bar: 2}
+    self.dog[1] = {foo: 3, bar: 4}
+    self.dog[2] = {foo: 5, bar: 6}
+    return self.dog[0].foo + self.dog[0].bar * 10 + self.dog[1].foo * 100 + \
+        self.dog[1].bar * 1000 + self.dog[2].foo * 10000 + self.dog[2].bar * 100000
 
 @public
 def fop() -> num:

--- a/tests/parser/integration/test_crowdfund.py
+++ b/tests/parser/integration/test_crowdfund.py
@@ -4,10 +4,10 @@ def test_crowdfund(t, chain, get_contract_with_gas_estimation_for_constants):
 funders: {sender: address, value: wei_value}[num]
 nextFunderIndex: num
 beneficiary: address
-deadline: timestamp
+deadline: public(timestamp)
 goal: wei_value
 refundIndex: num
-timelimit: timedelta
+timelimit: public(timedelta)
 
 @public
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
@@ -34,16 +34,6 @@ def expired() -> bool:
 @constant
 def timestamp() -> timestamp:
     return block.timestamp
-
-@public
-@constant
-def deadline() -> timestamp:
-    return self.deadline
-
-@public
-@constant
-def timelimit() -> timedelta:
-    return self.timelimit
 
 @public
 @constant
@@ -106,10 +96,10 @@ def test_crowdfund2(t, chain, get_contract_with_gas_estimation_for_constants):
 funders: {sender: address, value: wei_value}[num]
 nextFunderIndex: num
 beneficiary: address
-deadline: timestamp
+deadline: public(timestamp)
 goal: wei_value
 refundIndex: num
-timelimit: timedelta
+timelimit: public(timedelta)
 
 @public
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
@@ -135,16 +125,6 @@ def expired() -> bool:
 @constant
 def timestamp() -> timestamp:
     return block.timestamp
-
-@public
-@constant
-def deadline() -> timestamp:
-    return self.deadline
-
-@public
-@constant
-def timelimit() -> timedelta:
-    return self.timelimit
 
 @public
 @constant

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -165,17 +165,17 @@ def foo():
 """)
 
 must_fail("""
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = 5
+    self.bar = 5
 """, TypeMismatchException)
 
 must_succeed("""
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo[0] = 5
+    self.bar[0] = 5
 """)
 
 must_fail("""

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -50,16 +50,16 @@ def foo(x: num[3]):
     self.y = x
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = [1, 2, 0x1234567890123456789012345678901234567890]
+    self.bar = [1, 2, 0x1234567890123456789012345678901234567890]
     """,
     ("""
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = []
+    self.bar = []
     """, StructureException),
     """
 b: num[5]
@@ -68,10 +68,10 @@ def foo():
     x = self.b[0][1]
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = [1, [2], 3]
+    self.bar = [1, [2], 3]
     """,
     """
 bar: num[3][3]
@@ -86,16 +86,16 @@ def foo():
     self.bar = [2, 5]
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = [1, 2, 3, 4]
+    self.bar = [1, 2, 3, 4]
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = [1, 2]
+    self.bar = [1, 2]
     """,
     """
 b: num[5]
@@ -210,19 +210,19 @@ def foo() -> num[2]:
     return [3,5]
     """,
     """
-foo: decimal[3]
+bar: decimal[3]
 @public
 def foo():
-    self.foo = [1.0, 2.1, 3.0]
+    self.bar = [1.0, 2.1, 3.0]
     """,
     """
 x: num[1][2][3][4][5]
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = [1, 2, 3]
+    self.bar = [1, 2, 3]
     """,
     """
 b: num[5]

--- a/tests/parser/syntax/test_maps.py
+++ b/tests/parser/syntax/test_maps.py
@@ -82,16 +82,16 @@ def foo():
     self.nom = {a: [{c: 5}], b: 7}
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = {0: 5, 1: 7, 2: 9}
+    self.bar = {0: 5, 1: 7, 2: 9}
     """,
     """
-foo: num[3]
+bar: num[3]
 @public
 def foo():
-    self.foo = {a: 5, b: 7, c: 9}
+    self.bar = {a: 5, b: 7, c: 9}
     """,
     """
 @public

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -364,6 +364,7 @@ def parse_external_contracts(external_contracts, _contracts):
         external_contracts[_contractname] = contract
     return external_contracts
 
+
 def parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, runtime_only=False):
     sub = ['seq', initializer_lll]
     add_gas = initializer_lll.gas

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -231,7 +231,7 @@ def get_contracts_and_defs_and_globals(code):
         # Contract references
         if isinstance(item, ast.ClassDef):
             if _events or _globals or _defs:
-                    raise StructureException("External contract declarations must come before event declarations, global declarations, and function definitions", item)
+                raise StructureException("External contract declarations must come before event declarations, global declarations, and function definitions", item)
             _contracts[item.name] = add_contract(item.body)
         # Statements of the form:
         # variable_name: type
@@ -239,6 +239,8 @@ def get_contracts_and_defs_and_globals(code):
             _contracts, _events, _globals, _getters = add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item)
         # Function definitions
         elif isinstance(item, ast.FunctionDef):
+            if item.name in _globals:
+                raise VariableDeclarationException("Function name shadowing a variable name: %s" % item.name)
             _defs.append(item)
         else:
             raise StructureException("Invalid top-level statement", item)
@@ -361,7 +363,6 @@ def parse_external_contracts(external_contracts, _contracts):
             contract[sig.name] = sig
         external_contracts[_contractname] = contract
     return external_contracts
-
 
 def parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, runtime_only=False):
     sub = ['seq', initializer_lll]


### PR DESCRIPTION
### - What I did
Make it illegal for function names to match global variable names.
Response to #516 

### - How I did it
Add a check when functions are being created again global variable names.

### - How to verify it
Look at the tests I changed.

### - Description for the changelog
Functions cannot have the same name as globals

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/35709838-99f26ce0-0771-11e8-963d-ed1b197f6ce0.png)

