### PR TITLE
Fixed ERC20 contract to use int128 instead of num

### DIFF
--- a/examples/tokens/ERC20.v.py
+++ b/examples/tokens/ERC20.v.py
@@ -11,29 +11,22 @@ Approval: __log__({_owner: indexed(address), _spender: indexed(address), _value:
 
 
 # Variables of the token.
-name: bytes32
-symbol: bytes32
-totalSupply: num
-decimals: num
-balances: num[address]
-allowed: num[address][address]
+name: public(bytes32)
+symbol: public(bytes32)
+totalSupply: public(uint256)
+decimals: int128
+balances: int128[address]
+allowed: int128[address][address]
 
 
 @public
-def __init__(_name: bytes32, _symbol: bytes32, _decimals: num, _initialSupply: num):
+def __init__(_name: bytes32, _symbol: bytes32, _decimals: uint256, _initialSupply: uint256):
 
     self.name = _name
     self.symbol = _symbol
     self.decimals = _decimals
-    self.totalSupply = _initialSupply * 10 ** _decimals
-    self.balances[msg.sender] = self.totalSupply
-
-
-@public
-@constant
-def symbol() -> bytes32:
-
-    return self.symbol
+    self.totalSupply = uint256_mul(_initialSupply, uint256_exp(convert(10, 'uint256'), _decimals))
+    self.balances[msg.sender] = convert(self.totalSupply, 'int128')
 
 
 # What is the balance of a particular account?
@@ -44,17 +37,9 @@ def balanceOf(_owner: address) -> uint256:
     return convert(self.balances[_owner], 'uint256')
 
 
-# Return total supply of token.
-@public
-@constant
-def totalSupply() -> uint256:
-
-    return convert(self.totalSupply, 'uint256')
-
-
 # Send `_value` tokens to `_to` from your account
 @public
-def transfer(_to: address, _amount: num(uint256)) -> bool:
+def transfer(_to: address, _amount: int128(uint256)) -> bool:
 
     if self.balances[msg.sender] >= _amount and \
        self.balances[_to] + _amount >= self.balances[_to]:
@@ -70,7 +55,7 @@ def transfer(_to: address, _amount: num(uint256)) -> bool:
 
 # Transfer allowed tokens from a specific account to another.
 @public
-def transferFrom(_from: address, _to: address, _value: num(uint256)) -> bool:
+def transferFrom(_from: address, _to: address, _value: int128(uint256)) -> bool:
 
     if _value <= self.allowed[_from][msg.sender] and \
        _value <= self.balances[_from]:
@@ -88,7 +73,7 @@ def transferFrom(_from: address, _to: address, _value: num(uint256)) -> bool:
 # Allow _spender to withdraw from your account, multiple times, up to the _value amount.
 # If this function is called again it overwrites the current allowance with _value.
 @public
-def approve(_spender: address, _amount: num(uint256)) -> bool:
+def approve(_spender: address, _amount: int128(uint256)) -> bool:
 
     self.allowed[msg.sender][_spender] = _amount
     log.Approval(msg.sender, _spender, convert(_amount, 'uint256'))


### PR DESCRIPTION
### - What I did

Just changed num to use int128. Also, updated totalSuppy variable to be public and removed totalSupply method.

### - How I did it

Replacing the code.

### - How to verify it

Run and compile the erc20.v.py source code.

### - Description for the changelog

Described above.

### - Cute Animal Picture

![cute-baby-animals-33](https://user-images.githubusercontent.com/82811/36635700-fb7ec936-19b9-11e8-86e6-aa4adcf0bf08.jpg)

