### PR TITLE
Add py.test's cache to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 dist/
 .eggs/
 
+.pytest_cache/
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
### - What I did
`.pytest_cache/` was showing up when I ran the tests

### - How I did it
so I got rid of it in the `.gitignore`

### - How to verify it
run the tests, no folder should be unrecognized in git

### - Cute Animal Picture
![baby badger](https://i2-prod.mirror.co.uk/incoming/article7430239.ece/ALTERNATES/s1200/Adorable-baby-badger-almost-freezes-to-death.jpg)
