### PR TITLE
Fix num division

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.02.12**: Division by num returns decimal type.
 * **2018.02.09**: Standardize type conversions.
 * **2018.02.01**: Functions cannot have the same name as globals.
 * **2018.01.27**: Change getter from get_var to var.

--- a/examples/market_maker/on_chain_market_maker.v.py
+++ b/examples/market_maker/on_chain_market_maker.v.py
@@ -24,10 +24,10 @@ def initiate(token_addr: address, token_quantity: currency_value):
 @public
 @payable
 def eth_to_tokens():
-    fee: wei_value = msg.value / 500
+    fee: wei_value = floor(msg.value / 500)
     eth_in_purchase: wei_value = msg.value - fee
     new_total_eth: wei_value = self.total_eth_qty + eth_in_purchase
-    new_total_tokens: currency_value = self.invariant / new_total_eth
+    new_total_tokens: currency_value = floor(self.invariant / new_total_eth)
     self.token_address.transfer(msg.sender,
                                 convert(self.total_token_qty - new_total_tokens, 'num256'))
     self.total_eth_qty = new_total_eth
@@ -38,7 +38,7 @@ def eth_to_tokens():
 def tokens_to_eth(sell_quantity: currency_value):
     self.token_address.transferFrom(msg.sender, self, convert(sell_quantity, 'num256'))
     new_total_tokens: currency_value = self.total_token_qty + sell_quantity
-    new_total_eth: wei_value = self.invariant / new_total_tokens
+    new_total_eth: wei_value = floor(self.invariant / new_total_tokens)
     eth_to_send: wei_value = self.total_eth_qty - new_total_eth
     send(msg.sender, eth_to_send)
     self.total_eth_qty = new_total_eth

--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -25,7 +25,7 @@ unlocked: public(bool)
 @payable
 def __init__():
     assert (msg.value % 2) == 0
-    self.value = msg.value / 2 #The seller initializes the contract by  
+    self.value = floor(msg.value / 2) #The seller initializes the contract by  
         #posting a safety deposit of 2*value of the item up for sale.
     self.seller = msg.sender
     self.unlocked = true

--- a/examples/stock/company.v.py
+++ b/examples/stock/company.v.py
@@ -38,7 +38,7 @@ def stock_available() -> currency_value:
 def buy_stock():
     # Note: full amount is given to company (no fractional shares),
     #       so be sure to send exact amount to buy shares
-    buy_order: currency_value = msg.value / self.price # rounds down
+    buy_order: currency_value = floor(msg.value / self.price) # rounds down
 
     # There are enough shares to buy
     assert self.stock_available() >= buy_order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from vyper.parser.parser_utils import (
 )
 from vyper import (
     compile_lll,
-    optimizer
+    optimizer,
+    compiler,
 )
 from ethereum import utils as ethereum_utils
 
@@ -68,6 +69,7 @@ def t():
 
 @pytest.fixture(scope="module")
 def chain():
+    tester.languages['vyper'] = compiler.Compiler()
     s = tester.Chain()
     s.head_state.gas_limit = 10**9
     return s

--- a/tests/parser/features/iteration/test_repeater.py
+++ b/tests/parser/features/iteration/test_repeater.py
@@ -20,7 +20,7 @@ def reverse_digits(x: num) -> num:
     z: num = x
     for i in range(6):
         dig[i] = z % 10
-        z = z / 10
+        z = floor(z / 10)
     o: num = 0
     for i in range(6):
         o = o * 10 + dig[i]

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -22,12 +22,6 @@ def augsub(x: num, y: num) -> num:
     return z
 
 @public
-def augdiv(x: num, y: num) -> num:
-    z: num = x
-    z /= y
-    return z
-
-@public
 def augmod(x: num, y: num) -> num:
     z: num = x
     z %= y
@@ -39,7 +33,6 @@ def augmod(x: num, y: num) -> num:
     assert c.augadd(5, 12) == 17
     assert c.augmul(5, 12) == 60
     assert c.augsub(5, 12) == -7
-    assert c.augdiv(5, 12) == 0
     assert c.augmod(5, 12) == 5
     print('Passed aug-assignment test')
 

--- a/tests/parser/functions/test_ceil.py
+++ b/tests/parser/functions/test_ceil.py
@@ -1,0 +1,18 @@
+def test_ceil(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num:
+    return ceil(.9999999999)
+
+@public
+def fop() -> num:
+    return ceil(.0000000001)
+
+@public
+def foq() -> num:
+    return ceil(170141183460469231731687303715884105723.0000000001)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 1
+    assert c.fop() == 1
+    assert c.foq() == 170141183460469231731687303715884105724

--- a/tests/parser/functions/test_floor.py
+++ b/tests/parser/functions/test_floor.py
@@ -1,0 +1,18 @@
+def test_floor(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> num:
+    return floor(1.9999999999)
+
+@public
+def fop() -> num:
+    return floor(1.0000000001)
+
+@public
+def foq() -> num:
+    return floor(170141183460469231731687303715884105723.0000000001)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 1
+    assert c.fop() == 1
+    assert c.foq() == 170141183460469231731687303715884105723

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -24,7 +24,7 @@ def foo() -> timedelta[2]:
     """,
     """
 @public
-def foo() -> num(wei / sec):
+def foo() -> decimal(wei / sec):
     x: num(wei) = as_wei_value(5, "finney")
     y: num = block.timestamp + 50
     return x / y
@@ -106,7 +106,7 @@ def add_record():
     """,
     """
 @public
-def foo() -> num(wei / sec):
+def foo() -> decimal(wei / sec):
     x: num(wei) = as_wei_value(5, "finney")
     y: num(sec) = block.timestamp + 50 - block.timestamp
     return x / y

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -186,7 +186,7 @@ def foo() -> address:
 
 must_succeed("""
 @public
-def foo(x: wei_value, y: currency_value, z: num (wei*currency/sec**2)) -> num (sec**2):
+def foo(x: wei_value, y: currency_value, z: num (wei*currency/sec**2)) -> decimal(sec**2):
     return x * y / z
 """)
 

--- a/tests/parser/syntax/test_public.py
+++ b/tests/parser/syntax/test_public.py
@@ -13,7 +13,7 @@ y: public(num(wei / sec ** 2))
 z: public(num(1 / sec))
 
 @public
-def foo() -> num(sec ** 2):
+def foo() -> decimal(sec ** 2):
     return self.x / self.y / self.z
     """
 ]

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -17,6 +17,32 @@ def _num_exp(x: num, y: num) -> num:
     assert c._num_exp(72, 19) == 72 ** 19
 
 
+def test_num_divided_by_num(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo(inp: num) -> decimal:
+    y: decimal = 5/inp
+    return y
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo(2) == 2.5
+    assert c.foo(10) == .5
+    assert c.foo(50) == .1
+
+
+def test_decimal_divided_by_num(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo(inp: decimal) -> decimal:
+    y: decimal = inp/5
+    return y
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo(1) == .2
+    assert c.foo(.5) == .1
+    assert c.foo(.2) == .04
+
+
 def test_negative_nums(t, get_contract_with_gas_estimation, chain):
     negative_nums_code = """
 @public

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -71,6 +71,14 @@ def floor(expr, args, kwargs, context):
     )
 
 
+@signature('decimal')
+def ceil(expr, args, kwards, context):
+    return LLLnode.from_list(
+        ['sdiv', ['add', args[0], DECIMAL_DIVISOR - 1], DECIMAL_DIVISOR], typ=BaseType('num', args[0].typ.unit, args[0].typ.positional),
+        pos=getpos(expr)
+    )
+
+
 @signature(('num', 'decimal'))
 def as_unitless_number(expr, args, kwargs, context):
     return LLLnode(value=args[0].value, args=args[0].args, typ=BaseType(args[0].typ.typ, {}), pos=getpos(expr))
@@ -735,6 +743,7 @@ def minmax(expr, args, kwargs, context, is_min):
 
 dispatch_table = {
     'floor': floor,
+    'ceil': ceil,
     'as_unitless_number': as_unitless_number,
     'convert': _convert,
     'slice': _slice,

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -261,8 +261,8 @@ class Expr(object):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot divide positional values!", self.expr)
             new_unit = combine_units(left.typ.unit, right.typ.unit, div=True)
-            if rtyp == 'num':
-                o = LLLnode.from_list(['sdiv', left, ['clamp_nonzero', right]], typ=BaseType(ltyp, new_unit), pos=getpos(self.expr))
+            if ltyp == rtyp == 'num':
+                o = LLLnode.from_list(['sdiv', ['mul', left, DECIMAL_DIVISOR], ['clamp_nonzero', right]], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             elif ltyp == rtyp == 'decimal':
                 o = LLLnode.from_list(['with', 'l', left, ['with', 'r', ['clamp_nonzero', right],
                                             ['sdiv', ['mul', 'l', DECIMAL_DIVISOR], 'r']]],
@@ -270,6 +270,8 @@ class Expr(object):
             elif ltyp == 'num' and rtyp == 'decimal':
                 o = LLLnode.from_list(['sdiv', ['mul', left, DECIMAL_DIVISOR ** 2], ['clamp_nonzero', right]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
+            elif ltyp == 'decimal' and rtyp == 'num':
+                o = LLLnode.from_list(['sdiv', left,  ['clamp_nonzero', right]], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             else:
                 raise Exception("Unsupported Operation 'div(%r, %r)'" % (ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Mod):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -271,7 +271,7 @@ class Expr(object):
                 o = LLLnode.from_list(['sdiv', ['mul', left, DECIMAL_DIVISOR ** 2], ['clamp_nonzero', right]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             elif ltyp == 'decimal' and rtyp == 'num':
-                o = LLLnode.from_list(['sdiv', left,  ['clamp_nonzero', right]], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
+                o = LLLnode.from_list(['sdiv', left, ['clamp_nonzero', right]], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             else:
                 raise Exception("Unsupported Operation 'div(%r, %r)'" % (ltyp, rtyp))
         elif isinstance(self.expr.op, ast.Mod):


### PR DESCRIPTION
### - What I did
Change division by `num` to output a `decimal` instead of a `num`. 
Add `ceil` built in function for rounding up.
Remove support for:
```
x: num = 7
x /= 5
```
### - How I did it
Changed `def arithmetic` in `expr.py` to return `decimal` instead of a `num` when dividing by a `num`.
### - How to verify it
Look at `test_ceil.py`, `test_num.py`, and all the other tests I changed.
### - Description for the changelog
Division by num returns decimal type.
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/36176099-c1fc951a-10ce-11e8-9eab-a47d20a14782.png)
