### PR TITLE
Removed } from end of the function

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -37,7 +37,6 @@ Functions are the executable units of code within a contract.
   @payable
   def bid(): // Function
     // ...
-  }
 
 :ref:`Function-calls` can happen internally or externally
 and have different levels of visibility (:ref:`visibility-and-getters`)


### PR DESCRIPTION
For some reason there was a } in the end of an example of a function in the docs. Someone probably confused with Solidity.

### - Cute Animal Picture
![baby_bunny](https://user-images.githubusercontent.com/10667901/37240992-386979c6-245b-11e8-9f4b-d70bcdff5034.jpg)


