### PR TITLE
Disallow variables with built in functions name

### DIFF
--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -75,8 +75,8 @@ def bar(inp1: bytes[50]) -> int128:
 def test_test_slice4(get_contract_with_gas_estimation, assert_tx_failed):
     test_slice4 = """
 @public
-def foo(inp: bytes[10], start: int128, len: int128) -> bytes[10]:
-    return slice(inp, start=start, len=len)
+def foo(inp: bytes[10], start: int128, _len: int128) -> bytes[10]:
+    return slice(inp, start=start, len=_len)
     """
 
     c = get_contract_with_gas_estimation(test_slice4)

--- a/tests/parser/types/test_variable_naming.py
+++ b/tests/parser/types/test_variable_naming.py
@@ -20,6 +20,6 @@ def foo(len: int128, sha3: int128) -> int128:
 
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_variable_naming_fail(bad_code):
-    
+
     with raises(VariableDeclarationException):
         compiler.compile(bad_code)

--- a/tests/parser/types/test_variable_naming.py
+++ b/tests/parser/types/test_variable_naming.py
@@ -1,0 +1,25 @@
+import pytest
+from pytest import raises
+
+from vyper import compiler
+from vyper.exceptions import VariableDeclarationException
+
+fail_list = [
+    """
+@public
+def foo(max: int128) -> int128:
+    return max
+    """,
+    """
+@public
+def foo(len: int128, sha3: int128) -> int128:
+    return len+sha3
+    """
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_variable_naming_fail(bad_code):
+    
+    with raises(VariableDeclarationException):
+        compiler.compile(bad_code)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -146,19 +146,12 @@ reserved_words = ['int128', 'int256', 'uint256', 'address', 'bytes32',
                   'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada',
                   'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract', 'units']
 
-built_in_functions = ['floor', 'ceil', 'as_unitless_number',
-                      'convert', 'slice', 'len', 'concat',
-                      'sha3', 'method_id', 'keccak256', 'ecrecover',
-                      'ecadd', 'ecmul', 'extract32', 'as_wei_value',
-                      'raw_call', 'RLPList', 'blockhash', 'bitwise_and',
-                      'bitwise_or', 'bitwise_xor', 'bitwise_not',
-                      'uint256_addmod', 'uint256_mulmod', 'shift',
-                      'create_with_code_of', 'min', 'max', 'send',
-                      'selfdestruct', 'raw_log']
-
 
 # Is a variable or member variable name valid?
 def is_varname_valid(varname, custom_units):
+    from vyper.functions import dispatch_table, stmt_dispatch_table
+    built_in_functions = [x for x in stmt_dispatch_table.keys()] + \
+      [x for x in dispatch_table.keys()]
     if custom_units is None:
         custom_units = []
     if varname.lower() in [cu.lower() for cu in custom_units]:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -146,13 +146,16 @@ reserved_words = ['int128', 'int256', 'uint256', 'address', 'bytes32',
                   'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada',
                   'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract', 'units']
 
-built_in_functions = ['floor', 'ceil','as_unitless_number','convert','slice',
-                      'len','concat','sha3','method_id','keccak256', 'ecrecover',
-                      'ecadd', 'ecmul', 'extract32', 'as_wei_value', 'raw_call',
-                      'RLPList', 'blockhash', 'bitwise_and', 'bitwise_or',
-                      'bitwise_xor', 'bitwise_not', 'uint256_addmod', 'uint256_mulmod',
-                      'shift', 'create_with_code_of', 'min', 'max', 'send', 
-                      'selfdestruct', 'raw_call', 'raw_log', 'create_with_code_of',]
+built_in_functions = ['floor', 'ceil', 'as_unitless_number',
+                      'convert', 'slice', 'len', 'concat',
+                      'sha3', 'method_id', 'keccak256', 'ecrecover',
+                      'ecadd', 'ecmul', 'extract32', 'as_wei_value',
+                      'raw_call', 'RLPList', 'blockhash', 'bitwise_and',
+                      'bitwise_or', 'bitwise_xor', 'bitwise_not',
+                      'uint256_addmod', 'uint256_mulmod', 'shift',
+                      'create_with_code_of', 'min', 'max', 'send',
+                      'selfdestruct', 'raw_log']
+
 
 # Is a variable or member variable name valid?
 def is_varname_valid(varname, custom_units):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -146,6 +146,13 @@ reserved_words = ['int128', 'int256', 'uint256', 'address', 'bytes32',
                   'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada',
                   'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract', 'units']
 
+built_in_functions = ['floor', 'ceil','as_unitless_number','convert','slice',
+                      'len','concat','sha3','method_id','keccak256', 'ecrecover',
+                      'ecadd', 'ecmul', 'extract32', 'as_wei_value', 'raw_call',
+                      'RLPList', 'blockhash', 'bitwise_and', 'bitwise_or',
+                      'bitwise_xor', 'bitwise_not', 'uint256_addmod', 'uint256_mulmod',
+                      'shift', 'create_with_code_of', 'min', 'max', 'send', 
+                      'selfdestruct', 'raw_call', 'raw_log', 'create_with_code_of',]
 
 # Is a variable or member variable name valid?
 def is_varname_valid(varname, custom_units):
@@ -160,5 +167,7 @@ def is_varname_valid(varname, custom_units):
     if varname.lower() in reserved_words:
         return False
     if varname.upper() in opcodes:
+        return False
+    if varname.lower() in built_in_functions:
         return False
     return True


### PR DESCRIPTION
Disallow variables to have the name of a built in function.

### - What I did
Didn't have the time to open an issue for that since I want it to be in the beta release.
What do you think?

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/40840321-d14f43e8-65ae-11e8-80eb-d81ee3ddd9cd.png)

