### PR TITLE
ABI formatting: change behaviour of "abi", introduce "abi_python"

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -44,8 +44,9 @@ def get_asm(asm_list):
 if __name__ == '__main__':
 
     output_format = {}
-    output_format['abi'] = lambda code: compiler.mk_full_signature(code)
-    output_format['json'] = lambda code: json.dumps(compiler.mk_full_signature(code))
+    output_format['abi_python'] = lambda code: compiler.mk_full_signature(code)
+    output_format['abi'] = lambda code: json.dumps(compiler.mk_full_signature(code))
+    output_format['json'] = output_format['abi']  # for backwards compatibility
     output_format['bytecode'] = lambda code: '0x' + compiler.compile(code).hex()
     output_format['bytecode_runtime'] = lambda code: '0x' + compiler.compile(code, bytecode_runtime=True).hex()
     output_format['ir'] = lambda code: optimizer.optimize(parse_to_lll(code))

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -7,7 +7,9 @@ To compile a contract, use:
 
 You can also compile to other formats such as ABI using the below format:
 ::
-    vyper -f ['abi', 'json', 'bytecode', 'bytecode_runtime', 'ir'] yourFileName.vy
+    vyper -f ['abi', 'abi_python', 'bytecode', 'bytecode_runtime', 'ir', 'asm'] yourFileName.vy
+
+It is also possible to use the `-f json` option, which is a legacy alias for `-f abi`.
 
 .. note::
     Since .vy is not officially a language supported by any syntax highlighters or linters,


### PR DESCRIPTION
### - What I did

Changed the ABI formatting options in the following way:

* Python formatted output (single quotes, uppercase True and False): `abi` -> `python_abi`
* standard JSON output: accept `abi` in addition to the existing `json` option (the latter is now an alias)

The rationale is in Issue https://github.com/ethereum/vyper/issues/989 - vanilla `abi` option should produce the fully standards compliant result.

### - How I did it

Searched for which lines to change using this query:

https://github.com/ethereum/vyper/search?q=json&unscoped_q=json

### - How to verify it

1. Checkout my branch and `make`.
2. Run automated tests: `make test`
3. Manually check new and old formatting options: `vyper -f [abi, python_abi, json] examples/auctions/simple_open_auction.vy`

Running automated tests:

```
(vyper-venv) Highgarden:vyper kkom$ make test
python setup.py test

(...)

---------- coverage: platform darwin, python 3.6.5-final-0 -----------
Name                                     Stmts   Miss  Cover
------------------------------------------------------------
vyper/__init__.py                            7      0   100%
vyper/compile_lll.py                       248      2    99%
vyper/compiler.py                           34      3    91%
vyper/exceptions.py                         44      0   100%
vyper/functions/__init__.py                  1      0   100%
vyper/functions/functions.py               291      5    98%
vyper/functions/signature.py                81      2    98%
vyper/opcodes.py                             7      0   100%
vyper/optimizer.py                          83     14    83%
vyper/parser/__init__.py                     0      0   100%
vyper/parser/context.py                     49      0   100%
vyper/parser/expr.py                       467     21    96%
vyper/parser/lll_node.py                   179     16    91%
vyper/parser/parser.py                     682     20    97%
vyper/parser/parser_utils.py               169     12    93%
vyper/parser/s_expressions.py               34      1    97%
vyper/parser/stmt.py                       360     14    96%
vyper/premade_contracts.py                   5      0   100%
vyper/server.py                              0      0   100%
vyper/signatures/__init__.py                 0      0   100%
vyper/signatures/event_signature.py         56      4    93%
vyper/signatures/function_signature.py     117      3    97%
vyper/types/__init__.py                      1      0   100%
vyper/types/convert.py                      50      2    96%
vyper/types/types.py                       228      6    97%
vyper/utils.py                             101      5    95%
------------------------------------------------------------
TOTAL                                     3294    130    96%
Coverage HTML written to dir htmlcov


=========================================================================================== 857 passed in 216.19 seconds ===========================================================================================
```

Manually testing the new formatting options:

```
(vyper-venv) Highgarden:vyper kkom$ vyper -f abi_python examples/auctions/simple_open_auction.vy 
[{'name': '__init__', 'outputs': [], 'inputs': [{'type': 'address', 'name': '_beneficiary'}, {'type': 'uint256', 'name': '_bidding_time'}], 'constant': False, 'payable': False, 'type': 'constructor'}, {'name': 'bid', 'outputs': [], 'inputs': [], 'constant': False, 'payable': True, 'type': 'function', 'gas': 106241}, {'name': 'end_auction', 'outputs': [], 'inputs': [], 'constant': False, 'payable': False, 'type': 'function', 'gas': 71101}, {'name': 'beneficiary', 'outputs': [{'type': 'address', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 543}, {'name': 'auction_start', 'outputs': [{'type': 'uint256', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 573}, {'name': 'auction_end', 'outputs': [{'type': 'uint256', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 603}, {'name': 'highest_bidder', 'outputs': [{'type': 'address', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 633}, {'name': 'highest_bid', 'outputs': [{'type': 'uint256', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 663}, {'name': 'ended', 'outputs': [{'type': 'bool', 'name': 'out'}], 'inputs': [], 'constant': True, 'payable': False, 'type': 'function', 'gas': 693}]
(vyper-venv) Highgarden:vyper kkom$ vyper -f abi examples/auctions/simple_open_auction.vy 
[{"name": "__init__", "outputs": [], "inputs": [{"type": "address", "name": "_beneficiary"}, {"type": "uint256", "name": "_bidding_time"}], "constant": false, "payable": false, "type": "constructor"}, {"name": "bid", "outputs": [], "inputs": [], "constant": false, "payable": true, "type": "function", "gas": 106241}, {"name": "end_auction", "outputs": [], "inputs": [], "constant": false, "payable": false, "type": "function", "gas": 71101}, {"name": "beneficiary", "outputs": [{"type": "address", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 543}, {"name": "auction_start", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 573}, {"name": "auction_end", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 603}, {"name": "highest_bidder", "outputs": [{"type": "address", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 633}, {"name": "highest_bid", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 663}, {"name": "ended", "outputs": [{"type": "bool", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 693}]
(vyper-venv) Highgarden:vyper kkom$ vyper -f json examples/auctions/simple_open_auction.vy 
[{"name": "__init__", "outputs": [], "inputs": [{"type": "address", "name": "_beneficiary"}, {"type": "uint256", "name": "_bidding_time"}], "constant": false, "payable": false, "type": "constructor"}, {"name": "bid", "outputs": [], "inputs": [], "constant": false, "payable": true, "type": "function", "gas": 106241}, {"name": "end_auction", "outputs": [], "inputs": [], "constant": false, "payable": false, "type": "function", "gas": 71101}, {"name": "beneficiary", "outputs": [{"type": "address", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 543}, {"name": "auction_start", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 573}, {"name": "auction_end", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 603}, {"name": "highest_bidder", "outputs": [{"type": "address", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 633}, {"name": "highest_bid", "outputs": [{"type": "uint256", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 663}, {"name": "ended", "outputs": [{"type": "bool", "name": "out"}], "inputs": [], "constant": true, "payable": false, "type": "function", "gas": 693}]
```

@jacqueswww - should I write any more end-to-end automated tests for it? I'll defer it to your judgement, but I'd need some pointer for a good way to do it.

### - Description for the changelog

* Change the behaviour of `-f abi` to produce valid standard JSON ABI output 
* Introduce `-f abi_python` option for Python-formatted ABI output

### - Cute Animal Picture

![octopus](https://user-images.githubusercontent.com/5056119/44142231-8aadd072-a077-11e8-9506-9f6fe45ea89a.jpg)