### PR TITLE
Fixes #737, disallowing implicit conversion when comparing.

### DIFF
--- a/tests/parser/features/iteration/test_break.py
+++ b/tests/parser/features/iteration/test_break.py
@@ -27,7 +27,7 @@ def log(n: int128) -> int128:
     c: decimal = n * 1.0
     output: int128 = 0
     for i in range(40):
-        if c < 10:
+        if c < 10.0:
             output = i * 10
             break
         c = c / 10
@@ -55,13 +55,13 @@ def log(n: int128) -> int128:
     c: decimal = convert(n, 'decimal')
     output: int128 = 0
     for i in range(40):
-        if c < 10:
+        if c < 10.0:
             output = i * 10
             break
         c /= 10
     for i in range(10):
         c /= 1.2589
-        if c < 1:
+        if c < 1.0:
             output = output + i
             break
     return output

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -84,7 +84,7 @@ def foo() -> bool:
     """
 @public
 def foo() -> bool:
-    return 1. >= 1
+    return 2 >= 1
     """,
     """
 @public
@@ -94,7 +94,7 @@ def foo() -> bool:
     """
 @public
 def foo() -> bool:
-    return 1 <= 1.
+    return 1 <= 1
     """
 ]
 

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -32,6 +32,17 @@ def foo() -> bool:
 @public
 def foo() -> bool:
     return (1 == 2) or 3
+    """,
+    """
+@public
+def foo() -> bool:
+    return 1.0 == 1
+    """,
+    """
+@public
+def foo() -> bool:
+    a: address
+    return a == 1
     """
 ]
 


### PR DESCRIPTION
### - What I did
Fixes #737.
Prevents implicit conversion when comparing.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture

![](http://4.bp.blogspot.com/-ckoYRNOitMA/UJQBKINhnRI/AAAAAAAAaNs/OsgNR5ptdSo/s1600/cute-animal-shy-bunny.jpg)