### PR TITLE
Disallow calling non-constant function in a constant function

### DIFF
--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -52,6 +52,31 @@ def foo() -> num:
 @public
 def foo(x: num):
     x = 5
+    """,
+    """
+f:num
+
+@public
+def a (x:num)->num:
+    self.f = 100
+    return x+5
+
+@constant
+@public
+def b():
+    p: num = self.a(10)
+    """,
+    """
+f:num
+
+@public
+def a (x:num):
+    self.f = 100
+
+@constant
+@public
+def b():
+    self.a(10)
     """
 ]
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -465,7 +465,7 @@ class Expr(object):
 
             sig = self.context.sigs['self'][method_name]
             if self.context.is_constant and not sig.const:
-                raise  ConstancyViolationException(
+                raise ConstancyViolationException(
                     "May not call non-constant function '%s' within a constant function." % (method_name)
                 )
             add_gas = self.context.sigs['self'][method_name].gas  # gas of call

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -162,8 +162,13 @@ class Stmt(object):
             if method_name not in self.context.sigs['self']:
                 raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
                                                     "call functions later in code than themselves): %s" % self.stmt.func.attr)
+            sig = self.context.sigs['self'][method_name]
+            if self.context.is_constant and not sig.const:
+                raise  ConstancyViolationException(
+                    "May not call non-constant function '%s' within a constant function." % (method_name)
+                )
             add_gas = self.context.sigs['self'][method_name].gas
-            inargs, inargsize = pack_arguments(self.context.sigs['self'][self.stmt.func.attr],
+            inargs, inargsize = pack_arguments(sig,
                                                 [Expr(arg, self.context).lll_node for arg in self.stmt.args],
                                                 self.context)
             return LLLnode.from_list(['assert', ['call', ['gas'], ['address'], 0, inargs, inargsize, 0, 0]],

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -164,7 +164,7 @@ class Stmt(object):
                                                     "call functions later in code than themselves): %s" % self.stmt.func.attr)
             sig = self.context.sigs['self'][method_name]
             if self.context.is_constant and not sig.const:
-                raise  ConstancyViolationException(
+                raise ConstancyViolationException(
                     "May not call non-constant function '%s' within a constant function." % (method_name)
                 )
             add_gas = self.context.sigs['self'][method_name].gas


### PR DESCRIPTION
…ction.

### - What I did

Fixes #638. 

### - How I did it

Added checks in `expr.py` and `stmt.py`.

### - How to verify it
```python
f:num

@public
def a (x:num)->num:
    self.f = 100
    return x+5

@constant
@public
def b():
    p: num = self.a(10)
```
Should throw exception.

### - Description for the changelog

### - Cute Animal Picture
![](http://cuteanimalpicturesandvideos.com/wp-content/uploads/piglet.jpg)