### PR TITLE
Added alternate compilation types to docs

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -5,6 +5,10 @@ To compile a contract, use:
 ::
     vyper yourFileName.v.py
 
+You can also compile to other formats such as ABI using the below format:
+::
+    vyper -f ['abi', 'json', 'bytecode', 'bytecode_runtime', 'ir'] yourFileName.v.py
+
 .. note::
     Since .vy is not officially a language supported by any syntax highlighters or linters,
     it is recommended to name your Vyper file ending with `.vy` or optionally `.v.py` in order to have Python syntax highlighting.


### PR DESCRIPTION
This allows users to see compilation options without digging through the whole repository.

### - What I did

Added compilation options to docs. This is particularly useful to generate the ABI, though other options are also useful too.

### - How I did it

Wrote it out.

### - How to verify it

The options are listed in https://github.com/ethereum/vyper/blob/764439285d60e8c71dc691ae32f1a5101b9cb046/bin/vyper

### - Description for the changelog

Added alternate compilation types to the docs.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/35941672/38772101-0d2ed5ae-3ffd-11e8-897c-93f9973dbea7.png)



