### PR TITLE
Renamed signed256 to int256

### DIFF
--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -392,7 +392,7 @@ class Stmt(object):
             if not are_units_compatible(sub.typ, self.context.return_type):
                 raise TypeMismatchException("Return type units mismatch %r %r" % (sub.typ, self.context.return_type), self.stmt.value)
             elif is_base_type(sub.typ, self.context.return_type.typ) or \
-                    (is_base_type(sub.typ, 'int128') and is_base_type(self.context.return_type, 'signed256')):
+                    (is_base_type(sub.typ, 'int128') and is_base_type(self.context.return_type, 'int256')):
                 return LLLnode.from_list(['seq', ['mstore', 0, sub], ['return', 0, 32]], typ=None, pos=getpos(self.stmt))
             else:
                 raise TypeMismatchException("Unsupported type conversion: %r to %r" % (sub.typ, self.context.return_type), self.stmt.value)


### PR DESCRIPTION
Renamed signed256 to int256.

### - How I did it

Renamed signed256 to int256 in the following:
base_types
parse_return
canonicalize_type

### - Description for the changelog

Renamed signed256 to int256.

Please note: This is non-backward compatible. (Will add it to the docs changelog)

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/37909699-4f3b071c-3114-11e8-911b-80c2e80cff86.png)

