### PR TITLE
Ban functions with payable and constant decorators

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ Compatibility-breaking Changelog
 ********************************
 
 * **2018.02.22**: Renaming num to int128, and num256 to uint256.
+* **2018.02.13**: Ban functions with payable and constant decorators.
 * **2018.02.12**: Division by num returns decimal type.
 * **2018.02.09**: Standardize type conversions.
 * **2018.02.01**: Functions cannot have the same name as globals.

--- a/tests/parser/features/decorators/test_constant.py
+++ b/tests/parser/features/decorators/test_constant.py
@@ -1,3 +1,6 @@
+from vyper.exceptions import StructureException
+
+
 def test_constant_test(get_contract_with_gas_estimation_for_constants):
     constant_test = """
 @public
@@ -10,3 +13,14 @@ def foo() -> int128:
     assert c.foo() == 5
 
     print("Passed constant function test")
+
+
+def test_invalid_constant_and_payable(get_contract_with_gas_estimation_for_constants, assert_compile_failed):
+    code = """
+@public
+@payable
+@constant
+def foo() -> num:
+    return 5
+"""
+    assert_compile_failed(lambda: get_contract_with_gas_estimation_for_constants(code), StructureException)

--- a/vyper/function_signature.py
+++ b/vyper/function_signature.py
@@ -84,7 +84,9 @@ class FunctionSignature():
             else:
                 raise StructureException("Bad decorator", dec)
         if public and private:
-            raise StructureException("Cannot use public and private decorators on the same function", code)
+            raise StructureException("Cannot use public and private decorators on the same function: {}".format(name))
+        if payable and const:
+            raise StructureException("Function {} cannot be both constant and payable.".format(name))
         if not public and not private and not isinstance(code.body[0], ast.Pass):
             raise StructureException("Function visibility must be declared (@public or @private)", code)
         # Determine the return type and whether or not it's constant. Expects something


### PR DESCRIPTION
### - What I did
Ban functions with both `payable` and `constant` decorators because `constant` functions have not need to accept value.
In response to #675
### - How I did it
Add a check for `payable` and `constant` decorators to `function_signature.py`
### - How to verify it
Look at the test I added to `test_constant.py`
### - Description for the changelog
Ban functions with payable and constant decorators
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/36188049-a9d25456-1106-11e8-9402-af6bdb18e918.png)

