### PR TITLE
modified slice() function's keyword argument `length` to `len` in docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -100,7 +100,7 @@ Converts a variable's type.
 ---------
 ::
 
-  def slice(a, start=b, length=c) -> d:
+  def slice(a, start=b, len=c) -> d:
     """
     :param a: bytes to be sliced
     :type a: either bytes or bytes32


### PR DESCRIPTION
### - What I did
Modified slice() function's keyword argument `length` to `len` in docs

### - How I did it
Replaced `length` in the description of slice() function with `len`

### - Description for the changelog
Modified slice() function's keyword argument `length` to `len` in docs

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/22876645/43883446-1b69c708-9bee-11e8-9ac9-1ac80a4441fe.png)
