### PR TITLE
Added tests for ERC20 name and decimals getters

### DIFF
--- a/tests/examples/market_maker/test_on_chain_market_maker.py
+++ b/tests/examples/market_maker/test_on_chain_market_maker.py
@@ -36,6 +36,8 @@ def test_initiate(t, chain, utils, market_maker, erc20, assert_tx_failed):
     assert market_maker.total_eth_qty() == 2 * 10**18
     assert market_maker.total_token_qty() == 1 * 10**18
     assert market_maker.invariant() == 2 * 10**36
+    assert assert erc20.name().split(b'\0',1)[0].decode() == TOKEN_NAME
+    assert erc20.decimals() == TOKEN_DECIMALS
     assert utils.remove_0x_head(market_maker.owner()) == t.a0.hex()
     t.s = chain
     # Initiate cannot be called twice


### PR DESCRIPTION
Added tests for ERC20 name and decimals getters as requested in #709.

### - What I did
Added tests for ERC20 name and decimals getters in test_on_chain_market_maker as requested in #709.

### - How I did it

assert erc20.name().split(b'\0',1)[0].decode() == TOKEN_NAME
assert erc20.decimals() == TOKEN_DECIMALS

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/37729617-22724f14-2d46-11e8-853c-a73f232bf60e.png)

