### PR TITLE
Fix formatting issue in docs

### DIFF
--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -261,10 +261,10 @@ Like other examples, we begin by initiating our variables - except this time,
 we're not calling them with the ``public`` function. Variables initiated this
 way are, by default, private.
 
-..note ::
-Unlike the existence of the function ``public()``, there is no equivalent
-``private()`` function. Variables simply default to private if initiated
-without the ``public()`` function.
+.. note::
+  Unlike the existence of the function ``public()``, there is no equivalent
+  ``private()`` function. Variables simply default to private if initiated
+  without the ``public()`` function.
 
 The ``funders`` variable is initiated as a mapping where the key is a number,
 and the value is a struct representing the contribution of each participant.


### PR DESCRIPTION
### - What I did
Changed the spacing of text in the docs to result in proper formatting when viewing them.

### - How I did it
Edited the docs/vyper-by-example.rst file in the GitHub web editor.  I previewed the output and saw if it matched other notes on the page.  It did, and when I generated HTML from the changed doc files, they were correctly formatted.

### - How to verify it
Clone my fork, generate the HTML files from the doc files, and view them.

### - Description for the changelog
Fixed issue in formatting in "Vyper By Example" doc file.

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/10967785/43357100-6fb13e3e-924a-11e8-8612-53bcaf381a44.png)
