### PR TITLE
Update ERC20 Compatible token 

### DIFF
--- a/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
+++ b/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
@@ -9,17 +9,17 @@
 # language interoperability and not for production use.
 
 # Events issued by the contract
-Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
-Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256(wei)})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256(wei)})
 
-balances: uint256[address]
-allowances: (uint256[address])[address]
-num_issued: uint256
+balances: uint256(wei)[address]
+allowances: (uint256(wei)[address])[address]
+num_issued: uint256(wei)
 
 @public
 @payable
 def deposit():
-    _value: uint256 = convert(msg.value, 'uint256')
+    _value: uint256(wei) = msg.value
     _sender: address = msg.sender
     self.balances[_sender] = self.balances[_sender] + _value
     self.num_issued = self.num_issued + _value
@@ -27,29 +27,29 @@ def deposit():
     log.Transfer(0x0000000000000000000000000000000000000000, _sender, _value)
 
 @public
-def withdraw(_value : uint256) -> bool:
+def withdraw(_value : uint256(wei)) -> bool:
     _sender: address = msg.sender
     # Make sure sufficient funds are present, op will not underflow supply
     # implicitly through overflow protection
     self.balances[_sender] = self.balances[_sender] - _value
     self.num_issued = self.num_issued - _value
-    send(_sender, as_wei_value(convert(_value, 'int128'), 'wei'))
+    send(_sender, _value)
     # Fire withdraw event as transfer to 0x0
     log.Transfer(_sender, 0x0000000000000000000000000000000000000000, _value)
     return True
 
 @public
 @constant
-def totalSupply() -> uint256:
+def totalSupply() -> uint256(wei):
     return self.num_issued
 
 @public
 @constant
-def balanceOf(_owner : address) -> uint256:
+def balanceOf(_owner : address) -> uint256(wei):
     return self.balances[_owner]
 
 @public
-def transfer(_to : address, _value : uint256) -> bool:
+def transfer(_to : address, _value : uint256(wei)) -> bool:
     _sender: address = msg.sender
     # Make sure sufficient funds are present implicitly through overflow protection
     self.balances[_sender] = self.balances[_sender] - _value
@@ -59,9 +59,9 @@ def transfer(_to : address, _value : uint256) -> bool:
     return True
 
 @public
-def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+def transferFrom(_from : address, _to : address, _value : uint256(wei)) -> bool:
     _sender: address = msg.sender
-    allowance: uint256 = self.allowances[_from][_sender]
+    allowance: uint256(wei) = self.allowances[_from][_sender]
     # Make sure sufficient funds/allowance are present implicitly through overflow protection
     self.balances[_from] = self.balances[_from] - _value
     self.balances[_to] = self.balances[_to] + _value
@@ -71,7 +71,7 @@ def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
     return True
 
 @public
-def approve(_spender : address, _value : uint256) -> bool:
+def approve(_spender : address, _value : uint256(wei)) -> bool:
     _sender: address = msg.sender
     self.allowances[_sender][_spender] = _value
     # Fire approval event
@@ -80,6 +80,6 @@ def approve(_spender : address, _value : uint256) -> bool:
 
 @public
 @constant
-def allowance(_owner : address, _spender : address) -> uint256:
+def allowance(_owner : address, _spender : address) -> uint256(wei):
     return self.allowances[_owner][_spender]
 


### PR DESCRIPTION
### - What I did

Fix an issue compiling Phil Daian's ERC20 token impl

```
vyper.exceptions.TypeMismatchException: line 22: Expecting one of ('num_literal', 'int128', 'bytes32') for argument 1 of convert
    _value: uint256 = convert(msg.value, 'uint256')
```

### - How I did it

Converted `uint256` values to type `uint256(wei)`.

### - How to verify it

**Good question!** I ran the full test suite for the project, and noticed that it did not test this token. 
I also tried running this [test file](https://github.com/ethereum/vyper/blob/patch/updateERC20/tests/examples/tokens/ERC20_solidity_compatible/run_tests.py 
), but I got an error with the rlp lib: 

```
    from rlp.utils import decode_hex, encode_hex, ascii_chr, str_to_bytes
ImportError: cannot import name 'decode_hex'
```

### - Description for the changelog

Update ERC20 Compatible token 

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/23033765/40661442-cb0c31d8-6321-11e8-8cd6-0137bbf2a946.png)
