### PR TITLE
Remove preamble. We don't use it.

### DIFF
--- a/.github/ISSUE_TEMPLATE/vip.md
+++ b/.github/ISSUE_TEMPLATE/vip.md
@@ -2,18 +2,6 @@
 name: Vyper Improvement Proposal (VIP)
 about: This is the suggested template for new VIPs.
 ---
-## Preamble
-
-    VIP: <to be assigned>
-    Title: <VIP title>
-    Author: <list of authors' names and optionally, email addresses>
-    Type: <Standard Track | Informational | Meta>
-    Status: Draft
-    Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
-    Requires (*optional): <VIP number(s)>
-    Replaces (*optional): <VIP number(s)>
-
-
 ## Simple Summary
 "If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the VIP.
 


### PR DESCRIPTION
### - What I did
Removed the preamble

### - Why I did it
We don't use the preamble for anything right now.
This style was copied from the EIPs, which auto-build a webpage mirroring the current EIPs. We don't do that right now. I don't think we really need most of what's in the preamble.

### - Cute Animal Picture
![tartan rabbit](https://i.pinimg.com/originals/f5/27/56/f5275689644e106da6de9186fe5bf8ac.jpg)