### PR TITLE
Removed unnecessary comma

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -360,7 +360,7 @@ Structs can be accessed via ``struct.argname``.
     #Defining a struct
     exampleStruct: {
         value1: int128,
-        value2: decimal,
+        value2: decimal
     }
     #Accessing a value
     exampleStruct.value1 = 1


### PR DESCRIPTION
There was an extra comma in the struct example.
I guess it's a mistake but I noticed the code still compiles with no errors.
I don't know if it matters but I am asking just to make sure.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/37353966-33c39dee-26e9-11e8-8e5f-2b9ef97a9736.png)

