### PR TITLE
Fix bad readthedocs url in Dockerfile label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG VCS_REF
 LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.name="Vyper" \
     org.label-schema.description="Vyper is an experimental programming language" \
-    org.label-schema.url="https://vyperr.readthedocs.io/en/latest/" \
+    org.label-schema.url="https://vyper.readthedocs.io/en/latest/" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/ethereum/vyper" \
     org.label-schema.vendor="Ethereum" \


### PR DESCRIPTION
### - What I did
Fixed a typo in the dockerfile label pointing to readthedocs.

### - How I did it
Removed an unnecessary `r`? 

### - How to verify it
Review and check the URL

### - Description for the changelog
Fixed bad documentation URL label in the Dockerfile

### - Cute Animal Picture
![swing](https://user-images.githubusercontent.com/7315957/36434706-b3cc6560-162d-11e8-9413-1481e7151f4a.jpg)

