### PR TITLE
Allow conversion of uint256 to uint256

### DIFF
--- a/tests/parser/functions/test_convert_uint256.py
+++ b/tests/parser/functions/test_convert_uint256.py
@@ -26,3 +26,24 @@ def foo() -> uint256:
 
     c = get_contract_with_gas_estimation(code)
     assert c.foo() == 2 ** 256 - 1
+
+
+def test_convert_uint256_to_uint256(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> uint256:
+    return convert(convert(1, 'uint256'), 'uint256')
+
+@public
+def goo() -> uint256:
+    return convert(convert(2 ** 200, 'uint256'), 'uint256')
+
+@public
+def bar() -> uint256:
+    a: uint256 = 200
+    return convert(convert(2 ** a, 'uint256'), 'uint256')
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 1
+    assert c.goo() == 2 ** 200
+    assert c.bar() == 2 ** 200

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -37,7 +37,7 @@ def to_int128(expr, args, kwargs, context):
         return byte_array_to_num(in_node, expr, 'int128')
 
 
-@signature(('num_literal', 'int128', 'bytes32'), 'str_literal')
+@signature(('num_literal', 'int128', 'bytes32', 'uint256'), 'str_literal')
 def to_uint256(expr, args, kwargs, context):
     input = args[0]
     typ, len = get_type(input)
@@ -45,7 +45,7 @@ def to_uint256(expr, args, kwargs, context):
         if not(0 <= input <= 2**256 - 1):
             raise InvalidLiteralException("Number out of range: {}".format(input))
         return LLLnode.from_list(input, typ=BaseType('uint256'), pos=getpos(expr))
-    elif isinstance(input, LLLnode) and typ in ('int128', 'num_literal'):
+    elif isinstance(input, LLLnode) and typ in ('int128', 'num_literal', 'uint256'):
         return LLLnode.from_list(['clampge', input, 0], typ=BaseType('uint256'), pos=getpos(expr))
     elif isinstance(input, LLLnode) and typ in ('bytes32'):
         return LLLnode(value=input.value, args=input.args, typ=BaseType('uint256'), pos=getpos(expr))


### PR DESCRIPTION
Closes #881

### - What I did
Allow `uint256` to be `convert`ed into `uint256`.

### - How I did it
Added `uint256` to the list of tuple of expected arg types for `to_uint256()`.

### - How to verify it
Added tests that ensure that the issue doesn't occur at both compile time and run time.

### - Description for the changelog
`uint256`s can be `convert`ed into `uint256`.

### - Cute Animal Picture

![elephant](http://picpetz.com/wp-content/uploads/2014/11/photo-cute-baby-elephant-1069705.jpg)
