### PR TITLE
Updated changelog with the __log__ to event change

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2018.03.20**: Renaming ``__log__`` to ``event``.
 * **2018.02.22**: Renaming num to int128, and num256 to uint256.
 * **2018.02.13**: Ban functions with payable and constant decorators.
 * **2018.02.12**: Division by num returns decimal type.


### PR DESCRIPTION
Added * **2018.03.20**: Renaming ``__log__`` to ``event`` to the Compatibility-breaking Changelog in the docs.
As requested for issue #704.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/37642577-4ceb3e20-2c26-11e8-8b4f-edba9327d793.png)