### PR TITLE
 Fix floor and ceil for negative inputs

### DIFF
--- a/tests/parser/functions/test_ceil.py
+++ b/tests/parser/functions/test_ceil.py
@@ -11,8 +11,44 @@ def fop() -> int128:
 @public
 def foq() -> int128:
     return ceil(170141183460469231731687303715884105723.0000000001)
+
+@public
+def fos() -> int128:
+    return ceil(0.0)
 """
     c = get_contract_with_gas_estimation(code)
     assert c.foo() == 1
     assert c.fop() == 1
     assert c.foq() == 170141183460469231731687303715884105724
+    assert c.fos() == 0
+
+
+# ceil(x) should yeild the smallest integer greater than or equal to x
+def test_ceil_negative(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> int128:
+    return ceil(-11.01)
+
+@public
+def fop() -> int128:
+    return ceil(-5.0)
+
+@public
+def foq() -> int128:
+    return ceil(-.0000000001)
+
+@public
+def fos() -> int128:
+    return ceil(-5472.9999999999)
+
+@public
+def fot() -> int128:
+    return ceil(-170141183460469231731687303715884105727.0000000001)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == -11
+    assert c.fop() == -5
+    assert c.foq() == 0
+    assert c.fos() == -5472
+    assert c.fot() == -170141183460469231731687303715884105727

--- a/tests/parser/functions/test_ceil.py
+++ b/tests/parser/functions/test_ceil.py
@@ -1,5 +1,15 @@
 def test_ceil(get_contract_with_gas_estimation):
     code = """
+x: decimal
+
+@public
+def __init__():
+    self.x = 504.0000000001
+
+@public
+def x_ceil() -> int128:
+    return ceil(self.x)
+
 @public
 def foo() -> int128:
     return ceil(.9999999999)
@@ -10,22 +20,41 @@ def fop() -> int128:
 
 @public
 def foq() -> int128:
-    return ceil(170141183460469231731687303715884105723.0000000001)
+    return ceil(170141183460469231731687303715884105726.0000000002)
 
 @public
 def fos() -> int128:
     return ceil(0.0)
+
+@public
+def fou() -> int128:
+    a: int128 = 305
+    b: int128 = 100
+    c: decimal = a / b
+    return ceil(c)
 """
     c = get_contract_with_gas_estimation(code)
+    assert c.x_ceil() == 505
     assert c.foo() == 1
     assert c.fop() == 1
-    assert c.foq() == 170141183460469231731687303715884105724
+    assert c.foq() == 170141183460469231731687303715884105727
     assert c.fos() == 0
+    assert c.fou() == 4
 
 
 # ceil(x) should yeild the smallest integer greater than or equal to x
 def test_ceil_negative(get_contract_with_gas_estimation):
     code = """
+x: decimal
+
+@public
+def __init__():
+    self.x = -504.0000000001
+
+@public
+def x_ceil() -> int128:
+    return ceil(self.x)
+
 @public
 def foo() -> int128:
     return ceil(-11.01)
@@ -44,11 +73,26 @@ def fos() -> int128:
 
 @public
 def fot() -> int128:
-    return ceil(-170141183460469231731687303715884105727.0000000001)
+    return ceil(-170141183460469231731687303715884105727.0000000002)
+
+@public
+def fou() -> int128:
+    a: int128 = -305
+    b: int128 = 100
+    c: decimal = a / b
+    return ceil(c)
+
+@public
+def ceil_param(p: decimal) -> int128:
+    return ceil(p)
 """
     c = get_contract_with_gas_estimation(code)
+    assert c.x_ceil() == -504
     assert c.foo() == -11
     assert c.fop() == -5
     assert c.foq() == 0
     assert c.fos() == -5472
     assert c.fot() == -170141183460469231731687303715884105727
+    assert c.fou() == -3
+    assert c.ceil_param(-0.5) == 0
+    assert c.ceil_param(-7777777.7777777) == -7777777

--- a/tests/parser/functions/test_floor.py
+++ b/tests/parser/functions/test_floor.py
@@ -1,5 +1,15 @@
 def test_floor(get_contract_with_gas_estimation):
     code = """
+x: decimal
+
+@public
+def __init__():
+    self.x = 504.0000000001
+
+@public
+def x_floor() -> int128:
+    return floor(self.x)
+
 @public
 def foo() -> int128:
     return floor(1.9999999999)
@@ -10,7 +20,7 @@ def fop() -> int128:
 
 @public
 def foq() -> int128:
-    return floor(170141183460469231731687303715884105723.0000000001)
+    return floor(170141183460469231731687303715884105726.0000000002)
 
 @public
 def fos() -> int128:
@@ -19,22 +29,41 @@ def fos() -> int128:
 @public
 def fot() -> int128:
     return floor(0.0000000001)
+
+@public
+def fou() -> int128:
+    a: int128 = 305
+    b: int128 = 100
+    c: decimal = a / b
+    return floor(c)
 """
     c = get_contract_with_gas_estimation(code)
+    assert c.x_floor() == 504
     assert c.foo() == 1
     assert c.fop() == 1
-    assert c.foq() == 170141183460469231731687303715884105723
+    assert c.foq() == 170141183460469231731687303715884105726
     assert c.fos() == 0
     assert c.fot() == 0
+    assert c.fou() == 3
 
 
 def test_floor_negative(get_contract_with_gas_estimation):
     code = """
+x: decimal
+
+@public
+def __init__():
+    self.x = -504.0000000001
+
+@public
+def x_floor() -> int128:
+    return floor(self.x)
+
 @public
 def foo() -> int128:
-    x: int128 = -65
-    y: decimal = x / 10
-    return floor(y)
+    a: int128 = -65
+    b: decimal = a / 10
+    return floor(b)
 
 @public
 def fop() -> int128:
@@ -50,11 +79,26 @@ def fos() -> int128:
 
 @public
 def fot() -> int128:
-    return floor(-170141183460469231731687303715884105727.0000000001)
+    return floor(-170141183460469231731687303715884105727.0000000002)
+
+@public
+def fou() -> int128:
+    a: int128 = -305
+    b: int128 = 100
+    c: decimal = a / b
+    return floor(c)
+
+@public
+def floor_param(p: decimal) -> int128:
+    return floor(p)
 """
     c = get_contract_with_gas_estimation(code)
+    assert c.x_floor() == -505
     assert c.foo() == -7
     assert c.fop() == -27
     assert c.foq() == -9001
     assert c.fos() == -1
     assert c.fot() == -170141183460469231731687303715884105728
+    assert c.fou() == -4
+    assert c.floor_param(-5.6) == -6
+    assert c.floor_param(-0.0000000001) == -1

--- a/tests/parser/functions/test_floor.py
+++ b/tests/parser/functions/test_floor.py
@@ -11,8 +11,50 @@ def fop() -> int128:
 @public
 def foq() -> int128:
     return floor(170141183460469231731687303715884105723.0000000001)
+
+@public
+def fos() -> int128:
+    return floor(0.0)
+
+@public
+def fot() -> int128:
+    return floor(0.0000000001)
 """
     c = get_contract_with_gas_estimation(code)
     assert c.foo() == 1
     assert c.fop() == 1
     assert c.foq() == 170141183460469231731687303715884105723
+    assert c.fos() == 0
+    assert c.fot() == 0
+
+
+def test_floor_negative(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> int128:
+    x: int128 = -65
+    y: decimal = x / 10
+    return floor(y)
+
+@public
+def fop() -> int128:
+    return floor(-27.0)
+
+@public
+def foq() -> int128:
+    return floor(-9000.0000000001)
+
+@public
+def fos() -> int128:
+    return floor(-0.0000000001)
+
+@public
+def fot() -> int128:
+    return floor(-170141183460469231731687303715884105727.0000000001)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == -7
+    assert c.fop() == -27
+    assert c.foq() == -9001
+    assert c.fos() == -1
+    assert c.fot() == -170141183460469231731687303715884105728

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -68,7 +68,12 @@ def get_keyword(expr, keyword):
 @signature('decimal')
 def floor(expr, args, kwargs, context):
     return LLLnode.from_list(
-        ['sdiv', args[0], DECIMAL_DIVISOR], typ=BaseType('int128', args[0].typ.unit, args[0].typ.positional),
+        ['if',
+            ['slt', args[0], 0],
+            ['sdiv', ['sub', args[0], DECIMAL_DIVISOR - 1], DECIMAL_DIVISOR],
+            ['sdiv', args[0], DECIMAL_DIVISOR]
+        ],
+        typ=BaseType('int128', args[0].typ.unit, args[0].typ.positional),
         pos=getpos(expr)
     )
 
@@ -76,7 +81,12 @@ def floor(expr, args, kwargs, context):
 @signature('decimal')
 def ceil(expr, args, kwards, context):
     return LLLnode.from_list(
-        ['sdiv', ['add', args[0], DECIMAL_DIVISOR - 1], DECIMAL_DIVISOR], typ=BaseType('int128', args[0].typ.unit, args[0].typ.positional),
+        ['if',
+            ['slt', args[0], 0],
+            ['sdiv', args[0], DECIMAL_DIVISOR],
+            ['sdiv', ['add', args[0], DECIMAL_DIVISOR - 1], DECIMAL_DIVISOR]
+        ],
+        typ=BaseType('int128', args[0].typ.unit, args[0].typ.positional),
         pos=getpos(expr)
     )
 

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -11,7 +11,7 @@ def get_int_at(args, pos, signed=False):
         o = LOADED_LIMIT_MAP[args[pos].args[0].value]
     else:
         return None
-    if signed:
+    if signed or o < 0:
         return ((o + 2**255) % 2**256) - 2**255
     else:
         return o % 2**256

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -231,6 +231,10 @@ def get_number_as_fraction(expr, context):
         t += 1
     top = int(context_slice[:t].replace('.', ''))
     bottom = 1 if '.' not in context_slice[:t] else 10**(t - context_slice[:t].index('.') - 1)
+
+    if expr.n < 0:
+        top *= -1
+
     return context_slice[:t], top, bottom
 
 


### PR DESCRIPTION
### - What I did

Corrected the implementations of `floor` and `ceil` so that they behave correctly for negative inputs.

### - How I did it

Modified both `floor` and `ceil` to conditionally branch, and use an appropriate signed division to get the right rounding behaviour.

### - How to verify it

Read the code and run the included tests.

### - Description for the changelog

Make floor and ceil round towards negative and positive infinity respectively, rather than 0

### - Cute Animal Picture

https://www.flickr.com/photos/ekilby/4844114344
