### PR TITLE
Add static and modifiable keywords

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.02.12**: Add modifiable and static keywords for external contract calls.
 * **2018.02.09**: Standardize type conversions.
 * **2018.02.01**: Functions cannot have the same name as globals.
 * **2018.01.27**: Change getter from get_var to var.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from vyper.parser.parser_utils import (
 )
 from vyper import (
     compile_lll,
-    optimizer
+    optimizer,
+    compiler,
 )
 from ethereum import utils as ethereum_utils
 
@@ -68,6 +69,7 @@ def t():
 
 @pytest.fixture(scope="module")
 def chain():
+    tester.languages['vyper'] = compiler.Compiler()
     s = tester.Chain()
     s.head_state.gas_limit = 10**9
     return s

--- a/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
@@ -1,0 +1,241 @@
+from vyper.exceptions import StructureException, InvalidTypeException
+
+
+def test_external_contract_call_declaration_expr(get_contract, assert_tx_failed):
+    contract_1 = """
+lucky: public(num)
+
+@public
+def set_lucky(_lucky: num):
+    self.lucky = _lucky
+"""
+
+    contract_2 = """
+class Bar():
+    def set_lucky(_lucky: num): pass
+
+modifiable_bar_contract: modifiable(Bar)
+static_bar_contract: static(Bar)
+
+@public
+def __init__(contract_address: contract(Bar)):
+    self.modifiable_bar_contract = contract_address
+    self.static_bar_contract = contract_address
+
+@public
+def modifiable_set_lucky(_lucky: num):
+    self.modifiable_bar_contract.set_lucky(_lucky)
+
+@public
+def static_set_lucky(_lucky: num):
+    self.static_bar_contract.set_lucky(_lucky)
+    """
+
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2, args=[c1.address])
+    c2.modifiable_set_lucky(7)
+    assert c1.lucky() == 7
+    # Fails attempting a state change after a call to a static address
+    assert_tx_failed(lambda: c2.static_set_lucky(5))
+    assert c1.lucky() == 7
+
+
+def test_external_contract_call_declaration_stmt(get_contract, assert_tx_failed):
+    contract_1 = """
+lucky: public(num)
+
+@public
+def set_lucky(_lucky: num) -> num:
+    self.lucky = _lucky
+    return self.lucky
+"""
+
+    contract_2 = """
+class Bar():
+    def set_lucky(_lucky: num) -> num: pass
+
+modifiable_bar_contract: modifiable(Bar)
+static_bar_contract: static(Bar)
+
+@public
+def __init__(contract_address: contract(Bar)):
+    self.modifiable_bar_contract = contract_address
+    self.static_bar_contract = contract_address
+
+@public
+def modifiable_set_lucky(_lucky: num) -> num:
+    x:num = self.modifiable_bar_contract.set_lucky(_lucky)
+    return x
+
+@public
+def static_set_lucky(_lucky: num):
+    x:num = self.static_bar_contract.set_lucky(_lucky)
+    """
+
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2, args=[c1.address])
+    c2.modifiable_set_lucky(7)
+    assert c1.lucky() == 7
+    # Fails attempting a state change after a call to a static address
+    assert_tx_failed(lambda: c2.static_set_lucky(5))
+    assert c1.lucky() == 7
+
+
+def test_multiple_contract_state_changes(get_contract, assert_tx_failed):
+    contract_1 = """
+lucky: public(num)
+
+@public
+def set_lucky(_lucky: num):
+    self.lucky = _lucky
+"""
+
+    contract_2 = """
+class Bar():
+    def set_lucky(_lucky: num): pass
+
+modifiable_bar_contract: modifiable(Bar)
+static_bar_contract: static(Bar)
+
+@public
+def __init__(contract_address: contract(Bar)):
+    self.modifiable_bar_contract = contract_address
+    self.static_bar_contract = contract_address
+
+@public
+def modifiable_set_lucky(_lucky: num):
+    self.modifiable_bar_contract.set_lucky(_lucky)
+
+@public
+def static_set_lucky(_lucky: num):
+    self.static_bar_contract.set_lucky(_lucky)
+"""
+
+    contract_3 = """
+class Bar():
+    def modifiable_set_lucky(_lucky: num): pass
+    def static_set_lucky(_lucky: num): pass
+
+modifiable_bar_contract: modifiable(Bar)
+static_bar_contract: static(Bar)
+
+@public
+def __init__(contract_address: contract(Bar)):
+    self.modifiable_bar_contract = contract_address
+    self.static_bar_contract = contract_address
+
+@public
+def modifiable_modifiable_set_lucky(_lucky: num):
+    self.modifiable_bar_contract.modifiable_set_lucky(_lucky)
+
+@public
+def modifiable_static_set_lucky(_lucky: num):
+    self.modifiable_bar_contract.static_set_lucky(_lucky)
+
+@public
+def static_static_set_lucky(_lucky: num):
+    self.static_bar_contract.static_set_lucky(_lucky)
+
+@public
+def static_modifiable_set_lucky(_lucky: num):
+    self.static_bar_contract.modifiable_set_lucky(_lucky)
+    """
+
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2, args=[c1.address])
+    c3 = get_contract(contract_3, args=[c2.address])
+
+    assert c1.lucky() == 0
+    c3.modifiable_modifiable_set_lucky(7)
+    assert c1.lucky() == 7
+    assert_tx_failed(lambda: c3.modifiable_static_set_lucky(6))
+    assert_tx_failed(lambda: c3.static_modifiable_set_lucky(6))
+    assert_tx_failed(lambda: c3.static_static_set_lucky(6))
+    assert c1.lucky() == 7
+
+
+def test_address_can_returned_from_contract_type(get_contract, utils):
+    contract_1 = """
+@public
+def bar() -> num:
+    return 1
+"""
+    contract_2 = """
+class Bar():
+    def bar() -> num: pass
+
+bar_contract: public(static(Bar))
+
+@public
+def foo(contract_address: contract(Bar)):
+    self.bar_contract = contract_address
+
+@public
+def get_bar() -> num:
+    return self.bar_contract.bar()
+"""
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2)
+    c2.foo(c1.address)
+    assert utils.remove_0x_head(c2.bar_contract()) == c1.address.hex()
+    assert c2.get_bar() == 1
+
+
+def test_invalid_external_contract_call_declaration_1(assert_compile_failed, get_contract):
+    contract_1 = """
+class Bar():
+    def bar() -> num: pass
+
+bar_contract: static(Bar)
+
+@public
+def foo(contract_address: contract(Boo)) -> num:
+    self.bar_contract = contract_address
+    return self.bar_contract.bar()
+    """
+
+    assert_compile_failed(lambda: get_contract(contract_1), InvalidTypeException)
+
+
+def test_invalid_external_contract_call_declaration_2(assert_compile_failed, get_contract):
+    contract_1 = """
+class Bar():
+    def bar() -> num: pass
+
+bar_contract: static(Boo)
+
+@public
+def foo(contract_address: contract(Bar)) -> num:
+    self.bar_contract = contract_address
+    return self.bar_contract.bar()
+    """
+
+    assert_compile_failed(lambda: get_contract(contract_1), InvalidTypeException)
+
+
+def test_invalid_if_external_contract_doesnt_exist(get_contract, assert_compile_failed):
+    code = """
+modifiable_bar_contract: modifiable(Bar)
+"""
+
+    assert_compile_failed(lambda: get_contract(code), InvalidTypeException)
+
+
+def test_invalid_if_not_in_valid_global_keywords(get_contract, assert_compile_failed):
+    code = """
+class Bar():
+    def set_lucky(_lucky: num): pass
+
+modifiable_bar_contract: trusted(Bar)
+    """
+    assert_compile_failed(lambda: get_contract(code), StructureException)
+
+
+def test_invalid_if_have_modifiability_not_declared(get_contract_with_gas_estimation_for_constants, assert_compile_failed):
+    code = """
+class Bar():
+    def set_lucky(_lucky: num): pass
+
+modifiable_bar_contract: public(Bar)
+"""
+    assert_compile_failed(lambda: get_contract_with_gas_estimation_for_constants(code), StructureException)

--- a/vyper/function_signature.py
+++ b/vyper/function_signature.py
@@ -33,6 +33,12 @@ class VariableRecord():
         return get_size_of_type(self.typ)
 
 
+class ContractRecord(VariableRecord):
+    def __init__(self, modifiable, *args):
+        super(ContractRecord, self).__init__(*args)
+        self.modifiable = modifiable
+
+
 # Function signature object
 class FunctionSignature():
     def __init__(self, name, args, output_type, const, payable, private, sig, method_id):

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -1,0 +1,87 @@
+from vyper.utils import (
+    MemoryPositions,
+    is_varname_valid,
+)
+from vyper.types import (
+    get_size_of_type
+)
+
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
+
+from vyper.function_signature import (
+    VariableRecord,
+)
+
+
+# Contains arguments, variables, etc
+class Context():
+    def __init__(self, vars=None, globals=None, sigs=None, forvars=None, return_type=None, is_constant=False, is_payable=False, origcode=''):
+        # In-memory variables, in the form (name, memory location, type)
+        self.vars = vars or {}
+        self.next_mem = MemoryPositions.RESERVED_MEMORY
+        # Global variables, in the form (name, storage location, type)
+        self.globals = globals or {}
+        # ABI objects, in the form {classname: ABI JSON}
+        self.sigs = sigs or {}
+        # Variables defined in for loops, eg. for i in range(6): ...
+        self.forvars = forvars or {}
+        # Return type of the function
+        self.return_type = return_type
+        # Is the function constant?
+        self.is_constant = is_constant
+        # Is the function payable?
+        self.is_payable = is_payable
+        # Number of placeholders generated (used to generate random names)
+        self.placeholder_count = 1
+        # Original code (for error pretty-printing purposes)
+        self.origcode = origcode
+        # In Loop status. Whether body is currently evaluating within a for-loop or not.
+        self.in_for_loop = set()
+        # Count returns in function
+        self.function_return_count = 0
+        # Current block scope
+        self.blockscopes = set()
+
+    def set_in_for_loop(self, name_of_list):
+        self.in_for_loop.add(name_of_list)
+
+    def remove_in_for_loop(self, name_of_list):
+        self.in_for_loop.remove(name_of_list)
+
+    def start_blockscope(self, blockscope_id):
+        self.blockscopes.add(blockscope_id)
+
+    def end_blockscope(self, blockscope_id):
+        # Remove all variables that have specific blockscope_id attached.
+        self.vars = {
+            name: var_record for name, var_record in self.vars.items()
+            if blockscope_id not in var_record.blockscopes
+        }
+        # Remove block scopes
+        self.blockscopes.remove(blockscope_id)
+
+    def increment_return_counter(self):
+        self.function_return_count += 1
+
+    # Add a new variable
+    def new_variable(self, name, typ):
+        if not is_varname_valid(name):
+            raise VariableDeclarationException("Variable name invalid or reserved: " + name)
+        if name in self.vars or name in self.globals:
+            raise VariableDeclarationException("Duplicate variable name: %s" % name)
+        self.vars[name] = VariableRecord(name, self.next_mem, typ, True, self.blockscopes.copy())
+        pos = self.next_mem
+        self.next_mem += 32 * get_size_of_type(typ)
+        return pos
+
+    # Add an anonymous variable (used in some complex function definitions)
+    def new_placeholder(self, typ):
+        name = '_placeholder_' + str(self.placeholder_count)
+        self.placeholder_count += 1
+        return self.new_variable(name, typ)
+
+    # Get the next unused memory location
+    def get_next_mem(self):
+        return self.next_mem

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -442,7 +442,7 @@ class Expr(object):
     # Function calls
     def call(self):
         from .parser import (
-            external_contract_call_expr,
+            external_contract_call,
             pack_arguments,
         )
         from vyper.functions import (
@@ -488,17 +488,17 @@ class Expr(object):
         elif isinstance(self.expr.func, ast.Attribute) and isinstance(self.expr.func.value, ast.Call):
             contract_name = self.expr.func.value.func.id
             contract_address = Expr.parse_value_expr(self.expr.func.value.args[0], self.context)
-            return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
+            return external_contract_call(self.expr, self.context, contract_name, contract_address, True)
         elif isinstance(self.expr.func.value, ast.Attribute) and self.expr.func.value.attr in self.context.sigs:
             contract_name = self.expr.func.value.attr
             var = self.context.globals[self.expr.func.value.attr]
             contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.expr), annotation='self.' + self.expr.func.value.attr))
-            return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
+            return external_contract_call(self.expr, self.context, contract_name, contract_address, True)
         elif isinstance(self.expr.func.value, ast.Attribute) and self.expr.func.value.attr in self.context.globals:
             contract_name = self.context.globals[self.expr.func.value.attr].typ.unit
             var = self.context.globals[self.expr.func.value.attr]
             contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.expr), annotation='self.' + self.expr.func.value.attr))
-            return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
+            return external_contract_call(self.expr, self.context, contract_name, contract_address, var.modifiable)
         else:
             raise StructureException("Unsupported operator: %r" % ast.dump(self.expr), self.expr)
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -9,6 +9,7 @@ from vyper.exceptions import (
 from vyper.function_signature import (
     FunctionSignature,
     VariableRecord,
+    ContractRecord
 )
 from vyper.signatures.event_signature import (
     EventSignature
@@ -18,6 +19,7 @@ from vyper.premade_contracts import (
 )
 from .stmt import Stmt
 from .expr import Expr
+from .context import Context
 from .parser_utils import LLLnode
 from .parser_utils import (
     get_length,
@@ -47,7 +49,8 @@ from vyper.utils import (
     MemoryPositions,
     LOADED_LIMIT_MAP,
     reserved_words,
-    string_to_bytes
+    string_to_bytes,
+    valid_global_keywords
 )
 from vyper.utils import (
     bytes_to_int,
@@ -174,7 +177,29 @@ def add_contract(code):
     return _defs
 
 
+def get_item_name_and_attributes(item, attributes):
+    if isinstance(item, ast.Name):
+        return item.id, attributes
+    elif isinstance(item, ast.AnnAssign):
+        return get_item_name_and_attributes(item.annotation, attributes)
+    elif isinstance(item, ast.Subscript):
+        return get_item_name_and_attributes(item.value, attributes)
+    # elif ist
+    elif isinstance(item, ast.Call):
+        attributes[item.func.id] = True
+        # Raise for multiple args
+        if len(item.args) != 1:
+            raise StructureException("%s expects one arg (the type)" % item.func.id)
+        return get_item_name_and_attributes(item.args[0], attributes)
+    return None, attributes
+
+
 def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item):
+    item_attributes = {"public": False, "modifiable": False, "static": False}
+    if not (isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__"):
+        item_name, item_attributes = get_item_name_and_attributes(item, item_attributes)
+        if not all([attr in valid_global_keywords for attr in item_attributes.keys()]):
+            raise StructureException('Invalid global keyword used: %s' % item_attributes)
     if item.value is not None:
         raise StructureException('May not assign value whilst defining type', item)
     elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__":
@@ -194,20 +219,23 @@ def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item)
     # If the type declaration is of the form public(<type here>), then proceed with
     # the underlying type but also add getters
     elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "address":
-        if len(item.annotation.args) != 1:
-            raise StructureException("Address expects one arg (the type)")
         if item.annotation.args[0].id not in premade_contracts:
             raise VariableDeclarationException("Unsupported premade contract declaration", item.annotation.args[0])
         premade_contract = premade_contracts[item.annotation.args[0].id]
         _contracts[item.target.id] = add_contract(premade_contract.body)
         _globals[item.target.id] = VariableRecord(item.target.id, len(_globals), BaseType('address'), True)
-    elif isinstance(item, ast.AnnAssign) and isinstance(item.annotation, ast.Name) and item.annotation.id in _contracts:
-        _globals[item.target.id] = VariableRecord(item.target.id, len(_globals), BaseType('address', item.annotation.id), True)
+    elif item_name in _contracts:
+        if not item_attributes["modifiable"] and not item_attributes["static"]:
+            raise StructureException("All contracts must have `modifiable` or `static` keywords: %s" % item_attributes)
+        _globals[item.target.id] = ContractRecord(item_attributes["modifiable"], item.target.id, len(_globals), BaseType('address', item_name), True)
+        if item_attributes["public"]:
+            typ = BaseType('address', item_name)
+            for getter in mk_getter(item.target.id, typ):
+                _getters.append(parse_line('\n' * (item.lineno - 1) + getter))
+                _getters[-1].pos = getpos(item)
     elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "public":
-        if len(item.annotation.args) != 1:
-            raise StructureException("Public expects one arg (the type)")
-        if isinstance(item.annotation.args[0], ast.Name) and item.annotation.args[0].id in _contracts:
-            typ = BaseType('address', item.annotation.args[0].id)
+        if isinstance(item.annotation.args[0], ast.Name) and item_name in _contracts:
+            typ = BaseType('address', item_name)
         else:
             typ = parse_type(item.annotation.args[0], 'storage')
         _globals[item.target.id] = VariableRecord(item.target.id, len(_globals), typ, True)
@@ -252,78 +280,6 @@ initializer_list = ['seq', ['mstore', 28, ['calldataload', 0]]]
 # Store limit constants at fixed addresses in memory.
 initializer_list += [['mstore', pos, limit_size] for pos, limit_size in LOADED_LIMIT_MAP.items()]
 initializer_lll = LLLnode.from_list(initializer_list, typ=None)
-
-
-# Contains arguments, variables, etc
-class Context():
-    def __init__(self, vars=None, globals=None, sigs=None, forvars=None, return_type=None, is_constant=False, is_payable=False, origcode=''):
-        # In-memory variables, in the form (name, memory location, type)
-        self.vars = vars or {}
-        self.next_mem = MemoryPositions.RESERVED_MEMORY
-        # Global variables, in the form (name, storage location, type)
-        self.globals = globals or {}
-        # ABI objects, in the form {classname: ABI JSON}
-        self.sigs = sigs or {}
-        # Variables defined in for loops, eg. for i in range(6): ...
-        self.forvars = forvars or {}
-        # Return type of the function
-        self.return_type = return_type
-        # Is the function constant?
-        self.is_constant = is_constant
-        # Is the function payable?
-        self.is_payable = is_payable
-        # Number of placeholders generated (used to generate random names)
-        self.placeholder_count = 1
-        # Original code (for error pretty-printing purposes)
-        self.origcode = origcode
-        # In Loop status. Whether body is currently evaluating within a for-loop or not.
-        self.in_for_loop = set()
-        # Count returns in function
-        self.function_return_count = 0
-        # Current block scope
-        self.blockscopes = set()
-
-    def set_in_for_loop(self, name_of_list):
-        self.in_for_loop.add(name_of_list)
-
-    def remove_in_for_loop(self, name_of_list):
-        self.in_for_loop.remove(name_of_list)
-
-    def start_blockscope(self, blockscope_id):
-        self.blockscopes.add(blockscope_id)
-
-    def end_blockscope(self, blockscope_id):
-        # Remove all variables that have specific blockscope_id attached.
-        self.vars = {
-            name: var_record for name, var_record in self.vars.items()
-            if blockscope_id not in var_record.blockscopes
-        }
-        # Remove block scopes
-        self.blockscopes.remove(blockscope_id)
-
-    def increment_return_counter(self):
-        self.function_return_count += 1
-
-    # Add a new variable
-    def new_variable(self, name, typ):
-        if not is_varname_valid(name):
-            raise VariableDeclarationException("Variable name invalid or reserved: " + name)
-        if name in self.vars or name in self.globals:
-            raise VariableDeclarationException("Duplicate variable name: %s" % name)
-        self.vars[name] = VariableRecord(name, self.next_mem, typ, True, self.blockscopes.copy())
-        pos = self.next_mem
-        self.next_mem += 32 * get_size_of_type(typ)
-        return pos
-
-    # Add an anonymous variable (used in some complex function definitions)
-    def new_placeholder(self, typ):
-        name = '_placeholder_' + str(self.placeholder_count)
-        self.placeholder_count += 1
-        return self.new_variable(name, typ)
-
-    # Get the next unused memory location
-    def get_next_mem(self):
-        return self.next_mem
 
 
 # Is a function the initializer?
@@ -515,52 +471,39 @@ def parse_body(code, context):
     return LLLnode.from_list(['seq'] + o, pos=getpos(code[0]) if code else None)
 
 
-def external_contract_call_stmt(stmt, context, contract_name, contract_address):
+def external_contract_call(node, context, contract_name, contract_address, is_modifiable):
     if contract_name not in context.sigs:
         raise VariableDeclarationException("Contract not declared yet: %s" % contract_name)
-    method_name = stmt.func.attr
+    method_name = node.func.attr
     if method_name not in context.sigs[contract_name]:
         raise VariableDeclarationException("Function not declared yet: %s (reminder: "
                                                     "function must be declared in the correct contract)" % method_name)
     sig = context.sigs[contract_name][method_name]
-    inargs, inargsize = pack_arguments(sig, [parse_expr(arg, context) for arg in stmt.args], context)
+    inargs, inargsize = pack_arguments(sig, [parse_expr(arg, context) for arg in node.args], context)
+    output_placeholder, output_size, returner = get_external_contract_call_output(sig, context)
     sub = ['seq', ['assert', ['extcodesize', contract_address]],
                     ['assert', ['ne', 'address', contract_address]]]
-    if context.is_constant:
-        sub.append(['assert', ['staticcall', 'gas', contract_address, inargs, inargsize, 0, 0]])
+    if context.is_constant or not is_modifiable:
+        sub.append(['assert', ['staticcall', 'gas', contract_address, inargs, inargsize, output_placeholder, output_size]])
     else:
-        sub.append(['assert', ['call', 'gas', contract_address, 0, inargs, inargsize, 0, 0]])
-    o = LLLnode.from_list(sub, typ=sig.output_type, location='memory', pos=getpos(stmt))
+        sub.append(['assert', ['call', 'gas', contract_address, 0, inargs, inargsize, output_placeholder, output_size]])
+    sub.extend(returner)
+    o = LLLnode.from_list(sub, typ=sig.output_type, location='memory', pos=getpos(node))
     return o
 
 
-def external_contract_call_expr(expr, context, contract_name, contract_address):
-    if contract_name not in context.sigs:
-        raise VariableDeclarationException("Contract not declared yet: %s" % contract_name)
-    method_name = expr.func.attr
-    if method_name not in context.sigs[contract_name]:
-        raise VariableDeclarationException("Function not declared yet: %s (reminder: "
-                                                    "function must be declared in the correct contract)" % method_name)
-    sig = context.sigs[contract_name][method_name]
-    inargs, inargsize = pack_arguments(sig, [parse_expr(arg, context) for arg in expr.args], context)
+def get_external_contract_call_output(sig, context):
+    if not sig.output_type:
+        return 0, 0, []
     output_placeholder = context.new_placeholder(typ=sig.output_type)
+    output_size = get_size_of_type(sig.output_type) * 32
     if isinstance(sig.output_type, BaseType):
-        returner = output_placeholder
+        returner = [0, output_placeholder]
     elif isinstance(sig.output_type, ByteArrayType):
-        returner = output_placeholder + 32
+        returner = [0, output_placeholder + 32]
     else:
-        raise TypeMismatchException("Invalid output type: %r" % sig.output_type, expr)
-    sub = ['seq', ['assert', ['extcodesize', contract_address]],
-                    ['assert', ['ne', 'address', contract_address]]]
-    if context.is_constant:
-        sub.append(['assert', ['staticcall', 'gas', contract_address, inargs, inargsize,
-                    output_placeholder, get_size_of_type(sig.output_type) * 32]])
-    else:
-        sub.append(['assert', ['call', 'gas', contract_address, 0, inargs, inargsize,
-            output_placeholder, get_size_of_type(sig.output_type) * 32]])
-    sub.extend([0, returner])
-    o = LLLnode.from_list(sub, typ=sig.output_type, location='memory', pos=getpos(expr))
-    return o
+        raise TypeMismatchException("Invalid output type: %s" % sig.output_type)
+    return output_placeholder, output_size, returner
 
 
 # Parse an expression

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -153,7 +153,7 @@ class Stmt(object):
             pack_arguments,
             pack_logging_data,
             pack_logging_topics,
-            external_contract_call_stmt,
+            external_contract_call,
         )
         if isinstance(self.stmt.func, ast.Name) and self.stmt.func.id in stmt_dispatch_table:
                 return stmt_dispatch_table[self.stmt.func.id](self.stmt, self.context)
@@ -176,17 +176,17 @@ class Stmt(object):
         elif isinstance(self.stmt.func, ast.Attribute) and isinstance(self.stmt.func.value, ast.Call):
             contract_name = self.stmt.func.value.func.id
             contract_address = Expr.parse_value_expr(self.stmt.func.value.args[0], self.context)
-            return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
+            return external_contract_call(self.stmt, self.context, contract_name, contract_address, True)
         elif isinstance(self.stmt.func.value, ast.Attribute) and self.stmt.func.value.attr in self.context.sigs:
             contract_name = self.stmt.func.value.attr
             var = self.context.globals[self.stmt.func.value.attr]
             contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.stmt), annotation='self.' + self.stmt.func.value.attr))
-            return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
+            return external_contract_call(self.stmt, self.context, contract_name, contract_address, True)
         elif isinstance(self.stmt.func.value, ast.Attribute) and self.stmt.func.value.attr in self.context.globals:
             contract_name = self.context.globals[self.stmt.func.value.attr].typ.unit
             var = self.context.globals[self.stmt.func.value.attr]
             contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.stmt), annotation='self.' + self.stmt.func.value.attr))
-            return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
+            return external_contract_call(self.stmt, self.context, contract_name, contract_address, var.modifiable)
         elif isinstance(self.stmt.func, ast.Attribute) and self.stmt.func.value.id == 'log':
             if self.stmt.func.attr not in self.context.sigs['self']:
                 raise VariableDeclarationException("Event not declared yet: %s" % self.stmt.func.attr)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -119,6 +119,9 @@ valid_call_keywords = ['num', 'decimal', 'address', 'contract', 'indexed']
 # Valid base units
 valid_units = ['currency', 'wei', 'currency1', 'currency2', 'sec', 'm', 'kg']
 
+# Valid attributes for global variables
+valid_global_keywords = ['public', 'modifiable', 'static', 'address', 'num']
+
 # Cannot be used for variable or member naming
 reserved_words = ['int128', 'int256', 'uint256', 'address', 'bytes32',
                   'real', 'real128x128', 'if', 'for', 'while', 'until',


### PR DESCRIPTION
### - What I did
Add `STATICALL` opcode protections for external contract calls.
Implements VIP #542 
@jacqueswww 
### - How I did it
Added support for `modifiable` and `static` wrappers when declaring contract variables.
### - How to verify it
Look at `test_modifiable_external_contract_calls.py`

### - Description for the changelog
Add modifiable and static keywords for external contract calls.
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/36133108-8f357c64-1038-11e8-88e8-042f97c748be.png)

