### PR TITLE
Changed Vypercoin int128 usage to uint256

### DIFF
--- a/examples/tokens/vypercoin.v.py
+++ b/examples/tokens/vypercoin.v.py
@@ -13,8 +13,8 @@ name: public(bytes32)
 symbol: public(bytes32)
 totalSupply: public(uint256)
 decimals: public(uint256)
-balances: int128[address]
-allowed: int128[address][address]
+balances: uint256[address]
+allowed: uint256[address][address]
 
 @public
 def __init__(_name: bytes32, _symbol: bytes32, _decimals: uint256, _initialSupply: uint256):
@@ -23,7 +23,7 @@ def __init__(_name: bytes32, _symbol: bytes32, _decimals: uint256, _initialSuppl
     self.symbol = _symbol
     self.decimals = _decimals
     self.totalSupply =_initialSupply * convert(10, 'uint256') ** _decimals
-    self.balances[msg.sender] = convert(self.totalSupply, 'int128')
+    self.balances[msg.sender] = self.totalSupply
 
 
 # What is the balance of a particular account?
@@ -31,26 +31,26 @@ def __init__(_name: bytes32, _symbol: bytes32, _decimals: uint256, _initialSuppl
 @constant
 def balanceOf(_owner: address) -> uint256:
 
-    return convert(self.balances[_owner], 'uint256')
+    return self.balances[_owner]
 
 
 # Send `_value` tokens to `_to` from your account
 @public
-def transfer(_to: address, _amount: int128(uint256)) -> bool:
+def transfer(_to: address, _amount: uint256) -> bool:
 
     assert self.balances[msg.sender] >= _amount
     assert self.balances[_to] + _amount >= self.balances[_to]
 
     self.balances[msg.sender] -= _amount  # Subtract from the sender
     self.balances[_to] += _amount  # Add the same to the recipient
-    log.Transfer(msg.sender, _to, convert(_amount, 'uint256'))  # log transfer event.
+    log.Transfer(msg.sender, _to, _amount)  # log transfer event.
 
     return True
 
 
 # Transfer allowed tokens from a specific account to another.
 @public
-def transferFrom(_from: address, _to: address, _value: int128(uint256)) -> bool:
+def transferFrom(_from: address, _to: address, _value: uint256) -> bool:
 
     assert _value <= self.allowed[_from][msg.sender]
     assert _value <= self.balances[_from]
@@ -58,7 +58,7 @@ def transferFrom(_from: address, _to: address, _value: int128(uint256)) -> bool:
     self.balances[_from] -= _value  # decrease balance of from address.
     self.allowed[_from][msg.sender] -= _value  # decrease allowance.
     self.balances[_to] += _value  # incease balance of to address.
-    log.Transfer(_from, _to, convert(_value, 'uint256'))  # log transfer event.
+    log.Transfer(_from, _to, _value)  # log transfer event.
 
     return True
 
@@ -76,10 +76,10 @@ def transferFrom(_from: address, _to: address, _value: int128(uint256)) -> bool:
 #       same spender. THOUGH The contract itself shouldn't enforce it, to allow
 #       backwards compatilibilty with contracts deployed before.
 @public
-def approve(_spender: address, _amount: int128(uint256)) -> bool:
+def approve(_spender: address, _amount: uint256) -> bool:
 
     self.allowed[msg.sender][_spender] = _amount
-    log.Approval(msg.sender, _spender, convert(_amount, 'uint256'))
+    log.Approval(msg.sender, _spender, _amount)
 
     return True
 
@@ -88,4 +88,4 @@ def approve(_spender: address, _amount: int128(uint256)) -> bool:
 @public
 def allowance(_owner: address, _spender: address) -> uint256:
 
-    return convert(self.allowed[_owner][_spender], 'uint256')
+    return self.allowed[_owner][_spender]


### PR DESCRIPTION
Changed all ``int128`` usage to ``uint256``, as now ``uint256`` has full support in Vyper.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/40589046-a55451a6-61ef-11e8-80af-bcf794c9e04f.png)

