### PR TITLE
Add support for binary literals.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url='https://github.com/ethereum/vyper',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=['py-evm>=0.2.0a12'],
+    install_requires=['py-evm==0.2.0a12'],
     setup_requires=['pytest-runner'],
     python_requires='>=3.6',
     tests_require=['pytest', 'pytest-cov', 'ethereum==2.3.1'],

--- a/vyper/functions/signature.py
+++ b/vyper/functions/signature.py
@@ -1,7 +1,7 @@
 import ast
 
 from vyper.parser.parser_utils import (
-    get_original_if_0x_prefixed,
+    get_original_if_0_prefixed,
 )
 from vyper.exceptions import (
     TypeMismatchException,
@@ -35,10 +35,10 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
     vsub = None
     for expected_arg in expected_arg_typelist:
         if expected_arg == 'num_literal':
-            if isinstance(arg, ast.Num) and get_original_if_0x_prefixed(arg, context) is None:
+            if isinstance(arg, ast.Num) and get_original_if_0_prefixed(arg, context) is None:
                 return arg.n
         elif expected_arg == 'str_literal':
-            if isinstance(arg, ast.Str) and get_original_if_0x_prefixed(arg, context) is None:
+            if isinstance(arg, ast.Str) and get_original_if_0_prefixed(arg, context) is None:
                 bytez = b''
                 for c in arg.s:
                     if ord(c) >= 256:

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -7,6 +7,7 @@ from vyper.exceptions import (
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
+    ParserException
 )
 from .parser_utils import LLLnode
 from .parser_utils import (
@@ -390,7 +391,7 @@ class Expr(object):
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.comparators[0], self.context)
 
-        if isinstance(left.typ, ByteArrayType) and  isinstance(right.typ, ByteArrayType):
+        if isinstance(left.typ, ByteArrayType) and isinstance(right.typ, ByteArrayType):
             if left.typ.maxlen != right.typ.maxlen:
                 raise TypeMismatchException('Can only compare bytes of the same length', self.expr)
             if left.typ.maxlen > 32 or right.typ.maxlen > 32:
@@ -422,9 +423,9 @@ class Expr(object):
             raise Exception("Unsupported comparison operator")
 
         # Compare (limited to 32) byte arrays.
-        if isinstance(left.typ, ByteArrayType) and  isinstance(left.typ, ByteArrayType):
+        if isinstance(left.typ, ByteArrayType) and isinstance(left.typ, ByteArrayType):
             left = Expr(self.expr.left, self.context).lll_node
-            right =  Expr(self.expr.comparators[0], self.context).lll_node
+            right = Expr(self.expr.comparators[0], self.context).lll_node
 
             def load_bytearray(side):
                 if side.location == 'memory':

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -238,15 +238,24 @@ def get_number_as_fraction(expr, context):
     return context_slice[:t], top, bottom
 
 
-# Is a number of decimal form (e.g. 65281) or 0x form (e.g. 0xff01)
-def get_original_if_0x_prefixed(expr, context):
+# Is a number of decimal form (e.g. 65281) or 0x form (e.g. 0xff01) or 0b binary form (e.g. 0b0001)
+def get_original_if_0_prefixed(expr, context):
     context_slice = context.origcode.splitlines()[expr.lineno - 1][expr.col_offset:]
-    if context_slice[:2] != '0x':
+    type_prefix = context_slice[:2]
+
+    if type_prefix not in ('0x', '0b'):
         return None
-    t = 0
-    while t + 2 < len(context_slice) and context_slice[t + 2] in '0123456789abcdefABCDEF':
-        t += 1
-    return context_slice[:t + 2]
+
+    if type_prefix == '0x':
+        t = 0
+        while t + 2 < len(context_slice) and context_slice[t + 2] in '0123456789abcdefABCDEF':
+            t += 1
+        return context_slice[:t + 2]
+    elif type_prefix == '0b':
+        t = 0
+        while t + 2 < len(context_slice) and context_slice[t + 2] in '01':
+            t += 1
+        return context_slice[:t + 2]
 
 
 # Copies byte array

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -51,6 +51,7 @@ class LLLnode():
         self.annotation = annotation
         self.mutable = mutable
         self.add_gas_estimate = add_gas_estimate
+
         # Determine this node's valency (1 if it pushes a value on the stack,
         # 0 otherwise) and checks to make sure the number and valencies of
         # children are correct. Also, find an upper bound on gas consumption


### PR DESCRIPTION
### - What I did
Fixes #732. Adds support for super cool python-like binary notation. 

### - How I did it
Most the work was done in `expr.py`.

### - How to verify it
See the tests.

### - Description for the changelog
Adds support for binary literals.

### - Cute Animal Picture

![](http://www.cutestpaw.com/wp-content/uploads/2011/11/To-infinity-and-beyond.jpeg)