### PR TITLE
Update structure-of-a-contract.rst

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -56,6 +56,7 @@ Events may be logged in specially indexed data structures that allow clients, in
     total_paid: int128
 
     @public
+    @payable
     def pay():
         self.total_paid += msg.value
         log.Payment(msg.value, msg.sender)


### PR DESCRIPTION
Added payable modifier in docs example.

If there is no payable modifier, than you cannot get `msg.value` of the call.

Cute Animal Picture
![Cute Animal Picture](https://hdwallsource.com/img/2015/10/adorable-penguin-wallpaper-45690-46938-hd-wallpapers.jpg)
