### PR TITLE
Add test case to check non-payble function throws on sending it ether.

### DIFF
--- a/tests/parser/functions/test_send.py
+++ b/tests/parser/functions/test_send.py
@@ -12,3 +12,13 @@ def fop():
     assert_tx_failed(lambda: c.foo(transact={}))
     c.fop(transact={})
     assert_tx_failed(lambda: c.fop(transact={}))
+
+
+def test_payable_tx_fail(assert_tx_failed, get_contract, w3):
+    code = """
+@public
+def pay_me() -> bool:
+    return True
+    """
+    c = get_contract(code)
+    assert_tx_failed(lambda: c.pay_me(transact={'value': w3.toWei(0.1, 'ether')}))


### PR DESCRIPTION
### - What I did
Fixes #893.
The correct assert already existed.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](http://www.cuded.com/wp-content/uploads/2013/06/23-Bunny-Picture.jpg)