### PR TITLE
Functions returning lists inside argument tuple's

### DIFF
--- a/tests/parser/types/test_function_returns.py
+++ b/tests/parser/types/test_function_returns.py
@@ -1,0 +1,13 @@
+def test_function_return_list_in_tuple(get_contract_with_gas_estimation):
+    list_tester_code = """
+@public
+def foo() -> (uint256, uint256[2]):
+    return (0, [0, 1])
+    """
+
+    c = get_contract_with_gas_estimation(list_tester_code)
+    assert isinstance(c.foo()[1], list)
+    assert len(c.foo()[1]) == 2
+    assert c.foo()[0] == 0
+    assert c.foo()[1].sort() == [0, 1].sort()
+    print("Passed functions return as tuple")

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -534,7 +534,7 @@ class Stmt(object):
                     # list lefthand side types
                     sub_list_types = LLLnode.from_list(self.context.new_placeholder(arg.typ), typ=arg.typ, location='memory')
                     # left k & right values
-                    setter = make_setter(sub_list_types, arg, location = 'memory', pos=getpos(self.stmt))
+                    setter = make_setter(sub_list_types, arg, location='memory', pos=getpos(self.stmt))
                     # build inner list argument
                     list_arg = LLLnode.from_list(['seq', setter, ['return', sub_list_types, get_size_of_type(self.context.return_type) * 32]], typ=None, pos=getpos(self.stmt))
                     # append to tuples list args

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -530,6 +530,15 @@ class Stmt(object):
 
                 elif isinstance(arg.typ, BaseType):
                     subs.append(make_setter(variable_offset, arg, "memory", pos=getpos(self.stmt)))
+                elif isinstance(arg.typ, ListType):
+                    # list lefthand side types
+                    sub_list_types = LLLnode.from_list(self.context.new_placeholder(arg.typ), typ=arg.typ, location='memory')
+                    # left k & right values
+                    setter = make_setter(sub_list_types, arg, location = 'memory', pos=getpos(self.stmt))
+                    # build inner list argument
+                    list_arg = LLLnode.from_list(['seq', setter, ['return', sub_list_types, get_size_of_type(self.context.return_type) * 32]], typ=None, pos=getpos(self.stmt))
+                    # append to tuples list args
+                    subs.append(list_arg)
                 else:
                     raise Exception("Can't return type %s as part of tuple", type(arg.typ))
 


### PR DESCRIPTION
### - What I did
Trying to fix #955 by myself as i need support for a project of mine.  

### - How I did it
A look through how statements are built for everything else. A bit of research of the state machine instructions and LLL code. 

Added to stmt.py the check for ListType for when building the instructions of Tuple's arguments

### - How to verify it
First wrote a test to trigger the problem. 

Added as types/test_function_returns.py

### - Description for the changelog

Functions bag of values can now hold inner lists

### - Cute Animal Picture

![u4i5nl3bloa11](https://user-images.githubusercontent.com/1436105/42894039-be480f4a-8aad-11e8-9edb-e7f84e8c04c1.jpg)
