### PR TITLE
Update vyper-by-example.rst with minor grammar fix

### DIFF
--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -92,7 +92,7 @@ using the ``assert`` function which takes any boolean statement. We also check
 to see if the new bid is greater than the highest bid. If the two ``assert``
 statements pass, we can safely continue to the next lines; otherwise, the
 ``bid()`` method will throw an error and revert the transaction. If the two
-``assert`` statements the check that the previous bid is not equal to zero pass,
+``assert`` statements and the check that the previous bid is not equal to zero pass,
 we can safely conclude that we have a valid new highest bid. We will send back
 the previous ``highest_bid`` to the previous ``highest_bidder`` and set our new
 ``highest_bid`` and ``highest_bidder``.


### PR DESCRIPTION
### - What I did
Added the word `and` into the sentence so it's clear that both the `asserts` need to return true on Line 33 and Line 35 (https://github.com/ethereum/vyper/blob/master/examples/auctions/simple_open_auction.v.py#L33), and that the previously stored highest bid is not equal to 0 on Line 36 (https://github.com/ethereum/vyper/blob/master/examples/auctions/simple_open_auction.v.py#L36)

### - How I did it
Added the word `and` into the sentence

### - How to verify it
Check that the sentence is now more readable with the word `and`

### - Description for the changelog
N/A

### - Cute Animal Picture

 ,^^^^^^^.
|  Y o Y  |
 \TTTTT/ 