### PR TITLE
add `brew install leveldb` requirement for OSX

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -61,9 +61,9 @@ to get Homebrew on your system.
 To install Python 3.6, follow the instructions here:
 `Installing Python 3 on Mac OS X <http://python-guide.readthedocs.io/en/latest/starting/install3/osx/>`_
 
-Also, ensure the GMP arithmetic library is installed using `brew`:
+Also, ensure the following libraries are installed using `brew`:
 ::
-    brew install gmp
+    brew install gmp leveldb
 
 Creating a virtual environment
 ==============================


### PR DESCRIPTION
Quick fix for fresh install on OSX, I had to `brew install leveldb` to get it going

![image](https://user-images.githubusercontent.com/2185159/40325698-9966f5b8-5cf1-11e8-9161-7c23a9898a5e.png)
