### PR TITLE
Adds support deleting for nested map keys.

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -165,6 +165,18 @@ def foo() -> int128:
 q:int128 = 111
 def foo() -> int128:
     return self.q
+    """,
+    """
+b: bytes32[int128]
+@public
+def foo():
+    del self.b[0], self.b[1]
+    """,
+    """
+@public
+def foo():
+    b: int128
+    del b
     """
 ]
 

--- a/tests/parser/features/test_map_delete.py
+++ b/tests/parser/features/test_map_delete.py
@@ -1,0 +1,52 @@
+
+
+def test_map_delete(get_contract_with_gas_estimation):
+    code = """
+big_storage: bytes32[bytes32]
+
+@public
+def set(key: bytes32, value: bytes32):
+    self.big_storage[key] = value
+
+@public
+def get(key: bytes32) -> bytes32:
+    return self.big_storage[key]
+
+@public
+def delete(key: bytes32):
+    del self.big_storage[key]
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.get("test") == b'\x00' * 32
+    c.set("test", "value")
+    assert c.get("test")[:5] == b"value"
+    c.delete("test")
+    assert c.get("test") == b'\x00' * 32
+
+
+def test_map_delete_nested(get_contract_with_gas_estimation):
+    code = """
+big_storage: bytes32[bytes32][bytes32]
+
+@public
+def set(key1: bytes32, key2: bytes32, value: bytes32):
+    self.big_storage[key1][key2] = value
+
+@public
+def get(key1: bytes32, key2: bytes32) -> bytes32:
+    return self.big_storage[key1][key2]
+
+@public
+def delete(key1: bytes32, key2: bytes32):
+    del self.big_storage[key1][key2]
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.get("test1", "test2") == b'\x00' * 32
+    c.set("test1", "test2", "value")
+    assert c.get("test1", "test2")[:5] == b"value"
+    c.delete("test1", "test2")
+    assert c.get("test1", "test2") == b'\x00' * 32


### PR DESCRIPTION
### - What I did

Fixes #715.

### - How I did it

Added parse_delete to handle the specific case.

### - How to verify it

Check tests `del self.big_map["test"]` should now work.

### - Description for the changelog
Add deleting support for a map.

### - Cute Animal Picture
![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSnd4cJ22E4L8sVTzrhoMUDDL_fgMbMqITla5qUegtlC9_58uCYtw)
