### PR TITLE
Fix assignment checks

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -5,7 +5,7 @@ def test_basic_for_in_list(get_contract_with_gas_estimation):
     code = """
 @public
 def data() -> int128:
-    s: int128[5] = [1, 2, 3, 4, 5, 6]
+    s: int128[5] = [1, 2, 3, 4, 5]
     for i in s:
         if i >= 3:
             return i

--- a/tests/parser/syntax/test_ann_assign.py
+++ b/tests/parser/syntax/test_ann_assign.py
@@ -47,7 +47,24 @@ def do_stuff() -> bool:
 @public
 def test():
     a: bool = False or self.do_stuff()
-    """, StructureException)
+    """, StructureException),
+    ("""
+@public
+def data() -> int128:
+    s: int128[5] = [1, 2, 3, 4, 5, 6]
+    """, TypeMismatchException),
+    ("""
+@public
+def foo() -> int128:
+    struct: {a: int128, b: decimal} = {a: 1.2, b: 1}
+    return struct.a
+    """, TypeMismatchException),
+    ("""
+@public
+def foo() -> int128:
+    struct: {a: int128, b: decimal} = {b: 1.2, c: 1, d: 33, e: 55}
+    return struct.a
+    """, TypeMismatchException)
 ]
 
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -100,7 +100,7 @@ class Stmt(object):
         if self.stmt.value is not None:
             sub = Expr(self.stmt.value, self.context).lll_node
             self._check_valid_assign(sub)
-            variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(self.stmt))
+            variable_loc = LLLnode.from_list(pos, typ=typ, location='memory', pos=getpos(self.stmt))
             o = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
         self.context.set_in_assignment(False)
         return o


### PR DESCRIPTION
### - What I did
Fixes #703 .

-  Structs and lists where not properly type-checked on assignment.

### - How I did it
Turns out the variable location the was allocated always assumed the the type of the right hand side. Instead of using the information from the stmt.annotation. So simple fix, added necessary fail tests so we can pick this up again.

### - How to verify it
Check tests.

### - Description for the changelog
N/A

### - Cute Animal Picture

![094f3793044be99fbe20c769e36a23de](https://user-images.githubusercontent.com/6917456/37714354-05da33a4-2d22-11e8-954e-f26d4f61ef96.jpg)

