### PR TITLE
Remove duplicate description about convert() function in the document

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -81,21 +81,6 @@ The value of the input number as ``wei``, converted based on the specified unit.
     """
 Turns a ``int128``, ``uint256``, ``decimal`` with units into one without units (used for assignment and math).
 
-**convert**
------------
-::
-
-  def convert(inp, out) -> b:
-    """
-    :param inp: variable to be converted
-    :type inp: type of the variable
-    :param out: type to convert(e.g. 'int128', 'uint256', 'decimal', 'bytes32')
-    :type out: String
-
-    :output b: converted variable
-    """
-Converts a variable's type.
-
 **slice**
 ---------
 ::


### PR DESCRIPTION
### - What I did
Removed duplicate description about `convert()` function in docs.

### - How I did it
Looking at the source code

### - Description for the changelog
Removed the latter.
```
   def convert(inp, out) -> b:	
    	
    :param inp: variable to be converted	
    :type inp: type of the variable	
    :param out: type to convert(e.g. 'int128', 'uint256', 'decimal', 'bytes32')	
    :type out: String	

    :output b: converted variable	
 ```

The former still remains.
```
  def convert(a, b) -> c:
    
    :param a: value to convert
    :type a: either decimal, int128, uint256 or bytes32
    :param b: the destination type to convert to
    :type b: str_literal

    :output c: either decimal, int128, uint256 or bytes32
```

### - Cute Animal Picture

![dog-2522812_640](https://user-images.githubusercontent.com/20852667/43998682-226f0a6e-9e36-11e8-8a86-ac34a058ee8f.jpg)

