### PR TITLE
replace num128 in docs with int128

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -232,9 +232,9 @@ Takes two elliptical curves and multiplies them together.
     :param b: start point of bytes to be extracted
     :type b: int128
     :param c: type of output
-    :type c: either bytes32, num128, or address
+    :type c: either bytes32, int128, or address
 
-    :output d: either bytes32, num128, or address
+    :output d: either bytes32, int128, or address
     """
 
 **RLPList**


### PR DESCRIPTION
### - What I did
Replaced `num128` in docs with `int128`

### - How I did it
Replaced `num128` in docs with `int128` in the description of `extract32()` function

### - Description for the changelog
Replaced `num128` in docs with `int128`

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/22876645/43882776-ed0e0a38-9beb-11e8-8b52-f35ca9749370.png)

