### PR TITLE
capitalize the first letter of boolean in docs

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -34,7 +34,7 @@ A boolean is a type to store a logical/truth value.
 
 Values
 ------
-The only possible values are the constants ``true`` and ``false``.
+The only possible values are the constants ``True`` and ``False``.
 
 Operators
 ---------


### PR DESCRIPTION
### - What I did
Capitalized the first letter of boolean in docs

### - How I did it
Replaced `true` with `True` and `false` with `False` in docs.

### - Description for the changelog
Capitalized the first letter of boolean in docs

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/22876645/43884155-515f5060-9bf0-11e8-9037-fc34809acad3.png)

