### PR TITLE
Change eg. to e.g.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ Vyper is an experimental programming language that aims for some of the followin
 
 Some examples of what Vyper does NOT have and why:
 
-* **Modifiers** - eg. in Solidity you can do `function foo() mod1 { ... }`, where `mod1` can be defined elsewhere in the code to include a check that is done before execution, a check that is done after execution, some state changes, or possibly other things. Vyper does not have this, because it makes it too easy to write misleading code. `mod1` just _looks_ too innocuous for something that could add arbitrary pre-conditions, post-conditions or state changes. Also, it encourages people to write code where the execution jumps around the file, harming auditability. The usual use case for a modifier is something that performs a single check before execution of a program; our recommendation is to simply inline these checks as asserts.
+* **Modifiers** - e.g. in Solidity you can do `function foo() mod1 { ... }`, where `mod1` can be defined elsewhere in the code to include a check that is done before execution, a check that is done after execution, some state changes, or possibly other things. Vyper does not have this, because it makes it too easy to write misleading code. `mod1` just _looks_ too innocuous for something that could add arbitrary pre-conditions, post-conditions or state changes. Also, it encourages people to write code where the execution jumps around the file, harming auditability. The usual use case for a modifier is something that performs a single check before execution of a program; our recommendation is to simply inline these checks as asserts.
 * **Class inheritance** - requires people to jump between multiple files to understand what a program is doing, and requires people to understand the rules of precedence in case of conflicts (which class's function X is the one that's actually used?). Hence, it makes code too complicated to understand.
 * **Inline assembly** - adding inline assembly would make it no longer possible to Ctrl+F for a variable name to find all instances where that variable is read or modified.
 * **Operator overloading** - waaay too easy to write misleading code (what do you mean "+" means "send all my money to the developer"? I didn't catch the part of the code that says that!).
 * **Recursive calling** - cannot set an upper bound on gas limits, opening the door for gas limit attacks.
 * **Infinite-length loops** - cannot set an upper bound on gas limits, opening the door for gas limit attacks.
-* **Binary fixed point** - decimal fixed point is better, because any decimal fixed point value written as a literal in code has an exact representation, whereas with binary fixed point approximations are often required (eg. 0.2 -> 0.001100110011..., which needs to be truncated), leading to unintuitive results, eg. in python `0.3 + 0.3 + 0.3 + 0.1 != 1`.
+* **Binary fixed point** - decimal fixed point is better, because any decimal fixed point value written as a literal in code has an exact representation, whereas with binary fixed point approximations are often required (e.g. 0.2 -> 0.001100110011..., which needs to be truncated), leading to unintuitive results, e.g. in python `0.3 + 0.3 + 0.3 + 0.1 != 1`.
 
 Some changes that may be considered after Metropolis when STATICCALL becomes available include:
 
 * Forbidding state changes after non-static calls unless the address being non-statically called is explicitly marked "trusted". This would reduce risk of re-entrancy attacks.
-* Forbidding "inline" non-static calls, eg. `send(some_address, contract.do_something_and_return_a_weivalue())`, enforcing clear separation between "call to get a response" and "call to do something".
+* Forbidding "inline" non-static calls, e.g. `send(some_address, contract.do_something_and_return_a_weivalue())`, enforcing clear separation between "call to get a response" and "call to do something".
 
 Vyper does NOT strive to be a 100% replacement for everything that can be done in Solidity; it will deliberately forbid things or make things harder if it deems fit to do so for the goal of increasing security.
 

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -243,7 +243,7 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
     # != operator
     elif code.value == 'ne':
         return compile_to_assembly(LLLnode.from_list(['iszero', ['eq', code.args[0], code.args[1]]]), withargs, break_dest, height)
-    # eg. 95 -> 96, 96 -> 96, 97 -> 128
+    # e.g. 95 -> 96, 96 -> 96, 97 -> 128
     elif code.value == "ceil32":
         return compile_to_assembly(LLLnode.from_list(['with', '_val', code.args[0],
                                                         ['sub', ['add', '_val', 31],

--- a/vyper/functions/signature.py
+++ b/vyper/functions/signature.py
@@ -55,7 +55,7 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
             if isinstance(sub.typ, ByteArrayType):
                 return sub
         else:
-            # Does not work for unit-endowed types inside compound types, eg. timestamp[2]
+            # Does not work for unit-endowed types inside compound types, e.g. timestamp[2]
             parsed_expected_type = parse_type(ast.parse(expected_arg).body[0].value, 'memory')
             if isinstance(parsed_expected_type, BaseType):
                 vsub = vsub or Expr.parse_value_expr(arg, context)

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -264,7 +264,7 @@ class Context():
         self.globals = globals or {}
         # ABI objects, in the form {classname: ABI JSON}
         self.sigs = sigs or {}
-        # Variables defined in for loops, eg. for i in range(6): ...
+        # Variables defined in for loops, e.g. for i in range(6): ...
         self.forvars = forvars or {}
         # Return type of the function
         self.return_type = return_type

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -59,7 +59,7 @@ class LLLnode():
             self.valency = 1
             self.gas = 5
         elif isinstance(self.value, str):
-            # Opcodes and pseudo-opcodes (eg. clamp)
+            # Opcodes and pseudo-opcodes (e.g. clamp)
             if self.value.upper() in comb_opcodes:
                 _, ins, outs, gas = comb_opcodes[self.value.upper()]
                 self.valency = outs
@@ -234,7 +234,7 @@ def get_number_as_fraction(expr, context):
     return context_slice[:t], top, bottom
 
 
-# Is a number of decimal form (eg. 65281) or 0x form (eg. 0xff01)
+# Is a number of decimal form (e.g. 65281) or 0x form (e.g. 0xff01)
 def get_original_if_0x_prefixed(expr, context):
     context_slice = context.origcode.splitlines()[expr.lineno - 1][expr.col_offset:]
     if context_slice[:2] != '0x':

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -108,7 +108,7 @@ class Stmt(object):
         from .parser import (
             make_setter,
         )
-        # Assignment (eg. x[4] = y)
+        # Assignment (e.g. x[4] = y)
         if len(self.stmt.targets) != 1:
             raise StructureException("Assignment statement must have one target", self.stmt)
         sub = Expr(self.stmt.value, self.context).lll_node
@@ -221,7 +221,7 @@ class Stmt(object):
         from .parser import (
             parse_body,
         )
-        # Type 0 for, eg. for i in list(): ...
+        # Type 0 for, e.g. for i in list(): ...
         if self._is_list_iter():
             return self.parse_for_list()
 
@@ -234,18 +234,18 @@ class Stmt(object):
 
         block_scope_id = id(self.stmt.orelse)
         self.context.start_blockscope(block_scope_id)
-        # Type 1 for, eg. for i in range(10): ...
+        # Type 1 for, e.g. for i in range(10): ...
         if len(self.stmt.iter.args) == 1:
             if not isinstance(self.stmt.iter.args[0], ast.Num):
                 raise StructureException("Range only accepts literal values", self.stmt.iter)
             start = LLLnode.from_list(0, typ='int128', pos=getpos(self.stmt))
             rounds = self.stmt.iter.args[0].n
         elif isinstance(self.stmt.iter.args[0], ast.Num) and isinstance(self.stmt.iter.args[1], ast.Num):
-            # Type 2 for, eg. for i in range(100, 110): ...
+            # Type 2 for, e.g. for i in range(100, 110): ...
             start = LLLnode.from_list(self.stmt.iter.args[0].n, typ='int128', pos=getpos(self.stmt))
             rounds = LLLnode.from_list(self.stmt.iter.args[1].n - self.stmt.iter.args[0].n, typ='int128', pos=getpos(self.stmt))
         else:
-            # Type 3 for, eg. for i in range(x, x + 10): ...
+            # Type 3 for, e.g. for i in range(x, x + 10): ...
             if not isinstance(self.stmt.iter.args[1], ast.BinOp) or not isinstance(self.stmt.iter.args[1].op, ast.Add):
                 raise StructureException("Two-arg for statements must be of the form `for i in range(start, start + rounds): ...`",
                                             self.stmt.iter.args[1])

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -10,7 +10,7 @@ from vyper.utils import (
 )
 
 
-# Pretty-print a unit (eg. wei/seconds**2)
+# Pretty-print a unit (e.g. wei/seconds**2)
 def print_unit(unit):
     if unit is None:
         return '*'
@@ -110,7 +110,7 @@ class MappingType(NodeType):
         return repr(self.valuetype) + '[' + repr(self.keytype) + ']'
 
 
-# Data structure for a struct, eg. {a: <type>, b: <type>}
+# Data structure for a struct, e.g. {a: <type>, b: <type>}
 class StructType(NodeType):
     def __init__(self, members):
         self.members = copy.copy(members)
@@ -122,7 +122,7 @@ class StructType(NodeType):
         return '{' + ', '.join([k + ': ' + repr(v) for k, v in self.members.items()]) + '}'
 
 
-# Data structure for a list with heterogeneous types, eg. [int128, bytes32, bytes]
+# Data structure for a list with heterogeneous types, e.g. [int128, bytes32, bytes]
 class TupleType(NodeType):
     def __init__(self, members):
         self.members = copy.copy(members)
@@ -236,7 +236,7 @@ def parse_unit(item):
 # Parses an expression representing a type. Annotation refers to whether
 # the type is to be located in memory or storage
 def parse_type(item, location, sigs={}):
-    # Base types, eg. num
+    # Base types, e.g. num
     if isinstance(item, ast.Name):
         if item.id in base_types:
             return BaseType(item.id)
@@ -244,7 +244,7 @@ def parse_type(item, location, sigs={}):
             return special_types[item.id]
         else:
             raise InvalidTypeException("Invalid base type: " + item.id, item)
-    # Units, eg. num (1/sec) or contracts
+    # Units, e.g. num (1/sec) or contracts
     elif isinstance(item, ast.Call):
         # Contract_types
         if item.func.id == 'contract' or item.func.id == 'address':
@@ -277,12 +277,12 @@ def parse_type(item, location, sigs={}):
     elif isinstance(item, ast.Subscript):
         if 'value' not in vars(item.slice):
             raise InvalidTypeException("Array access must access a single element, not a slice", item)
-        # Fixed size lists, eg. num[100]
+        # Fixed size lists, e.g. num[100]
         elif isinstance(item.slice.value, ast.Num):
             if not isinstance(item.slice.value.n, int) or item.slice.value.n <= 0:
                 raise InvalidTypeException("Arrays must have a positive integral number of elements", item.slice.value)
             return ListType(parse_type(item.value, location), item.slice.value.n)
-        # Mappings, eg. num[address]
+        # Mappings, e.g. num[address]
         else:
             if location == 'memory':
                 raise InvalidTypeException("No mappings allowed for in-memory types, only fixed-size arrays", item)
@@ -290,7 +290,7 @@ def parse_type(item, location, sigs={}):
             if not isinstance(keytype, (BaseType, ByteArrayType)):
                 raise InvalidTypeException("Mapping keys must be base or bytes types", item.slice.value)
             return MappingType(keytype, parse_type(item.value, location))
-    # Dicts, used to represent mappings, eg. {uint: uint}. Key must be a base type
+    # Dicts, used to represent mappings, e.g. {uint: uint}. Key must be a base type
     elif isinstance(item, ast.Dict):
         o = {}
         for key, value in zip(item.keys, item.values):

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -49,7 +49,7 @@ class NodeType():
     pass
 
 
-# Data structure for a type that representsa 32-byte object
+# Data structure for a type that represents a 32-byte object
 class BaseType(NodeType):
 
     def __init__(self, typ, unit=False, positional=False, override_signature=False):


### PR DESCRIPTION
### - What I did
Changed eg. to e.g.

### - How I did it
Search and change (although there are more eg. in old_readme.txt, there is a pull request deleting old_readme so I didn't touch old_readme.txt)

### - How to verify it
By reading the docs. Dictionary says "exempli gratia", for example in Latin, is e.g.

### - Description for the changelog
Only one commit, changing eg. to e.g.

### - Cute Animal Picture

![huksoon](https://user-images.githubusercontent.com/19610222/36406804-c3d0370c-163c-11e8-96d9-b6199c77457c.jpg)
