### PR TITLE
Support multiple output formats

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -39,28 +39,20 @@ def get_asm(asm_list):
     return output_string
 
 
-def format_output(code, return_format):
-    if return_format == 'abi':
-        return compiler.mk_full_signature(code)
-    elif return_format == 'json':
-        return json.dumps(compiler.mk_full_signature(code))
-    elif return_format == 'bytecode':
-        return '0x' + compiler.compile(code).hex()
-    elif return_format == 'bytecode_runtime':
-        return '0x' + compiler.compile(code, bytecode_runtime=True).hex()
-    elif return_format == 'ir':
-        return optimizer.optimize(parse_to_lll(code))
-    elif return_format == 'asm':
-        lll = optimizer.optimize(parse_to_lll(code))
-        return get_asm(compile_lll.compile_to_assembly(lll))
-
-
 if __name__ == '__main__':
+
+    output_format = {}
+    output_format['abi'] = lambda code: compiler.mk_full_signature(code)
+    output_format['json'] = lambda code: json.dumps(compiler.mk_full_signature(code))
+    output_format['bytecode'] = lambda code: '0x' + compiler.compile(code).hex()
+    output_format['bytecode_runtime'] = lambda code: '0x' + compiler.compile(code, bytecode_runtime=True).hex()
+    output_format['ir'] = lambda code: optimizer.optimize(parse_to_lll(code))
+    output_format['asm'] = lambda code: get_asm(compile_lll.compile_to_assembly(optimizer.optimize(parse_to_lll(code))))
 
     with open(args.input_file) as fh:
         code = fh.read()
         if args.show_gas_estimates:
             parser_utils.LLLnode.repr_show_gas = True
 
-        for i in args.format:
-            print(format_output(code, i))
+        for i in list(dict.fromkeys(args.format)):
+            print(output_format[i](code))

--- a/bin/vyper
+++ b/bin/vyper
@@ -13,28 +13,46 @@ sys.tracebacklimit = 0
 
 parser = argparse.ArgumentParser(description='Vyper {0} programming language for Ethereum'.format(vyper.__version__))
 parser.add_argument('input_file', help='Vyper sourcecode to compile')
-parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'bytecode_runtime', 'ir', 'asm'], default='bytecode', dest='format')
+parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'bytecode_runtime', 'ir', 'asm'], default=['bytecode'], dest='format', nargs='+')
 parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")
 
 args = parser.parse_args()
 
 
-def print_asm(asm_list):
+def get_asm(asm_list):
+    output_string = ''
     skip_newlines = 0
     for node in asm_list:
         if isinstance(node, list):
-            print_asm(node)
+            output_string += get_asm(node)
             continue
 
         is_push = isinstance(node, str) and node.startswith('PUSH')
 
-        print(str(node) + ' ', end='')
+        output_string += str(node) + ' '
         if skip_newlines:
             skip_newlines -= 1
         elif is_push:
             skip_newlines = int(node[4:]) - 1
         else:
-            print('')
+            output_string += '\n'
+    return output_string
+
+
+def format_output(code, return_format):
+    if return_format == 'abi':
+        return compiler.mk_full_signature(code)
+    elif return_format == 'json':
+        return json.dumps(compiler.mk_full_signature(code))
+    elif return_format == 'bytecode':
+        return '0x' + compiler.compile(code).hex()
+    elif return_format == 'bytecode_runtime':
+        return '0x' + compiler.compile(code, bytecode_runtime=True).hex()
+    elif return_format == 'ir':
+        return optimizer.optimize(parse_to_lll(code))
+    elif return_format == 'asm':
+        lll = optimizer.optimize(parse_to_lll(code))
+        return get_asm(compile_lll.compile_to_assembly(lll))
 
 
 if __name__ == '__main__':
@@ -44,16 +62,5 @@ if __name__ == '__main__':
         if args.show_gas_estimates:
             parser_utils.LLLnode.repr_show_gas = True
 
-        if args.format == 'abi':
-            print(compiler.mk_full_signature(code))
-        elif args.format == 'json':
-            print(json.dumps(compiler.mk_full_signature(code)))
-        elif args.format == 'bytecode':
-            print('0x' + compiler.compile(code).hex())
-        elif args.format == 'bytecode_runtime':
-            print('0x' + compiler.compile(code, bytecode_runtime=True).hex())
-        elif args.format == 'ir':
-            print(optimizer.optimize(parse_to_lll(code)))
-        elif args.format == 'asm':
-            lll = optimizer.optimize(parse_to_lll(code))
-            print_asm(compile_lll.compile_to_assembly(lll))
+        for i in args.format:
+            print(format_output(code, i))


### PR DESCRIPTION
### - What I did

Closes #948. Support multiple output formats while running `vyper filename -f`.

### - How I did it

### - How to verify it

- If the format option is skipped the existing behavior continues.
<img width="1440" alt="screen shot 2018-07-17 at 3 10 05 am" src="https://user-images.githubusercontent.com/10276811/42785134-ed49cdaa-896e-11e8-885e-cd3fe72effd6.png">

- If a single format is specified only that format is printed.
<img width="1440" alt="screen shot 2018-07-17 at 3 10 44 am" src="https://user-images.githubusercontent.com/10276811/42785163-068efc36-896f-11e8-81a9-624a70a4e7d2.png">

- If two or more formats are specified they are both printed - with a `\n` between them.
<img width="1440" alt="screen shot 2018-07-23 at 2 36 36 pm" src="https://user-images.githubusercontent.com/10276811/43067758-f5193356-8e85-11e8-86d2-86568d13c432.png">


---

Since the method `print_asm`/`get_asm` has also undergone a change I recommend testing the output asm on master and this branch. I've compared the two and the diff checker indicated that there was no difference.


### - Description for the changelog

The compiler can now print multiple formats simultaneously, use `[-f {abi,json,bytecode,bytecode_runtime,ir,asm} [{abi,json,bytecode,bytecode_runtime,ir,asm} ...]]`.

### - Cute Animal Picture

![](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fthesnoozebuttonblog.files.wordpress.com%2F2014%2F02%2Fsiblings_elephants.jpg&f=1)
