### PR TITLE
Update contributing.rst

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -26,7 +26,7 @@ How to Suggest Improvements
 ===========================
 
 To suggest an improvement, please create a Vyper Improvement Proposal (VIP for short)
-using the `VIP Template <https://github.com/ethereum/vyper/tree/master/.github/VIP_TEMPLATE.md>`_.
+using the `VIP Template <https://github.com/ethereum/vyper/blob/master/.github/ISSUE_TEMPLATE/vip.md>`_.
 
 How to Report Issues
 ====================


### PR DESCRIPTION
fixing VIP template link

### - What I did
fixing VIP template link


### - How I did it

### - How to verify it

### - Description for the changelog
VIP Template file have been changed on the github repo, but the docs is still using the old link,
I have changed the link to point to the new file
### - Cute Animal Picture

![pexels-photo-127028](https://user-images.githubusercontent.com/15138914/43403703-11e765e4-9416-11e8-9d48-1a66b3ebf3ca.jpeg)