### PR TITLE
Remove true,false,null keywords.

### DIFF
--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -28,7 +28,7 @@ def __init__():
     self.value = floor(msg.value / 2) #The seller initializes the contract by
         #posting a safety deposit of 2*value of the item up for sale.
     self.seller = msg.sender
-    self.unlocked = true
+    self.unlocked = True
 
 @public
 def abort():
@@ -41,9 +41,9 @@ def abort():
 @payable
 def purchase():
     assert self.unlocked #Is the contract still open (is the item still up for sale)?
-    assert msg.value == (2*self.value) #Is the deposit the correct value?
+    assert msg.value == (2 * self.value) #Is the deposit the correct value?
     self.buyer = msg.sender
-    self.unlocked = false
+    self.unlocked = False
 
 @public
 def received():

--- a/tests/compiler/test_bytecode_runtime.py
+++ b/tests/compiler/test_bytecode_runtime.py
@@ -5,7 +5,7 @@ def test_bytecode_runtime():
     code = """
 @public
 def a() -> bool:
-    return true
+    return True
     """
 
     bytecode = compiler.compile(code)

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -9,7 +9,7 @@ fail_list = [
     """
 @public
 def foo():
-    x: bool = true
+    x: bool = True
     x = 5
     """,
     ("""
@@ -51,13 +51,13 @@ valid_list = [
     """
 @public
 def foo():
-    x: bool = true
-    z: bool = x and false
+    x: bool = True
+    z: bool = x and False
     """,
     """
 @public
 def foo():
-    x: bool = true
+    x: bool = True
     z: bool = x and False
     """,
     """

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -132,7 +132,7 @@ def test() -> int128:
     """
 @public
 def test() -> int128:
-    a = [1, 2, true]
+    a = [1, 2, True]
     return a[0]
     """
 ]

--- a/tests/parser/syntax/test_maps.py
+++ b/tests/parser/syntax/test_maps.py
@@ -172,7 +172,7 @@ mom: {a: {c: int128}[3], b: int128}
 nom: {c: int128}[3]
 @public
 def foo():
-    self.mom = {a: null, b: 5}
+    self.mom = {a: None, b: 5}
     """,
     """
 mom: {a: {c: int128}[3], b: int128}

--- a/tests/parser/syntax/test_missing_return.py
+++ b/tests/parser/syntax/test_missing_return.py
@@ -29,7 +29,7 @@ def foo() -> int128:
     """
 @public
 def foo() -> int128:
-    if false:
+    if False:
         return 123
     """,  # For the time being this is valid code, even though it should not be.
 ]

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -126,12 +126,6 @@ class Expr(object):
     def variables(self):
         if self.expr.id == 'self':
             return LLLnode.from_list(['address'], typ='address', pos=getpos(self.expr))
-        if self.expr.id == 'true':
-            return LLLnode.from_list(1, typ='bool', pos=getpos(self.expr))
-        if self.expr.id == 'false':
-            return LLLnode.from_list(0, typ='bool', pos=getpos(self.expr))
-        if self.expr.id == 'null':
-            return LLLnode.from_list(None, typ=NullType(), pos=getpos(self.expr))
         if self.expr.id in self.context.vars:
             var = self.context.vars[self.expr.id]
             return LLLnode.from_list(var.pos, typ=var.typ, location='memory', pos=getpos(self.expr), annotation=self.expr.id, mutable=var.mutable)


### PR DESCRIPTION
### - What I did
Fixes #742 .

### - How I did it
Removed them from expr.py.

### - How to verify 

try to do anything with true, false and null. :tongue: 

### - Description for the changelog

Remove lowercase true, false and null.

### - Cute Animal Picture
![](https://i.pinimg.com/originals/b4/c6/a4/b4c6a4a61ffc86016ccf5a1779ea4c7b.jpg)