### PR TITLE
Fixed the assert documentation

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -348,7 +348,9 @@ CAUTION! This method will delete the contract from the Ethereum blockchain. All 
     """
 
 Asserts the specified condition, if the condition is equals to true the code will continue to run.
-Otherwise, the OPCODE ``REVERT`` (0xfd) will be triggered, the code will stop it's operation, the contract's state will be reverted to the state before the transaction took place and the remaining gas will be returned to the transaction's sender. 
+Otherwise, the OPCODE ``REVERT`` (0xfd) will be triggered, the code will stop it's operation, the contract's state will be reverted to the state before the transaction took place and the remaining gas will be returned to the transaction's sender.
+
+Note: To give it a more Python like syntax, the assert function can be called without parenthesis, the syntax would be ``assert your_bool_condition``. Even though both options will compile, it's recommended to use the Pythonic version without parenthesis.
 
 **raw_log**
 ---------------


### PR DESCRIPTION
Mentioned the correct way to use the assert function in the docs.

I think we should consider removing one of the assert syntaxes.
Currently, both ``assert 1 < 2`` and ``assert(1 < 2)`` will work the same. We might want to remove one of them for uniformity.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/10667901/41411924-1adc9e4c-6fe7-11e8-9067-ff6ecd4b99d4.png)
