### PR TITLE
Remove auto-zero padding for binary literals.

### DIFF
--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -198,19 +198,19 @@ r: bytes[1]
 
 @public
 def get(a: bytes[1]) -> bytes[2]:
-    return concat(a, 0b0001)
+    return concat(a, 0b00000001)
 
 @public
 def getsome() -> bytes[1]:
-    return 0b1110
+    return 0b00001110
 
 @public
 def testsome(a: bytes[1]) -> bool:
-    return a == 0b1100001
+    return a == 0b01100001
 
 @public
 def testsome_storage(y: bytes[1]) -> bool:
-    self.r = 0b1100001
+    self.r = 0b01100001
     return self.r == y
     """
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -104,9 +104,8 @@ class Expr(object):
             str_val = orignum[2:]
             total_bits = len(orignum[2:])
             total_bits = total_bits if total_bits % 8 == 0 else total_bits + 8 - (total_bits % 8)  # ceil8 to get byte length.
-            if total_bits != len(orignum[2:]):  # add necessary zero padding.
-                pad_len = total_bits - len(orignum[2:])
-                str_val = pad_len * '0' + str_val
+            if len(orignum[2:]) != total_bits:  # Support only full formed bit definitions.
+                raise InvalidLiteralException("Bit notation requires a multiple of 8 bits / 1 byte. {} bit(s) are missing.".format(total_bits - len(orignum[2:])), self.expr)
             byte_len = int(total_bits / 8)
             placeholder = self.context.new_placeholder(ByteArrayType(byte_len))
             seq = []


### PR DESCRIPTION
### - What I did
- Fixes #861. 
- Forces binary literals to be multiples of 8 / without auto zero padding.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](http://www.lovethispic.com/uploaded_images/169834-Cute-Dog.jpg)
