### PR TITLE
Add ERC721 example

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -9,7 +9,7 @@ contract NFTReceiver:
             _from: address,
             _tokenId: uint256,
             _data: bytes[1024]
-        ) -> bytes[4]: constant
+        ) -> bytes32: constant
 
 
 # @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
@@ -153,6 +153,7 @@ def transferFrom(_from: address, _to: address, _tokenId: uint256):
 #         the zero address. Throws if `_tokenId` is not a valid NFT. When transfer is complete, this
 #         function checks if `_to` is a smart contract (code size > 0). If so, it calls `onERC721Received`
 #         on `_to` and throws if the return value is not `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`.
+#         NOTE: bytes4 is represented by bytes32 with padding
 # @param _from The current owner of the NFT.
 # @param _to The new owner.
 # @param _tokenId The NFT to transfer.
@@ -168,8 +169,8 @@ def safeTransferFrom(
     self._doTransfer(_from, _to, _tokenId)
     _operator: address = ZERO_ADDRESS
     if(_to.codesize > 0):
-        returnValue: bytes[4] = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
-        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", bytes[4])
+        returnValue: bytes32 = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
+        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", bytes32)
   
 
 # @dev Set or reaffirm the approved address for an NFT.

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -9,7 +9,7 @@ contract NFTReceiver:
             _from: address,
             _tokenId: uint256,
             _data: bytes[1024]
-        ) -> bytes32: constant
+        ) -> bytes[4]: constant
 
 
 # @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
@@ -168,8 +168,8 @@ def safeTransferFrom(
     self._doTransfer(_from, _to, _tokenId)
     _operator: address = ZERO_ADDRESS
     if(_to.codesize > 0):
-        returnValue: bytes32 = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
-        assert returnValue == 0xf0b9e5ba00000000000000000000000000000000000000000000000000000000
+        returnValue: bytes[4] = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
+        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", bytes[4])
   
 
 # @dev Set or reaffirm the approved address for an NFT.

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -1,0 +1,224 @@
+# @dev Implementation of ERC-721 non-fungible token standard.
+# @author Jon Mardlin (@maurelian)
+# @author Bryant Eisenbach (@fubuloubu, editor)
+
+# Interface for the contract called by safeTransferFrom()
+contract NFTReceiver:
+    def onERC721Received(
+            _operator: address,
+            _from: address,
+            _tokenId: uint256,
+            _data: bytes[1024]
+        ) -> bytes32: constant
+
+
+# @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
+#      created (`from` == 0) and destroyed (`to` == 0). Exception: during contract creation, any
+#      number of NFTs may be created and assigned without emitting Transfer. At the time of any
+#      transfer, the approved address for that NFT (if any) is reset to none.
+# @param _from Sender of NFT (if address is zero address it indicates token creation).
+# @param _to Receiver of NFT (if address is zero address it indicates token destruction).
+# @param _tokenId The NFT that got transfered.
+Transfer: event({
+        _from: indexed(address),
+        _to: indexed(address),
+        _tokenId:indexed(uint256)
+    })
+
+# @dev This emits when the approved address for an NFT is changed or reaffirmed. The zero
+#      address indicates there is no approved address. When a Transfer event emits, this also
+#      indicates that the approved address for that NFT (if any) is reset to none.
+# @param _owner Owner of NFT.
+# @param _approved Address that we are approving.
+# @param _tokenId NFT which we are approving.
+Approval: event({
+        _owner: indexed(address),
+        _approved: indexed(address),
+        _tokenId:indexed(uint256)
+    })
+
+# @dev This emits when an operator is enabled or disabled for an owner. The operator can manage
+#      all NFTs of the owner.
+# @param _owner Owner of NFT.
+# @param _operator Address to which we are setting operator rights.
+# @param _approved Status of operator rights(true if operator rights are given and false if
+# revoked).
+ApprovalForAll: event({
+        _owner: indexed(address),
+        _operator: indexed(address),
+        _approved: bool
+    })
+
+
+# @dev Mapping from NFT ID to the address that owns it.
+idToOwner: address[uint256]
+
+# @dev Mapping from NFT ID to approved address.
+idToApprovals: address[uint256]
+
+# @dev Mapping from owner address to count of his tokens.
+ownerToNFTokenCount: uint256[address]
+
+# @dev Mapping from owner address to mapping of operator addresses.
+ownerToOperators: (bool[address])[address]
+
+
+# @dev Contract constructor. Per the Transfer event spec; during contract creation, any number of 
+#      NFTs may be created and assigned without emitting Transfer.
+@public
+def __init__(_recipients: address[64], _tokenIds: uint256[64]):
+    for i in range(64):
+        self.idToOwner[_tokenIds[i]] = _recipients[i]
+        self.ownerToNFTokenCount[_recipients[i]] += 1
+
+
+# @dev Returns the number of NFTs owned by `_owner`. NFTs assigned to the zero address are
+#      considered invalid, and this function throws for queries about the zero address.
+# @param _owner Address for whom to query the balance.
+@public
+@constant
+def balanceOf(_owner: address) -> uint256:
+    assert _owner != 0x0000000000000000000000000000000000000000
+    return self.ownerToNFTokenCount[_owner]
+
+
+# @dev Returns the address of the owner of the NFT. NFTs assigned to zero address are considered
+#      invalid, and queries about them do throw. 
+# @param _tokenId The identifier for an NFT.
+@public
+@constant
+def ownerOf(_tokenId: uint256) -> address:
+    assert self.idToOwner[_tokenId] != 0x0000000000000000000000000000000000000000
+    return self.idToOwner[_tokenId]
+
+
+### TRANSFER FUNCTION HELPERS ###
+
+# NOTE: as VYPER uses a new message call for a function call, I needed to pass `_sender: address` 
+#       rather than use msg.sender
+# @dev Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+#      address for this NFT. 
+# Throws if `_from` is not the current owner. 
+# Throws if `_to` is the zero address. 
+# Throws if `_tokenId` is not a valid NFT.
+@private
+def _validateTransferFrom(_from: address, _to: address, _tokenId: uint256, _sender: address):
+    # Check that _to and _from are valid addresses
+    assert _from != 0x0000000000000000000000000000000000000000
+    assert _to != 0x0000000000000000000000000000000000000000
+    # Throws if `_from` is not the current owner
+    assert self.idToOwner[_tokenId] == _from
+    # Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+    # address for this NFT. 
+    senderIsOwner: bool = self.idToOwner[_tokenId] == _sender 
+    senderIsApproved: bool = self.idToApprovals[_tokenId] == _sender
+    senderIsOperator: bool = (self.ownerToOperators[_from])[_sender]
+    assert (senderIsOwner or senderIsApproved) or senderIsOperator
+
+
+@private
+def _doTransfer(_from: address, _to: address, _tokenId: uint256):
+    # Change the owner
+    self.idToOwner[_tokenId] = _to
+    # Reset approvals
+    self.idToApprovals[_tokenId] = 0x0000000000000000000000000000000000000000
+    # Change count tracking
+    self.ownerToNFTokenCount[_to] += 1
+    self.ownerToNFTokenCount[_from] -= 1
+    # Log the transfer
+    log.Transfer(_from, _to, _tokenId)
+
+
+### TRANSFER FUNCTIONS ###
+
+# @dev Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+#      address for this NFT. 
+#      Throws if `_from` is not the current owner. 
+#      Throws if `_to` is the zero address. 
+#      Throws if `_tokenId` is not a valid NFT.
+# @notice The caller is responsible to confirm that `_to` is capable of receiving NFTs or else
+#         they maybe be permanently lost.
+# @param _from The current owner of the NFT.
+# @param _to The new owner.
+# @param _tokenId The NFT to transfer.
+@public
+def transferFrom(_from: address, _to: address, _tokenId: uint256):
+    self._validateTransferFrom(_from, _to, _tokenId, msg.sender)
+    self._doTransfer(_from, _to, _tokenId)  
+
+
+# @dev Transfers the ownership of an NFT from one address to another address.
+# @notice Throws unless `msg.sender` is the current owner, an authorized operator, or the
+#         approved address for this NFT. Throws if `_from` is not the current owner. Throws if `_to` is
+#         the zero address. Throws if `_tokenId` is not a valid NFT. When transfer is complete, this
+#         function checks if `_to` is a smart contract (code size > 0). If so, it calls `onERC721Received`
+#         on `_to` and throws if the return value is not `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`.
+# @param _from The current owner of the NFT.
+# @param _to The new owner.
+# @param _tokenId The NFT to transfer.
+# @param _data Additional data with no specified format, sent in call to `_to`.
+@public
+def safeTransferFrom(
+        _from: address,
+        _to: address,
+        _tokenId: uint256,
+        _data: bytes[1024]=b""
+    ):
+    self._validateTransferFrom(_from, _to, _tokenId, msg.sender)
+    self._doTransfer(_from, _to, _tokenId)
+    _operator: address = 0x0000000000000000000000000000000000000000
+    if(_to.codesize > 0):
+        returnValue: bytes32 = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
+        assert returnValue == 0xf0b9e5ba00000000000000000000000000000000000000000000000000000000
+  
+
+# @dev Set or reaffirm the approved address for an NFT.
+# @notice The zero address indicates there is no approved address. Throws unless `msg.sender` is
+#         the current NFT owner, or an authorized operator of the current owner.
+# @param _approved Address to be approved for the given NFT ID.
+# @param _tokenId ID of the token to be approved.
+@public
+def approve(_approved: address, _tokenId: uint256):
+    # get owner
+    owner: address = self.idToApprovals[_tokenId]
+    # check requirements
+    senderIsOwner: bool = self.idToOwner[_tokenId] == msg.sender
+    senderIsOperator: bool = (self.ownerToOperators[owner])[msg.sender]
+    assert (senderIsOwner or senderIsOperator)
+    # set the approval
+    self.idToApprovals[_tokenId] = _approved
+    log.Approval(owner, _approved, _tokenId)
+
+
+# @dev Enables or disables approval for a third party ("operator") to manage all of
+#      `msg.sender`'s assets. It also emits the ApprovalForAll event.
+# @notice This works even if sender doesn't own any tokens at the time.
+# @param _operator Address to add to the set of authorized operators.
+# @param _approved True if the operators is approved, false to revoke approval.
+@public
+def setApprovalForAll(_operator: address, _approved: bool):
+    assert _operator != 0x0000000000000000000000000000000000000000
+    self.ownerToOperators[msg.sender][_operator] = _approved
+    log.ApprovalForAll(msg.sender, _operator, _approved)
+
+
+# @dev Get the approved address for a single NFT.
+# @notice Throws if `_tokenId` is not a valid NFT.
+# @param _tokenId ID of the NFT to query the approval of.
+@public
+@constant
+def getApproved(_tokenId: uint256) -> address:
+    assert self.idToOwner[_tokenId] != 0x0000000000000000000000000000000000000000
+    return self.idToApprovals[_tokenId]
+
+
+# @dev Checks if `_operator` is an approved operator for `_owner`.
+# @param _owner The address that owns the NFTs.
+# @param _operator The address that acts on behalf of the owner.
+@public 
+@constant
+def isApprovedForAll( _owner: address, _operator: address) -> bool:
+    # TODO: check original for _owner == 0x0
+    if (_owner == 0x0000000000000000000000000000000000000000):
+        return False
+    return (self.ownerToOperators[_owner])[_operator]

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -78,7 +78,7 @@ def __init__(_recipients: address[64], _tokenIds: uint256[64]):
 @public
 @constant
 def balanceOf(_owner: address) -> uint256:
-    assert _owner != 0x0000000000000000000000000000000000000000
+    assert _owner != ZERO_ADDRESS
     return self.ownerToNFTokenCount[_owner]
 
 
@@ -88,7 +88,7 @@ def balanceOf(_owner: address) -> uint256:
 @public
 @constant
 def ownerOf(_tokenId: uint256) -> address:
-    assert self.idToOwner[_tokenId] != 0x0000000000000000000000000000000000000000
+    assert self.idToOwner[_tokenId] != ZERO_ADDRESS
     return self.idToOwner[_tokenId]
 
 
@@ -104,8 +104,8 @@ def ownerOf(_tokenId: uint256) -> address:
 @private
 def _validateTransferFrom(_from: address, _to: address, _tokenId: uint256, _sender: address):
     # Check that _to and _from are valid addresses
-    assert _from != 0x0000000000000000000000000000000000000000
-    assert _to != 0x0000000000000000000000000000000000000000
+    assert _from != ZERO_ADDRESS
+    assert _to != ZERO_ADDRESS
     # Throws if `_from` is not the current owner
     assert self.idToOwner[_tokenId] == _from
     # Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
@@ -121,7 +121,7 @@ def _doTransfer(_from: address, _to: address, _tokenId: uint256):
     # Change the owner
     self.idToOwner[_tokenId] = _to
     # Reset approvals
-    self.idToApprovals[_tokenId] = 0x0000000000000000000000000000000000000000
+    self.idToApprovals[_tokenId] = ZERO_ADDRESS
     # Change count tracking
     self.ownerToNFTokenCount[_to] += 1
     self.ownerToNFTokenCount[_from] -= 1
@@ -166,7 +166,7 @@ def safeTransferFrom(
     ):
     self._validateTransferFrom(_from, _to, _tokenId, msg.sender)
     self._doTransfer(_from, _to, _tokenId)
-    _operator: address = 0x0000000000000000000000000000000000000000
+    _operator: address = ZERO_ADDRESS
     if(_to.codesize > 0):
         returnValue: bytes32 = NFTReceiver(_to).onERC721Received(_operator, _from, _tokenId, _data)
         assert returnValue == 0xf0b9e5ba00000000000000000000000000000000000000000000000000000000
@@ -197,7 +197,7 @@ def approve(_approved: address, _tokenId: uint256):
 # @param _approved True if the operators is approved, false to revoke approval.
 @public
 def setApprovalForAll(_operator: address, _approved: bool):
-    assert _operator != 0x0000000000000000000000000000000000000000
+    assert _operator != ZERO_ADDRESS
     self.ownerToOperators[msg.sender][_operator] = _approved
     log.ApprovalForAll(msg.sender, _operator, _approved)
 
@@ -208,7 +208,7 @@ def setApprovalForAll(_operator: address, _approved: bool):
 @public
 @constant
 def getApproved(_tokenId: uint256) -> address:
-    assert self.idToOwner[_tokenId] != 0x0000000000000000000000000000000000000000
+    assert self.idToOwner[_tokenId] != ZERO_ADDRESS
     return self.idToApprovals[_tokenId]
 
 
@@ -219,6 +219,6 @@ def getApproved(_tokenId: uint256) -> address:
 @constant
 def isApprovedForAll( _owner: address, _operator: address) -> bool:
     # TODO: check original for _owner == 0x0
-    if (_owner == 0x0000000000000000000000000000000000000000):
+    if (_owner == ZERO_ADDRESS):
         return False
     return (self.ownerToOperators[_owner])[_operator]

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -162,7 +162,7 @@ def safeTransferFrom(
         _from: address,
         _to: address,
         _tokenId: uint256,
-        _data: bytes[1024]=b""
+        _data: bytes[1024]=""
     ):
     self._validateTransferFrom(_from, _to, _tokenId, msg.sender)
     self._doTransfer(_from, _to, _tokenId)

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -123,7 +123,7 @@ def onERC721Received(
         _from: address,
         _tokenId: uint256,
         _data: bytes[1024]
-    ) -> bytes[4]:
-    return method_id("onERC721Received(address,address,uint256,bytes)", bytes[4])
+    ) -> bytes32:
+    return method_id("onERC721Received(address,address,uint256,bytes)", bytes32)
     """)
     c.safeTransferFrom(a0, receiver.address, IDS[0], transact={'from': a0})

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -1,7 +1,5 @@
 import pytest
 
-from web3.exceptions import ValidationError
-
 
 IDS = range(1, 65)
 
@@ -49,21 +47,21 @@ def test_approve(w3, c, assert_tx_failed):
     a0, a1, a2 = w3.eth.accounts[:3]
     # Approval can be given and taken away
     assert c.getApproved(IDS[0]) != a1
-    c.approve(a1, IDS[0], transact={'from':a0})
+    c.approve(a1, IDS[0], transact={'from': a0})
     assert c.getApproved(IDS[0]) == a1
-    c.approve(a2, IDS[0], transact={'from':a0})
+    c.approve(a2, IDS[0], transact={'from': a0})
     assert c.getApproved(IDS[0]) != a1
     # Can't approve something you don't own
-    assert_tx_failed(lambda: c.approve(a1, IDS[1], transact={'from':a0}))
+    assert_tx_failed(lambda: c.approve(a1, IDS[1], transact={'from': a0}))
 
 
 def test_approveAll(w3, c):
     a0, a1 = w3.eth.accounts[:2]
 
     assert not c.isApprovedForAll(a0, a1)
-    c.setApprovalForAll(a1, True, transact={'from':a0})
+    c.setApprovalForAll(a1, True, transact={'from': a0})
     assert c.isApprovedForAll(a0, a1)
-    c.setApprovalForAll(a1, False, transact={'from':a0})
+    c.setApprovalForAll(a1, False, transact={'from': a0})
     assert not c.isApprovedForAll(a0, a1)
 
 
@@ -71,20 +69,20 @@ def test_owner_transferFrom(w3, c, assert_tx_failed):
     a0, a1 = w3.eth.accounts[:2]
 
     # Basic transfer.
-    c.transferFrom(a0, a1, IDS[0], transact={'from':a0})
+    c.transferFrom(a0, a1, IDS[0], transact={'from': a0})
     assert c.balanceOf(a0) == 0
     assert c.balanceOf(a1) == 2
 
     # Can't transfer one you don't own
-    assert_tx_failed(lambda: c.transferFrom(a0, a1, IDS[0], transact={'from':a0}))
+    assert_tx_failed(lambda: c.transferFrom(a0, a1, IDS[0], transact={'from': a0}))
 
 
 def test_approve_transferFrom(w3, c, assert_tx_failed):
     a0, a1, a2 = w3.eth.accounts[:3]
 
     # Approved transfer
-    c.approve(a2, IDS[0], transact={'from':a0})
-    c.transferFrom(a0, a1, IDS[0], transact={'from':a2})
+    c.approve(a2, IDS[0], transact={'from': a0})
+    c.transferFrom(a0, a1, IDS[0], transact={'from': a2})
     assert c.balanceOf(a0) == 0
     assert c.balanceOf(a1) == 2
 
@@ -93,8 +91,8 @@ def test_operator_transferFrom(w3, c, assert_tx_failed):
     a0, a1, a2 = w3.eth.accounts[:3]
 
     # Approved transfer
-    c.setApprovalForAll(a2, True, transact={'from':a0})
-    c.transferFrom(a0, a1, IDS[0], transact={'from':a2})
+    c.setApprovalForAll(a2, True, transact={'from': a0})
+    c.transferFrom(a0, a1, IDS[0], transact={'from': a2})
     assert c.balanceOf(a0) == 0
     assert c.balanceOf(a1) == 2
 
@@ -103,19 +101,19 @@ def test_account_safeTransferFrom(w3, c, assert_tx_failed):
     a0, a1 = w3.eth.accounts[:2]
 
     # Basic transfer.
-    c.safeTransferFrom(a0, a1, IDS[0], transact={'from':a0})
+    c.safeTransferFrom(a0, a1, IDS[0], transact={'from': a0})
     assert c.balanceOf(a0) == 0
     assert c.balanceOf(a1) == 2
 
     # Can't transfer one you don't own
-    assert_tx_failed(lambda: c.safeTransferFrom(a0, a1, IDS[0], transact={'from':a0}))
+    assert_tx_failed(lambda: c.safeTransferFrom(a0, a1, IDS[0], transact={'from': a0}))
 
 
 def test_contract_safeTransferFrom(w3, c, assert_tx_failed, get_contract):
     a0, a1 = w3.eth.accounts[:2]
 
     # Can't transfer to a contract that doesn't implement the receiver code
-    #assert_tx_failed(lambda: c.safeTransferFrom(a0, c.address, IDS[0], transact={'from':a0}))
+    assert_tx_failed(lambda: c.safeTransferFrom(a0, c.address, IDS[0], transact={'from': a0}))
 
     # Only to an address that implements that function
     receiver = get_contract("""
@@ -128,4 +126,4 @@ def onERC721Received(
     ) -> bytes[4]:
     return method_id("onERC721Received(address,address,uint256,bytes)", bytes[4])
     """)
-    c.safeTransferFrom(a0, receiver.address, IDS[0], transact={'from':a0})
+    c.safeTransferFrom(a0, receiver.address, IDS[0], transact={'from': a0})

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -1,0 +1,131 @@
+import pytest
+
+from web3.exceptions import ValidationError
+
+
+IDS = range(1, 65)
+
+
+@pytest.fixture
+def c(get_contract, w3):
+    # a0, a1 own 1 token each
+    owners = w3.eth.accounts[:3]
+    # a2 owns 2 tokens
+    owners.append(w3.eth.accounts[2])
+    # a3 owns the rest
+    owners.extend([w3.eth.accounts[3]] * 60)
+    with open('examples/tokens/ERC721.vy') as f:
+        return get_contract(
+            f.read(),
+            owners, IDS
+        )
+
+
+def test_balanceOf(c, w3):
+    a0, a1, a2, a3, a4 = w3.eth.accounts[:5]
+    # Correctly lists balances
+    assert c.balanceOf(a0) == 1
+    assert c.balanceOf(a1) == 1
+    assert c.balanceOf(a2) == 2
+    assert c.balanceOf(a3) == 60
+    # Correctly reports account with no balance
+    assert c.balanceOf(a4) == 0
+
+
+def test_ownerOf(c, w3, assert_tx_failed):
+    a0, a1, a2, a3 = w3.eth.accounts[:4]
+    # Correctly finds ownership
+    assert c.ownerOf(IDS[0]) == a0
+    assert c.ownerOf(IDS[1]) == a1
+    assert c.ownerOf(IDS[2]) == a2
+    assert c.ownerOf(IDS[3]) == a2
+    for _id in IDS[4:]:
+        assert c.ownerOf(_id) == a3
+    # Reverts for non-existant ID
+    assert_tx_failed(lambda: c.ownerOf(99))
+
+
+def test_approve(w3, c, assert_tx_failed):
+    a0, a1, a2 = w3.eth.accounts[:3]
+    # Approval can be given and taken away
+    assert c.getApproved(IDS[0]) != a1
+    c.approve(a1, IDS[0], transact={'from':a0})
+    assert c.getApproved(IDS[0]) == a1
+    c.approve(a2, IDS[0], transact={'from':a0})
+    assert c.getApproved(IDS[0]) != a1
+    # Can't approve something you don't own
+    assert_tx_failed(lambda: c.approve(a1, IDS[1], transact={'from':a0}))
+
+
+def test_approveAll(w3, c):
+    a0, a1 = w3.eth.accounts[:2]
+
+    assert not c.isApprovedForAll(a0, a1)
+    c.setApprovalForAll(a1, True, transact={'from':a0})
+    assert c.isApprovedForAll(a0, a1)
+    c.setApprovalForAll(a1, False, transact={'from':a0})
+    assert not c.isApprovedForAll(a0, a1)
+
+
+def test_owner_transferFrom(w3, c, assert_tx_failed):
+    a0, a1 = w3.eth.accounts[:2]
+
+    # Basic transfer.
+    c.transferFrom(a0, a1, IDS[0], transact={'from':a0})
+    assert c.balanceOf(a0) == 0
+    assert c.balanceOf(a1) == 2
+
+    # Can't transfer one you don't own
+    assert_tx_failed(lambda: c.transferFrom(a0, a1, IDS[0], transact={'from':a0}))
+
+
+def test_approve_transferFrom(w3, c, assert_tx_failed):
+    a0, a1, a2 = w3.eth.accounts[:3]
+
+    # Approved transfer
+    c.approve(a2, IDS[0], transact={'from':a0})
+    c.transferFrom(a0, a1, IDS[0], transact={'from':a2})
+    assert c.balanceOf(a0) == 0
+    assert c.balanceOf(a1) == 2
+
+
+def test_operator_transferFrom(w3, c, assert_tx_failed):
+    a0, a1, a2 = w3.eth.accounts[:3]
+
+    # Approved transfer
+    c.setApprovalForAll(a2, True, transact={'from':a0})
+    c.transferFrom(a0, a1, IDS[0], transact={'from':a2})
+    assert c.balanceOf(a0) == 0
+    assert c.balanceOf(a1) == 2
+
+
+def test_account_safeTransferFrom(w3, c, assert_tx_failed):
+    a0, a1 = w3.eth.accounts[:2]
+
+    # Basic transfer.
+    c.safeTransferFrom(a0, a1, IDS[0], transact={'from':a0})
+    assert c.balanceOf(a0) == 0
+    assert c.balanceOf(a1) == 2
+
+    # Can't transfer one you don't own
+    assert_tx_failed(lambda: c.safeTransferFrom(a0, a1, IDS[0], transact={'from':a0}))
+
+
+def test_contract_safeTransferFrom(w3, c, assert_tx_failed, get_contract):
+    a0, a1 = w3.eth.accounts[:2]
+
+    # Can't transfer to a contract that doesn't implement the receiver code
+    #assert_tx_failed(lambda: c.safeTransferFrom(a0, c.address, IDS[0], transact={'from':a0}))
+
+    # Only to an address that implements that function
+    receiver = get_contract("""
+@public
+def onERC721Received(
+        _operator: address,
+        _from: address,
+        _tokenId: uint256,
+        _data: bytes[1024]
+    ) -> bytes[4]:
+    return method_id("onERC721Received(address,address,uint256,bytes)", bytes[4])
+    """)
+    c.safeTransferFrom(a0, receiver.address, IDS[0], transact={'from':a0})


### PR DESCRIPTION
### - What I did
Adapted a version of @maurelian's ERC721 example for our repository
Added default argument support for `safeTransferFrom()` per merge of #987

### - How I did it
Copy, paste, compile

### - How to verify it
compile, write some tests (TODO)

### - Description for the changelog
Added ERC721 example

### - Cute Animal Picture

![NFTy Dragon](http://www.dogbazar.org/wp-content/uploads/2017/02/81NFt0LKkuL._SL1500_.jpg)
