### PR TITLE
fixed #735, removed pyethereum dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+bumpversion

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,8 @@ setup(
     url='https://github.com/ethereum/vyper',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=[
-        'ethereum==2.1.3',
-        'bumpversion',
-        'pytest-cov',
-        'pytest-runner',  # Must be after pytest-cov or it will not work
-                          # due to https://github.com/pypa/setuptools/issues/196
-    ],
+    install_requires=[],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'pytest-cov', 'ethereum==2.1.3'],
     scripts=['bin/vyper', 'bin/vyper-serve']
 )

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     url='https://github.com/ethereum/vyper',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=[],
+    install_requires=['py-evm>=0.2.0a12'],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'ethereum==2.1.3'],
+    tests_require=['pytest', 'pytest-cov', 'ethereum==2.3.1'],
     scripts=['bin/vyper', 'bin/vyper-serve']
 )

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -90,6 +90,14 @@ pseudo_opcodes = {
     'NE': [None, 2, 1, 6],
 }
 
+#
+# Pre-compile contract gas costs
+#
+# Extracted from https://github.com/ethereum/py-evm/blob/master/evm/constants.py
+
+GAS_IDENTITY = 15
+GAS_IDENTITYWORD = 3
+
 comb_opcodes = {}
 for k in opcodes:
     comb_opcodes[k] = opcodes[k]

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -90,14 +90,6 @@ pseudo_opcodes = {
     'NE': [None, 2, 1, 6],
 }
 
-#
-# Pre-compile contract gas costs
-#
-# Extracted from https://github.com/ethereum/py-evm/blob/master/evm/constants.py
-
-GAS_IDENTITY = 15
-GAS_IDENTITYWORD = 3
-
 comb_opcodes = {}
 for k in opcodes:
     comb_opcodes[k] = opcodes[k]

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -1,6 +1,9 @@
 import re
+
+from evm.constants import GAS_IDENTITY, GAS_IDENTITYWORD
+
 from vyper.exceptions import TypeMismatchException
-from vyper.opcodes import comb_opcodes, GAS_IDENTITY, GAS_IDENTITYWORD
+from vyper.opcodes import comb_opcodes
 from vyper.types import (
     BaseType,
     ByteArrayType,

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -1,9 +1,6 @@
 import re
-
-from ethereum import opcodes
-
 from vyper.exceptions import TypeMismatchException
-from vyper.opcodes import comb_opcodes
+from vyper.opcodes import comb_opcodes, GAS_IDENTITY, GAS_IDENTITYWORD
 from vyper.types import (
     BaseType,
     ByteArrayType,
@@ -257,8 +254,7 @@ def make_byte_array_copier(destination, source):
         raise TypeMismatchException("Cannot cast from greater max-length %d to shorter max-length %d" % (source.typ.maxlen, destination.typ.maxlen))
     # Special case: memory to memory
     if source.location == "memory" and destination.location == "memory":
-        gas_calculation = opcodes.GIDENTITYBASE + \
-            opcodes.GIDENTITYWORD * (ceil32(source.typ.maxlen) // 32)
+        gas_calculation = GAS_IDENTITY + GAS_IDENTITYWORD * (ceil32(source.typ.maxlen) // 32)
         o = LLLnode.from_list(
             ['with', '_source', source,
                 ['with', '_sz', ['add', 32, ['mload', '_source']],


### PR DESCRIPTION
### - What I did

To address #735, 

- Removed pyethereum installation dependency
- Moved `bumpversion`, `pytest-cov`, and `pytest-runner` out of `install_requires`.

### - How I did it

Copy pasting from [py-evm constants](https://github.com/ethereum/py-evm/blob/master/evm/constants.py#L83-L84)

### - How to verify it

check if new constants in `vyper/opcodes.py` fit [py-evm constants](https://github.com/ethereum/py-evm/blob/master/evm/constants.py#L83-L84) and  [pyethereum opcodes](https://github.com/ethereum/pyethereum/blob/develop/ethereum/opcodes.py)

### - Description for the changelog

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/38161033-2f5b2032-34fa-11e8-84e1-3ad20bb4c7d8.png)

