### PR TITLE
cast `topics` to tuple

### DIFF
--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -552,7 +552,7 @@ def ioo(inp: bytes[100]):
     assert chain.head_state.receipts[-1].logs[0].data == b'moo'
     c.goo()
     assert chain.head_state.receipts[-1].logs[0].data == b'moo2'
-    assert chain.head_state.receipts[-1].logs[0].topics == [0x1234567812345678123456781234567812345678123456781234567812345678]
+    assert tuple(chain.head_state.receipts[-1].logs[0].topics) == (0x1234567812345678123456781234567812345678123456781234567812345678,)
     c.hoo()
     assert chain.head_state.receipts[-1].logs[0].data == b'moo3'
     c.ioo(b"moo4")


### PR DESCRIPTION
### - What I did

In a new version of rlp these `topics` becomes a tuple. This is a backwards-compatible change to support that.

### - How to verify it

Unit tests

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/130362/39863816-4e1516f0-547a-11e8-9e88-a33cd3d073b4.png)
