### PR TITLE
Fixed Broken Link

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -11,7 +11,7 @@ any errors.
 
 .. note::
    The easiest way to try out the language, experiment with examples, and compile code to ``bytecode``
-   or ``LLL`` is to use the online compiler at https://vyper.tools.
+   or ``LLL`` is to use the online compiler at https://viper.tools.
 
 *************
 Prerequisites


### PR DESCRIPTION
Fixed broken link form vyper.tools to viper.tools

### - What I did
Fixed broken link form vyper.tools to viper.tools

### - How I did it

### - How to verify it
Try vyper.tools, then try viper.tools
### - Description for the changelog
Fixed broken link

### - Cute Animal Picture

> 🐿
