### PR TITLE
Disallow conversion of int128 to int128

### DIFF
--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -3,38 +3,29 @@ from decimal import Decimal
 
 def test_convert_to_num(get_contract_with_gas_estimation, assert_tx_failed):
     code = """
-a: int128
-b: uint256
-c: bytes32
-d: bytes[1]
-
-@public
-def int128_to_num(inp: int128) -> (int128, int128, int128):
-    self.a = inp
-    memory: int128  = convert(inp, 'int128')
-    storage: int128 = convert(self.a, 'int128')
-    literal: int128 = convert(1, 'int128')
-    return  memory, storage, literal
+a: uint256
+b: bytes32
+c: bytes[1]
 
 @public
 def uint256_to_num(inp: uint256) -> (int128, int128):
-    self.b = inp
+    self.a = inp
     memory: int128  = convert(inp, 'int128')
-    storage: int128 = convert(self.b, 'int128')
+    storage: int128 = convert(self.a, 'int128')
     return  memory, storage
 
 @public
 def bytes32_to_num() -> (int128, int128):
-    self.c = 0x0000000000000000000000000000000000000000000000000000000000000001
+    self.b = 0x0000000000000000000000000000000000000000000000000000000000000001
     literal: int128 = convert(0x0000000000000000000000000000000000000000000000000000000000000001, 'int128')
-    storage: int128 = convert(self.c, 'int128')
+    storage: int128 = convert(self.b, 'int128')
     return literal, storage
 
 @public
 def bytes_to_num() -> (int128, int128):
-    self.d = 'a'
+    self.c = 'a'
     literal: int128 = convert('a', 'int128')
-    storage: int128 = convert(self.d, 'int128')
+    storage: int128 = convert(self.c, 'int128')
     return literal, storage
 
 @public
@@ -42,7 +33,6 @@ def zero_bytes(inp: bytes[1]) -> int128:
     return convert(inp, 'int128')
 """
     c = get_contract_with_gas_estimation(code)
-    assert c.int128_to_num(1) == [1, 1, 1]
     assert c.uint256_to_num(1) == [1, 1]
     assert c.bytes32_to_num() == [1, 1]
     assert c.bytes_to_num() == [97, 97]

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -23,11 +23,11 @@ from vyper.utils import (
 )
 
 
-@signature(('int128', 'uint256', 'bytes32', 'bytes'), 'str_literal')
+@signature(('uint256', 'bytes32', 'bytes'), 'str_literal')
 def to_int128(expr, args, kwargs, context):
     in_node = args[0]
     typ, len = get_type(in_node)
-    if typ in ('int128', 'uint256', 'bytes32'):
+    if typ in ('uint256', 'bytes32'):
         if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
         return LLLnode.from_list(


### PR DESCRIPTION
### - What I did
Closes #888 

### - How I did it

### - How to verify it
`convert(1, 'int128')` should fail

### - Description for the changelog

### - Cute Animal Picture

![elephant](http://picpetz.com/wp-content/uploads/2014/11/photo-cute-baby-elephant-1069705.jpg)
