### PR TITLE
Fix deleting a struct from a map.

### DIFF
--- a/tests/parser/features/test_map_delete.py
+++ b/tests/parser/features/test_map_delete.py
@@ -50,3 +50,36 @@ def delete(key1: bytes32, key2: bytes32):
     assert c.get("test1", "test2")[:5] == b"value"
     c.delete("test1", "test2")
     assert c.get("test1", "test2") == b'\x00' * 32
+
+
+def test_map_delete_struct(get_contract_with_gas_estimation):
+    code = """
+structmap: {
+    a: int128,
+    b: int128
+}[int128]
+
+
+@public
+def set():
+    self.structmap[123] = {
+        a: 333,
+        b: 444
+    }
+
+@public
+def get() -> (int128, int128):
+    return self.structmap[123].a, self.structmap[123].b
+
+@public
+def delete():
+    self.structmap[123] = None
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.get() == [0, 0]
+    c.set()
+    assert c.get() == [333, 444]
+    c.delete()
+    assert c.get() == [0, 0]

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -22,7 +22,8 @@ from vyper.types import (
     ByteArrayType,
     ListType,
     TupleType,
-    StructType
+    StructType,
+    NullType
 )
 from vyper.types import (
     get_size_of_type,
@@ -494,6 +495,9 @@ class Stmt(object):
             raise TypeMismatchException("Can only return base type!", self.stmt)
 
     def parse_delete(self):
+        from .parser import (
+            make_setter,
+        )
         if len(self.stmt.targets) != 1:
             raise StructureException("Can delete one variable at a time", self.stmt)
         target = self.stmt.targets[0]
@@ -501,7 +505,7 @@ class Stmt(object):
 
         if isinstance(target, ast.Subscript):
             if target_lll.location == "storage":
-                return LLLnode.from_list(['seq', ['sstore', target_lll, 0]], typ=None)
+                return make_setter(target_lll, LLLnode.from_list(None, typ=NullType()), "storage", pos=getpos(self.stmt))
 
         raise StructureException("Deleting type not supported.", self.stmt)
 


### PR DESCRIPTION
### - What I did

Fixes `del map[1]` syntax when a struct is being stored.

### - How I did it
Using Nulltype instead of hardcoded LLL fixes, by deleting all members of the struct as well.

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](http://justsomething.co/wp-content/uploads/2016/11/18-hilarious-brand-new-animal-names-that-are-so-much-better-than-the-originals-04.jpg)
