### PR TITLE
752 custom units

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -264,6 +264,26 @@ Keyword              Unit         Base type  Description
 ``currency2_value``  1 currency2  ``int128``    This is an amount of currency2.
 ===================  ===========  =========  ====================================================================================
 
+Custom Unit Types
+=================
+
+Vyper allows you to add additional not-provided unit label to either ``int128`` or ``decimal``.
+
+**Custom units example:**
+::
+    # specify units used in the contract.
+    units: {
+        cm: "centimeter",
+        km: "kilometer"
+    }
+
+Having defined the units they can be defined on variables as follows.
+
+**Custom units usage:**
+::
+    a: int128(cm)
+    b: int128(km)
+
 .. index:: !bytes32
 32-bit-wide Byte Array
 ======================

--- a/tests/parser/syntax/test_custom_units.py
+++ b/tests/parser/syntax/test_custom_units.py
@@ -1,0 +1,92 @@
+import pytest
+from pytest import raises
+
+from vyper import compiler
+from vyper.exceptions import (
+    VariableDeclarationException,
+    InvalidTypeException
+)
+
+
+fail_list = [
+    """
+units: 1
+    """,
+    """
+units: {
+    "cm": "centimeter"
+}
+    """,
+    """
+units: {
+    "cm": 1
+}
+    """,
+    """
+units: {
+    cm: "centimeter"
+}
+units: {
+    km: "kilometer"
+}
+    """,
+    """
+units: {
+    wei: "wei"
+}
+    """,
+    """
+units: {
+    cm: 123
+}
+    """,
+    """
+units: {
+    cm: "centimeter",
+    cm: "kilometer"
+}
+    """,
+    ("""
+units: {
+    cm: "centimeter",
+}
+@public
+def test():
+    a: int128(km)
+    """, InvalidTypeException),
+    """
+units: {
+    cm: "centimeter",
+}
+@public
+def test():
+    cm: int128
+    """,
+    ("""
+units: {
+    cm: "centimeter",
+}
+a: int128(km)
+    """, InvalidTypeException),
+    """
+units: {
+    cm: "centimeter",
+}
+cm: bytes[5]
+    """,
+    """
+@public
+def test():
+    units: bytes[4]
+    """
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_custom_units_fail(bad_code):
+    if isinstance(bad_code, tuple):
+        with raises(bad_code[1]):
+            compiler.compile(bad_code[0])
+    else:
+        with raises(VariableDeclarationException):
+            compiler.compile(bad_code)

--- a/tests/parser/types/numbers/test_custom_units.py
+++ b/tests/parser/types/numbers/test_custom_units.py
@@ -1,0 +1,23 @@
+
+
+def test_custom_units(get_contract_with_gas_estimation):
+    code = """
+units: {
+    cm: "centimeter",
+    km: "kilometer"
+}
+
+# global storage
+a: int128(cm)
+
+
+@public
+def test() -> int128(km):
+    b: int128(km)
+    b = 100
+    return b
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.test() == 100

--- a/vyper/function_signature.py
+++ b/vyper/function_signature.py
@@ -64,7 +64,7 @@ class FunctionSignature():
             typ = arg.annotation
             if not typ:
                 raise InvalidTypeException("Argument must have type", arg)
-            if not is_varname_valid(arg.arg, custom_units=self.custom_units):
+            if not is_varname_valid(arg.arg, custom_units=custom_units):
                 raise VariableDeclarationException("Argument name invalid or reserved: " + arg.arg, arg)
             if arg.arg in (x.name for x in args):
                 raise VariableDeclarationException("Duplicate function argument name: " + arg.arg, arg)
@@ -111,7 +111,7 @@ class FunctionSignature():
             assert isinstance(output_type, TupleType) or canonicalize_type(output_type)
         # Get the canonical function signature
         sig = name + '(' + ','.join([
-            canonicalize_type(parse_type(arg.annotation, None, _sigs, custom_units=custom_units))
+            canonicalize_type(parse_type(arg.annotation, None, sigs, custom_units=custom_units))
             for arg in code.args.args
         ]) + ')'
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -17,7 +17,7 @@ from vyper.function_signature import (
 
 # Contains arguments, variables, etc
 class Context():
-    def __init__(self, vars=None, globals=None, sigs=None, forvars=None, return_type=None, is_constant=False, is_payable=False, origcode=''):
+    def __init__(self, vars=None, globals=None, custom_units=None, sigs=None, forvars=None, return_type=None, is_constant=False, is_payable=False, origcode=''):
         # In-memory variables, in the form (name, memory location, type)
         self.vars = vars or {}
         self.next_mem = MemoryPositions.RESERVED_MEMORY
@@ -45,6 +45,8 @@ class Context():
         self.blockscopes = set()
         # In assignment. Whether expressiong is currently evaluating an assignment expression.
         self.in_assignment = False
+        # List of custom units that have been defined.
+        self.custom_units = custom_units
 
     def set_in_assignment(self, state: bool):
         self.in_assignment = state
@@ -72,7 +74,7 @@ class Context():
 
     # Add a new variable
     def new_variable(self, name, typ):
-        if not is_varname_valid(name):
+        if not is_varname_valid(name, custom_units=self.custom_units):
             raise VariableDeclarationException("Variable name invalid or reserved: " + name)
         if name in self.vars or name in self.globals:
             raise VariableDeclarationException("Duplicate variable name: %s" % name)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -522,7 +522,7 @@ class Expr(object):
         o = {}
         members = {}
         for key, value in zip(self.expr.keys, self.expr.values):
-            if not isinstance(key, ast.Name) or not is_varname_valid(key.id):
+            if not isinstance(key, ast.Name) or not is_varname_valid(key.id, self.context.custom_units):
                 raise TypeMismatchException("Invalid member variable for struct: %r" % vars(key).get('id', key), key)
             if key.id in o:
                 raise TypeMismatchException("Member variable duplicated: " + key.id, key)

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -234,17 +234,19 @@ def add_globals_and_events(_custom_units, _contracts, _defs, _events, _getters, 
     elif item.target.id == 'units':
         if not _custom_units:
             if not isinstance(item.annotation, ast.Dict):
-                raise VariableDeclarationException("Define custom units using {}.", item.target)
+                raise VariableDeclarationException("Define custom units using units: { }.", item.target)
             for key, value in zip(item.annotation.keys, item.annotation.values):
-                if not isinstance(value, ast.Str) and value.s:
+                if not isinstance(value, ast.Str):
                     raise VariableDeclarationException("Custom unit description must be a valid string.", value)
-                if not isinstance(key, ast.Name) and key.id:
+                if not isinstance(key, ast.Name):
                     raise VariableDeclarationException("Custom unit name must be a valid string unquoted string.", key)
+                if key.id in _custom_units:
+                    raise VariableDeclarationException("Custom unit may only be defined once", key)
                 if not is_varname_valid(key.id, custom_units=_custom_units):
                     raise VariableDeclarationException("Custom unit may not be a reserved keyword", key)
                 _custom_units.append(key.id)
         else:
-            raise VariableDeclarationException("Can only define custom units once.", item.target)
+            raise VariableDeclarationException("Can units can only defined once.", item.target)
     # Check if variable name is reserved or invalid
     elif not is_varname_valid(item.target.id, custom_units=_custom_units):
         raise VariableDeclarationException("Variable name invalid or reserved: ", item.target)
@@ -403,7 +405,7 @@ def parse_tree_to_lll(code, origcode, runtime_only=False):
     # If there is an init func...
     if initfunc:
         o.append(['seq', initializer_lll])
-        o.append(parse_func(initfunc[0], _globals, {**{'self': sigs}, **external_contracts}, origcode))
+        o.append(parse_func(initfunc[0], _globals, {**{'self': sigs}, **external_contracts}, origcode, _custom_units))
     # If there are regular functions...
     if otherfuncs:
         o = parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, _custom_units, runtime_only)

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -216,7 +216,7 @@ def get_item_name_and_attributes(item, attributes):
     return None, attributes
 
 
-def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item):
+def add_globals_and_events(_custom_units, _contracts, _defs, _events, _getters, _globals, item):
     item_attributes = {"public": False, "modifiable": False, "static": False}
     if not (isinstance(item.annotation, ast.Call) and item.annotation.func.id == "event"):
         item_name, item_attributes = get_item_name_and_attributes(item, item_attributes)
@@ -230,8 +230,23 @@ def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item)
         _events.append(item)
     elif not isinstance(item.target, ast.Name):
         raise StructureException("Can only assign type to variable in top-level statement", item)
+    # Is this a custom unit definition.
+    elif item.target.id == 'units':
+        if not _custom_units:
+            if not isinstance(item.annotation, ast.Dict):
+                raise VariableDeclarationException("Define custom units using {}.", item.target)
+            for key, value in zip(item.annotation.keys, item.annotation.values):
+                if not isinstance(value, ast.Str) and value.s:
+                    raise VariableDeclarationException("Custom unit description must be a valid string.", value)
+                if not isinstance(key, ast.Name) and key.id:
+                    raise VariableDeclarationException("Custom unit name must be a valid string unquoted string.", key)
+                if not is_varname_valid(key.id, custom_units=_custom_units):
+                    raise VariableDeclarationException("Custom unit may not be a reserved keyword", key)
+                _custom_units.append(key.id)
+        else:
+            raise VariableDeclarationException("Can only define custom units once.", item.target)
     # Check if variable name is reserved or invalid
-    elif not is_varname_valid(item.target.id):
+    elif not is_varname_valid(item.target.id, custom_units=_custom_units):
         raise VariableDeclarationException("Variable name invalid or reserved: ", item.target)
     # Check if global already exists, if so error
     elif item.target.id in _globals:
@@ -266,8 +281,12 @@ def add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item)
             _getters.append(parse_line('\n' * (item.lineno - 1) + getter))
             _getters[-1].pos = getpos(item)
     else:
-        _globals[item.target.id] = VariableRecord(item.target.id, len(_globals), parse_type(item.annotation, 'storage'), True)
-    return _contracts, _events, _globals, _getters
+        _globals[item.target.id] = VariableRecord(
+            item.target.id, len(_globals),
+            parse_type(item.annotation, 'storage', custom_units=_custom_units),
+            True
+        )
+    return _custom_units, _contracts, _events, _globals, _getters
 
 
 # Parse top-level functions and variables
@@ -277,6 +296,8 @@ def get_contracts_and_defs_and_globals(code):
     _globals = {}
     _defs = []
     _getters = []
+    _custom_units = []
+
     for item in code:
         # Contract references
         if isinstance(item, ast.ClassDef):
@@ -286,7 +307,7 @@ def get_contracts_and_defs_and_globals(code):
         # Statements of the form:
         # variable_name: type
         elif isinstance(item, ast.AnnAssign):
-            _contracts, _events, _globals, _getters = add_globals_and_events(_contracts, _defs, _events, _getters, _globals, item)
+            _custom_units, _contracts, _events, _globals, _getters = add_globals_and_events(_custom_units, _contracts, _defs, _events, _getters, _globals, item)
         # Function definitions
         elif isinstance(item, ast.FunctionDef):
             if item.name in _globals:
@@ -294,7 +315,7 @@ def get_contracts_and_defs_and_globals(code):
             _defs.append(item)
         else:
             raise StructureException("Invalid top-level statement", item)
-    return _contracts, _events, _defs + _getters, _globals
+    return _contracts, _events, _defs + _getters, _globals, _custom_units
 
 
 # Header code
@@ -312,12 +333,12 @@ def is_initializer(code):
 # Get ABI signature
 def mk_full_signature(code):
     o = []
-    _contracts, _events, _defs, _globals = get_contracts_and_defs_and_globals(code)
+    _contracts, _events, _defs, _globals, _custom_units = get_contracts_and_defs_and_globals(code)
     for code in _events:
         sig = EventSignature.from_declaration(code)
         o.append(sig.to_abi_dict())
     for code in _defs:
-        sig = FunctionSignature.from_definition(code, _contracts)
+        sig = FunctionSignature.from_definition(code, sigs=_contracts, custom_units=_custom_units)
         if not sig.private:
             o.append(sig.to_abi_dict())
     return o
@@ -343,14 +364,14 @@ def parse_external_contracts(external_contracts, _contracts):
     return external_contracts
 
 
-def parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, runtime_only=False):
+def parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, _custom_units, runtime_only=False):
     sub = ['seq', initializer_lll]
     add_gas = initializer_lll.gas
     for _def in otherfuncs:
-        sub.append(parse_func(_def, _globals, {**{'self': sigs}, **external_contracts}, origcode))  # noqa E999
+        sub.append(parse_func(_def, _globals, {**{'self': sigs}, **external_contracts}, origcode, _custom_units))  # noqa E999
         sub[-1].total_gas += add_gas
         add_gas += 30
-        sig = FunctionSignature.from_definition(_def, external_contracts)
+        sig = FunctionSignature.from_definition(_def, external_contracts, custom_units=_custom_units)
         sig.gas = sub[-1].total_gas
         sigs[sig.name] = sig
     if runtime_only:
@@ -362,7 +383,7 @@ def parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, ori
 
 # Main python parse tree => LLL method
 def parse_tree_to_lll(code, origcode, runtime_only=False):
-    _contracts, _events, _defs, _globals = get_contracts_and_defs_and_globals(code)
+    _contracts, _events, _defs, _globals, _custom_units = get_contracts_and_defs_and_globals(code)
     _names = [_def.name for _def in _defs] + [_event.target.id for _event in _events]
     # Checks for duplicate function / event names
     if len(set(_names)) < len(_names):
@@ -385,7 +406,7 @@ def parse_tree_to_lll(code, origcode, runtime_only=False):
         o.append(parse_func(initfunc[0], _globals, {**{'self': sigs}, **external_contracts}, origcode))
     # If there are regular functions...
     if otherfuncs:
-        o = parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, runtime_only)
+        o = parse_other_functions(o, otherfuncs, _globals, sigs, external_contracts, origcode, _custom_units, runtime_only)
     return LLLnode.from_list(o, typ=None)
 
 
@@ -426,17 +447,17 @@ def make_clamper(datapos, mempos, typ, is_init=False):
 
 
 # Parses a function declaration
-def parse_func(code, _globals, sigs, origcode, _vars=None):
+def parse_func(code, _globals, sigs, origcode, _custom_units, _vars=None):
     if _vars is None:
         _vars = {}
-    sig = FunctionSignature.from_definition(code, sigs)
+    sig = FunctionSignature.from_definition(code, sigs=sigs, custom_units=_custom_units)
     # Check for duplicate variables with globals
     for arg in sig.args:
         if arg.name in _globals:
             raise VariableDeclarationException("Variable name duplicated between function arguments and globals: " + arg.name)
     # Create a context
     context = Context(vars=_vars, globals=_globals, sigs=sigs,
-                      return_type=sig.output_type, is_constant=sig.const, is_payable=sig.payable, origcode=origcode)
+                      return_type=sig.output_type, is_constant=sig.const, is_payable=sig.payable, origcode=origcode, custom_units=_custom_units)
     # Copy calldata to memory for fixed-size arguments
     copy_size = sum([32 if isinstance(arg.typ, ByteArrayType) else get_size_of_type(arg.typ) * 32 for arg in sig.args])
     context.next_mem += copy_size

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -90,7 +90,7 @@ class Stmt(object):
             make_setter,
         )
         self.context.set_in_assignment(True)
-        typ = parse_type(self.stmt.annotation, location='memory')
+        typ = parse_type(self.stmt.annotation, location='memory', custom_units=self.context.custom_units)
         if isinstance(self.stmt.target, ast.Attribute) and self.stmt.target.value.id == 'self':
             raise TypeMismatchException('May not redefine storage variables.', self.stmt)
         varname = self.stmt.target.id

--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -18,7 +18,7 @@ class EventSignature():
 
     # Get a signature from an event declaration
     @classmethod
-    def from_declaration(cls, code):
+    def from_declaration(cls, code, custom_units=None):
         name = code.target.id
         pos = 0
         # Determine the arguments, expects something of the form def foo(arg1: num, arg2: num ...
@@ -48,7 +48,7 @@ class EventSignature():
                     raise VariableDeclarationException("Argument name invalid", arg)
                 if not typ:
                     raise InvalidTypeException("Argument must have type", arg)
-                if not is_varname_valid(arg):
+                if not is_varname_valid(arg, custom_units):
                     raise VariableDeclarationException("Argument name invalid or reserved: " + arg, arg)
                 if arg in (x.name for x in args):
                     raise VariableDeclarationException("Duplicate function argument name: " + arg, arg)

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -192,9 +192,9 @@ special_types = {
 
 
 # Parse an expression representing a unit
-def parse_unit(item):
+def parse_unit(item, custom_units):
     if isinstance(item, ast.Name):
-        if item.id not in valid_units:
+        if item.id not in valid_units + custom_units:
             raise InvalidTypeException("Invalid base unit", item)
         return {item.id: 1}
     elif isinstance(item, ast.Num) and item.n == 1:
@@ -202,10 +202,10 @@ def parse_unit(item):
     elif not isinstance(item, ast.BinOp):
         raise InvalidTypeException("Invalid unit expression", item)
     elif isinstance(item.op, ast.Mult):
-        left, right = parse_unit(item.left), parse_unit(item.right)
+        left, right = parse_unit(item.left, custom_units), parse_unit(item.right, custom_units)
         return combine_units(left, right)
     elif isinstance(item.op, ast.Div):
-        left, right = parse_unit(item.left), parse_unit(item.right)
+        left, right = parse_unit(item.left, custom_units), parse_unit(item.right, custom_units)
         return combine_units(left, right, div=True)
     elif isinstance(item.op, ast.Pow):
         if not isinstance(item.left, ast.Name):
@@ -219,7 +219,10 @@ def parse_unit(item):
 
 # Parses an expression representing a type. Annotation refers to whether
 # the type is to be located in memory or storage
-def parse_type(item, location, sigs={}):
+def parse_type(item, location, sigs=None, custom_units=None):
+    custom_units = [] if custom_units is None else custom_units
+    sigs = {} if sigs is None else sigs
+
     # Base types, e.g. num
     if isinstance(item, ast.Name):
         if item.id in base_types:
@@ -256,7 +259,7 @@ def parse_type(item, location, sigs={}):
         # Check for uint256 to num casting
         if item.func.id == 'int128' and getattr(item.args[0], 'id', '') == 'uint256':
             return BaseType('int128', override_signature='uint256')
-        unit = parse_unit(argz[0])
+        unit = parse_unit(argz[0], custom_units=custom_units)
         return BaseType(base_type, unit, positional)
     # Subscripts
     elif isinstance(item, ast.Subscript):

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -287,7 +287,7 @@ def parse_type(item, location, sigs=None, custom_units=None):
     elif isinstance(item, ast.Dict):
         o = {}
         for key, value in zip(item.keys, item.values):
-            if not isinstance(key, ast.Name) or not is_varname_valid(key.id):
+            if not isinstance(key, ast.Name) or not is_varname_valid(key.id, custom_units):
                 raise InvalidTypeException("Invalid member variable for struct", key)
             o[key.id] = parse_type(value, location)
         return StructType(o)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -130,11 +130,15 @@ reserved_words = ['int128', 'int256', 'uint256', 'address', 'bytes32',
                   'raise', 'init', '_init_', '___init___', '____init____',
                   'true', 'false', 'self', 'this', 'continue', 'ether',
                   'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada',
-                  'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract']
+                  'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract', 'units']
 
 
 # Is a variable or member variable name valid?
-def is_varname_valid(varname):
+def is_varname_valid(varname, custom_units):
+    if custom_units is None:
+        custom_units = []
+    if varname.lower() in [cu.lower() for cu in custom_units]:
+        return False
     if varname.lower() in base_types:
         return False
     if varname.lower() in valid_units:


### PR DESCRIPTION
### - What I did
Implements #752, custom units.

### - How I did it
Added support for units as a custom global keyword.
```python
# specify units used in the contract.
units: {
    cm: "centimeter",
    km: "kilometer"
}

# global storage
a: int128(cm)


@public
def test() -> int128(km):
    b: int128(km)
    b = 100
    return b

```
### - How to verify it
See tests and exceptions in parser.py

### - Description for the changelog

### - Cute Animal Picture
![](https://i.pinimg.com/originals/3e/7d/7d/3e7d7d124d70a0a5405ad9100e2922d4.jpg)