### PR TITLE
Modified the requirement of py-evm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,17 @@ setup(
     url='https://github.com/ethereum/vyper',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=['py-evm==0.2.0a16'],
+    install_requires=['py-evm>=0.2.0a16,<1.0.0'],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'eth-tester==0.1.0b24'],
-    scripts=['bin/vyper', 'bin/vyper-serve', 'bin/vyper-run']
+    tests_require=[
+        'pytest',
+        'pytest-cov',
+        'eth-tester==0.1.0b24',
+        'py-evm==0.2.0a16',
+    ],
+    scripts=[
+        'bin/vyper',
+        'bin/vyper-serve',
+        'bin/vyper-run',
+    ]
 )


### PR DESCRIPTION
### - What I did
`sharding` repo has [a dependency hell of eth-tester/pyetherem/py-evm/vyper](https://github.com/ethereum/sharding/issues/86#issuecomment-388955286
). Since the only thing that Vyper "package" needs from `py-evm` is importing constants (`from evm.constants import GAS_IDENTITY, GAS_IDENTITYWORD`), the easy way to solve the problem is making Vyper package doesn't require a fixed `py-evm` version and only use fixed version for testing.

### - How I did it
Modified the requirement of `py-evm` from
```python
install_requires=['py-evm>=0.2.0a12]
```
to
```python
install_requires=['py-evm>=0.2.0a12,<1.0.0']
...
tests_require=[
    ...
    'py-evm==0.2.0a12',
],
```

### - How to verify it
CI passed.

### - Description for the changelog
Modified the requirement of py-evm

### - Cute Animal Picture
![bat](https://user-images.githubusercontent.com/9263930/40054117-513b2950-5876-11e8-9f14-dc57d0870268.jpg)

