### PR TITLE
added version option in command line

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -11,7 +11,8 @@ from vyper import compile_lll
 
 sys.tracebacklimit = 0
 
-parser = argparse.ArgumentParser(description='Vyper {0} programming language for Ethereum'.format(vyper.__version__))
+parser = argparse.ArgumentParser(description='Vyper programming language for Ethereum')
+parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))
 parser.add_argument('input_file', help='Vyper sourcecode to compile')
 parser.add_argument('-f', help='Format to print', default='bytecode', dest='format')
 parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")

--- a/bin/vyper-lll
+++ b/bin/vyper-lll
@@ -9,7 +9,8 @@ from vyper import (
 from vyper.parser.s_expressions import parse_s_exp
 from vyper.parser.parser_utils import LLLnode
 from vyper import compile_lll
-parser = argparse.ArgumentParser(description='Vyper {0} LLL for Ethereum'.format(vyper.__version__))
+parser = argparse.ArgumentParser(description='Vyper LLL for Ethereum')
+parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))
 parser.add_argument('input_file', help='Vyper sourcecode to compile')
 parser.add_argument('-f', help='Format to print csv list of ir,opt_ir,asm,bytecode', default='bytecode', dest='format')
 parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")

--- a/bin/vyper-serve
+++ b/bin/vyper-serve
@@ -14,8 +14,9 @@ from vyper import compiler, optimizer
 
 
 parser = argparse.ArgumentParser(
-    description='Serve Vyper compiler as an HTTP Service, Vyper {0}'.format(vyper.__version__)
+    description='Serve Vyper compiler as an HTTP Service'
 )
+parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))
 parser.add_argument(
     '-b',
     help='Address to bind JSON server on, default: localhost:8000',


### PR DESCRIPTION
### - What I did
The command line vyper now can print version number with  
vyper --version
### - How I did it
https://docs.python.org/3/library/argparse.html

`parser.add_argument('--version', action='version', version='%(prog)s 2.0')`


### - How to verify it
vyper --version

I did "make test" and all tests were passed (96% coverage)
 
### - Description for the changelog
command line print version number
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/15138914/43678106-73a79218-980d-11e8-9f23-75e55ce56b18.png)

