### PR TITLE
Cleanup docs - literals are not always interpreted as int128's & correct typecasting example

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -110,7 +110,7 @@ Values
 Integer values between 0 and (2\ :sup:`256`-1).
 
 .. note::
-    Integer literals are always interpreted as ``int128``. In order to assign a literal to a ``uint256`` use ``as_uint256(_literal)``.
+    Integer literals are interpreted as ``int128`` by default. In cases where ``uint256`` is more appropriate, such as assignment, the literal might be interpreted as ``uint256``. Example: ``_variable: uint256 = _literal``. In order to explicitly cast a literal to a ``uint256`` use ``convert(_literal, 'uint256')``.
 
 Operators
 ---------


### PR DESCRIPTION
### - What I did
Updated docs as a deprecated function was still being recommended. Developers should now use `convert(_literal, 'uint256')` instead of `as_uint256(_literal)`.

### - How I did it
Doc change.

### - How to verify it
Visual verification should be sufficient.

### - Description for the changelog

### - Cute Animal Picture

![baby_elephant_1024x768](https://user-images.githubusercontent.com/10276811/41057272-4cc994fe-69e4-11e8-89b8-2d7c71884ade.jpg)
