### PR TITLE
Rename __log__ to event keyword

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -51,7 +51,7 @@ Events may be logged in specially indexed data structures that allow clients, in
 
 ::
 
-    Payment: __log__({amount: int128, arg2: indexed(address)})
+    Payment: event({amount: int128, arg2: indexed(address)})
 
     total_paid: int128
 

--- a/examples/stock/company.v.py
+++ b/examples/stock/company.v.py
@@ -1,8 +1,8 @@
 # Financial events the contract logs
-Transfer: __log__({_from: indexed(address), _to: indexed(address), _value: currency_value})
-Buy: __log__({_buyer: indexed(address), _buy_order: currency_value})
-Sell: __log__({_seller: indexed(address), _sell_order: currency_value})
-Pay: __log__({_vendor: indexed(address), _amount: wei_value})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: currency_value})
+Buy: event({_buyer: indexed(address), _buy_order: currency_value})
+Sell: event({_seller: indexed(address), _sell_order: currency_value})
+Pay: event({_vendor: indexed(address), _amount: wei_value})
 
 # Own shares of a company!
 company: public(address)

--- a/examples/tokens/ERC20.v.py
+++ b/examples/tokens/ERC20.v.py
@@ -6,8 +6,8 @@
 
 
 # Events of the token.
-Transfer: __log__({_from: indexed(address), _to: indexed(address), _value: uint256})
-Approval: __log__({_owner: indexed(address), _spender: indexed(address), _value: uint256})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
 
 # Variables of the token.

--- a/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
+++ b/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
@@ -9,8 +9,8 @@
 # language interoperability and not for production use.
 
 # Events issued by the contract
-Transfer: __log__({_from: indexed(address), _to: indexed(address), _value: uint256})
-Approval: __log__({_owner: indexed(address), _spender: indexed(address), _value: uint256})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
 balances: uint256[address]
 allowances: (uint256[address])[address]

--- a/examples/tokens/vypercoin.v.py
+++ b/examples/tokens/vypercoin.v.py
@@ -4,8 +4,8 @@
 # https://theethereum.wiki/w/index.php/ERC20_Token_Standard
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
 # Events of the token.
-Transfer: __log__({_from: indexed(address), _to: indexed(address), _value: uint256})
-Approval: __log__({_owner: indexed(address), _spender: indexed(address), _value: uint256})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
 
 # Variables of the token.

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -356,7 +356,7 @@ class Foo():
 def test_external_contracts_must_be_declared_first_2(assert_tx_failed, get_contract):
     contract = """
 
-MyLog: __log__({})
+MyLog: event({})
 
 class Foo():
     def foo(arg2: int128) -> int128: pass

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -3,7 +3,7 @@ from vyper.exceptions import VariableDeclarationException, TypeMismatchException
 
 def test_empy_event_logging(get_contract_with_gas_estimation, utils, chain):
     loggy_code = """
-MyLog: __log__({})
+MyLog: event({})
 
 @public
 def foo():
@@ -26,7 +26,7 @@ def foo():
 
 def test_event_logging_with_topics(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 3)})
+MyLog: event({arg1: indexed(bytes <= 3)})
 
 @public
 def foo():
@@ -49,7 +49,7 @@ def foo():
 
 def test_event_logging_with_multiple_topics(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address)})
+MyLog: event({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address)})
 
 @public
 def foo():
@@ -78,7 +78,7 @@ def foo():
 
 def test_logging_the_same_event_multiple_times_with_topics(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128), arg2: indexed(address)})
+MyLog: event({arg1: indexed(int128), arg2: indexed(address)})
 
 @public
 def foo():
@@ -108,7 +108,7 @@ def bar():
 
 def test_event_logging_cannot_have_more_than_three_topics(assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address), arg4: indexed(int128)})
+MyLog: event({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address), arg4: indexed(int128)})
     """
 
     assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
@@ -116,7 +116,7 @@ MyLog: __log__({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: inde
 
 def test_event_logging_with_data(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: int128})
+MyLog: event({arg1: int128})
 
 @public
 def foo():
@@ -139,7 +139,7 @@ def foo():
 
 def test_event_logging_with_units(get_contract_with_gas_estimation, chain, utils):
     code = """
-MyLog: __log__({arg1: indexed(int128(wei)), arg2: int128(wei)})
+MyLog: event({arg1: indexed(int128(wei)), arg2: int128(wei)})
 
 @public
 def foo():
@@ -150,7 +150,7 @@ def foo():
 
 def test_event_logging_with_fixed_array_data(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: int128[2], arg2: timestamp[3], arg3: int128[2][2]})
+MyLog: event({arg1: int128[2], arg2: timestamp[3], arg3: int128[2][2]})
 
 @public
 def foo():
@@ -175,7 +175,7 @@ def foo():
 
 def test_logging_with_input_bytes_1(bytes_helper, get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 4), arg2: indexed(bytes <= 29), arg3: bytes<=31})
+MyLog: event({arg1: indexed(bytes <= 4), arg2: indexed(bytes <= 29), arg3: bytes<=31})
 
 @public
 def foo(arg1: bytes <= 29, arg2: bytes <= 31):
@@ -203,7 +203,7 @@ def foo(arg1: bytes <= 29, arg2: bytes <= 31):
 
 def test_event_logging_with_bytes_input_2(t, bytes_helper, get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: bytes <= 20})
+MyLog: event({arg1: bytes <= 20})
 
 @public
 def foo(_arg1: bytes <= 20):
@@ -226,7 +226,7 @@ def foo(_arg1: bytes <= 20):
 
 def test_event_logging_with_bytes_input_3(get_contract, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: bytes <= 5})
+MyLog: event({arg1: bytes <= 5})
 
 @public
 def foo(_arg1: bytes <= 5):
@@ -249,7 +249,7 @@ def foo(_arg1: bytes <= 5):
 
 def test_event_logging_with_data_with_different_types(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: int128, arg2: bytes <= 4, arg3: bytes <= 3, arg4: address, arg5: address, arg6: timestamp})
+MyLog: event({arg1: int128, arg2: bytes <= 4, arg3: bytes <= 3, arg4: address, arg5: address, arg6: timestamp})
 
 @public
 def foo():
@@ -272,7 +272,7 @@ def foo():
 
 def test_event_logging_with_topics_and_data_1(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128), arg2: bytes <= 3})
+MyLog: event({arg1: indexed(int128), arg2: bytes <= 3})
 
 @public
 def foo():
@@ -295,8 +295,8 @@ def foo():
 
 def test_event_logging_with_multiple_logs_topics_and_data(get_contract_with_gas_estimation, chain, utils):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128), arg2: bytes <= 3})
-YourLog: __log__({arg1: indexed(address), arg2: bytes <= 5})
+MyLog: event({arg1: indexed(int128), arg2: bytes <= 3})
+YourLog: event({arg1: indexed(address), arg2: bytes <= 5})
 
 @public
 def foo():
@@ -326,7 +326,7 @@ def foo():
 
 def test_fails_when_input_is_the_wrong_type(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128)})
+MyLog: event({arg1: indexed(int128)})
 
 @public
 def foo_():
@@ -338,7 +338,7 @@ def foo_():
 
 def test_fails_when_topic_is_the_wrong_size(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 3)})
+MyLog: event({arg1: indexed(bytes <= 3)})
 
 @public
 def foo():
@@ -350,7 +350,7 @@ def foo():
 
 def test_fails_when_input_topic_is_the_wrong_size(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 3)})
+MyLog: event({arg1: indexed(bytes <= 3)})
 
 @public
 def foo(arg1: bytes <= 4):
@@ -362,7 +362,7 @@ def foo(arg1: bytes <= 4):
 
 def test_fails_when_data_is_the_wrong_size(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: bytes <= 3})
+MyLog: event({arg1: bytes <= 3})
 
 @public
 def foo():
@@ -374,7 +374,7 @@ def foo():
 
 def test_fails_when_input_data_is_the_wrong_size(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: bytes <= 3})
+MyLog: event({arg1: bytes <= 3})
 
 @public
 def foo(arg1: bytes <= 4):
@@ -386,7 +386,7 @@ def foo(arg1: bytes <= 4):
 
 def test_fails_when_topic_is_over_32_bytes(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(bytes <= 100)})
+MyLog: event({arg1: indexed(bytes <= 100)})
 
 @public
 def foo():
@@ -398,7 +398,7 @@ def foo():
 
 def test_logging_fails_with_over_three_topics(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128), arg2: indexed(int128), arg3: indexed(int128), arg4: indexed(int128)})
+MyLog: event({arg1: indexed(int128), arg2: indexed(int128), arg3: indexed(int128), arg4: indexed(int128)})
 @public
 def __init__():
     log.MyLog(1, 2, 3, 4)
@@ -409,8 +409,8 @@ def __init__():
 
 def test_logging_fails_with_duplicate_log_names(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({})
-MyLog: __log__({})
+MyLog: event({})
+MyLog: event({})
 
 @public
 def foo():
@@ -433,7 +433,7 @@ def foo():
 
 def test_logging_fails_with_topic_type_mismatch(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: indexed(int128)})
+MyLog: event({arg1: indexed(int128)})
 
 @public
 def foo():
@@ -445,7 +445,7 @@ def foo():
 
 def test_logging_fails_with_data_type_mismatch(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
-MyLog: __log__({arg1: bytes <= 3})
+MyLog: event({arg1: bytes <= 3})
 
 @public
 def foo():
@@ -458,7 +458,7 @@ def foo():
 def test_logging_fails_after_a_global_declaration(t, assert_tx_failed, get_contract_with_gas_estimation, chain):
     loggy_code = """
 age: int128
-MyLog: __log__({arg1: bytes <= 3})
+MyLog: event({arg1: bytes <= 3})
     """
     t.s = chain
     assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
@@ -470,14 +470,14 @@ def test_logging_fails_after_a_function_declaration(t, assert_tx_failed, get_con
 def foo():
     pass
 
-MyLog: __log__({arg1: bytes <= 3})
+MyLog: event({arg1: bytes <= 3})
     """
     assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
 
 
 def test_logging_fails_when_number_of_arguments_is_greater_than_declaration(t, assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
-MyLog: __log__({arg1: int128})
+MyLog: event({arg1: int128})
 
 @public
 def foo():
@@ -488,7 +488,7 @@ def foo():
 
 def test_logging_fails_when_number_of_arguments_is_less_than_declaration(assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
-MyLog: __log__({arg1: int128, arg2: int128})
+MyLog: event({arg1: int128, arg2: int128})
 
 @public
 def foo():
@@ -535,7 +535,7 @@ def ioo(inp: bytes <= 100):
 def test_variable_list_packing(t, get_last_log, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 
 @public
 def foo():
@@ -551,7 +551,7 @@ def foo():
 def test_literal_list_packing(t, get_last_log, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 
 @public
 def foo():
@@ -566,7 +566,7 @@ def foo():
 def test_storage_list_packing(t, get_last_log, bytes_helper, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 x: int128[4]
 
 @public
@@ -589,7 +589,7 @@ def set_list():
 def test_passed_list_packing(t, get_last_log, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 
 @public
 def foo(barbaric: int128[4]):
@@ -605,7 +605,7 @@ def test_variable_decimal_list_packing(t, get_last_log, get_contract_with_gas_es
     t.s = chain
 
     code = """
-Bar: __log__({_value: decimal[4]})
+Bar: event({_value: decimal[4]})
 
 @public
 def foo():
@@ -620,7 +620,7 @@ def foo():
 def test_storage_byte_packing(t, get_last_log, bytes_helper, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-MyLog: __log__({arg1: bytes <= 29})
+MyLog: event({arg1: bytes <= 29})
 x:bytes<=5
 
 @public
@@ -643,7 +643,7 @@ def setbytez():
 def test_storage_decimal_list_packing(t, get_last_log, bytes_helper, get_contract_with_gas_estimation, chain):
     t.s = chain
     code = """
-Bar: __log__({_value: decimal[4]})
+Bar: event({_value: decimal[4]})
 x: decimal[4]
 
 @public
@@ -665,14 +665,14 @@ def set_list():
 
 def test_logging_fails_when_declartation_is_too_big(assert_tx_failed, get_contract_with_gas_estimation):
     code = """
-Bar: __log__({_value: indexed(bytes <= 33)})
+Bar: event({_value: indexed(bytes <= 33)})
 """
     assert_tx_failed(lambda: get_contract_with_gas_estimation(code), VariableDeclarationException)
 
 
 def test_logging_fails_when_input_is_too_big(assert_tx_failed, get_contract_with_gas_estimation):
     code = """
-Bar: __log__({_value: indexed(bytes <= 32)})
+Bar: event({_value: indexed(bytes <= 32)})
 
 @public
 def foo(inp: bytes <= 33):

--- a/tests/parser/features/test_logging_bytes_extended.py
+++ b/tests/parser/features/test_logging_bytes_extended.py
@@ -2,7 +2,7 @@
 
 def test_bytes_logging_extended(t, get_contract_with_gas_estimation, get_logs, chain):
     code = """
-MyLog: __log__({arg1: int128, arg2: bytes <= 64, arg3: int128})
+MyLog: event({arg1: int128, arg2: bytes <= 64, arg3: int128})
 
 @public
 def foo():
@@ -20,7 +20,7 @@ def foo():
 
 def test_bytes_logging_extended_variables(t, get_contract_with_gas_estimation, get_logs, chain):
     code = """
-MyLog: __log__({arg1: bytes <= 64, arg2: bytes <= 64, arg3: bytes <= 64})
+MyLog: event({arg1: bytes <= 64, arg2: bytes <= 64, arg3: bytes <= 64})
 
 @public
 def foo():
@@ -41,7 +41,7 @@ def foo():
 
 def test_bytes_logging_extended_passthrough(t, get_contract_with_gas_estimation, get_logs, chain):
     code = """
-MyLog: __log__({arg1: int128, arg2: bytes <= 64, arg3: int128})
+MyLog: event({arg1: int128, arg2: bytes <= 64, arg3: int128})
 
 @public
 def foo(a: int128, b: bytes <= 64, c: int128):
@@ -59,7 +59,7 @@ def foo(a: int128, b: bytes <= 64, c: int128):
 
 def test_bytes_logging_extended_storage(t, get_contract_with_gas_estimation, get_logs, chain):
     code = """
-MyLog: __log__({arg1: int128, arg2: bytes <= 64, arg3: int128})
+MyLog: event({arg1: int128, arg2: bytes <= 64, arg3: int128})
 a: int128
 b: bytes <= 64
 c: int128
@@ -94,7 +94,7 @@ def set(x: int128, y: bytes <= 64, z: int128):
 
 def test_bytes_logging_extended_mixed_with_lists(t, get_contract_with_gas_estimation, get_logs, chain):
     code = """
-MyLog: __log__({
+MyLog: event({
     arg1: int128[2][2],
     arg2: bytes <= 64,
     arg3: int128,

--- a/tests/parser/syntax/test_logging.py
+++ b/tests/parser/syntax/test_logging.py
@@ -7,7 +7,7 @@ from vyper.exceptions import TypeMismatchException
 
 fail_list = [
     """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 x: decimal[4]
 
 @public
@@ -15,7 +15,7 @@ def foo():
     log.Bar(self.x)
     """,
     """
-Bar: __log__({_value: int128[4]})
+Bar: event({_value: int128[4]})
 
 @public
 def foo():

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -200,7 +200,7 @@ def add_contract(code):
 def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item):
     if item.value is not None:
         raise StructureException('May not assign value whilst defining type', item)
-    elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__":
+    elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "event":
         if _globals or len(_defs):
             raise StructureException("Events must all come before global declarations and function definitions", item)
         _events.append(item)


### PR DESCRIPTION
# - What I did
Changed the `__log__` keyword to `event` as described in issue #695.
Changed the examples and tests to comply with the new keyword.
Updated the docs in accordance to the new keyword.

### - How I did it
Changed this: `elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__":`
to this: `elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "event":`
Changed the tests and ensured they successfully pass.

### - How to verify it
Try the tests.
Try to compile this: `MyLog: __log__({})` to make sure if fails to compile.
Try to compile this: `MyLog: event({})` to make sure it compiles successfully.

### - Description for the changelog
Rename __log__ to event keyword

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/37563426-049bb274-2a89-11e8-8689-88ba99828945.png)

(p.s. not sure if this issue #695 was agreed to be implemented so if not please let me know, personally I support this change as it is more readable and fits better with the current Solidity standard.)