### PR TITLE
Fix Dockerfile to be able to run tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update && \
 ADD . /code
 
 WORKDIR /code
+
+# Pass `--addopts "--version"` because want to execute `python setup.py test` to include test dependencies in built docker-image, but avoid to execute the whole test suite here.
 RUN python setup.py install && \
+    python setup.py test --addopts "--version" && \
     apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev
 
 ENTRYPOINT ["/usr/local/bin/vyper"]

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -162,7 +162,7 @@ Dockerfile
 A Dockerfile is provided in the master branch of the repository. In order to build a Docker Image please run:
 ::
     docker build https://github.com/ethereum/vyper.git -t vyper:1
-    docker run -it vyper:1 /bin/bash
+    docker run -it --entrypoint /bin/bash vyper:1
 To ensure that everything works correctly after the installtion, please run the test commands
 and try compiling a contract:
 ::

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -166,7 +166,7 @@ A Dockerfile is provided in the master branch of the repository. In order to bui
 To ensure that everything works correctly after the installtion, please run the test commands
 and try compiling a contract:
 ::
-    make test
+    python setup.py test
     vyper examples/crowdfund.vy
 
 ****


### PR DESCRIPTION
### - What I did

Fix the following errors which occurred building docker image and running tests within that according to  [docs/installing-vyper.rst](https://github.com/ethereum/vyper/blob/master/docs/installing-vyper.rst)

```sh
$ docker build https://github.com/ethereum/vyper.git -t vyper:1 
$ docker run -it vyper:1 /bin/bash                                                                                                                
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x88 in position 40: invalid start byte

$ docker run -it --entrypoint /bin/bash vyper:1
root@42d73a0c0c5a:/code# make test
bash: make: command not found

root@42d73a0c0c5a:/code# python setup.py test
... snip...
unable to execute 'gcc': No such file or directory
error: Setup script exited with error: command 'gcc' failed with exit status 1
```

### - How I did it

- Fix a command to run test
  - `make` has not been existed since using slim docker image base [here](a526598). So we need to call `pytest` directly instead of that way
- Modify the docker-run command to overwrite entrypoint
  - The command has not been worked properly since Dockerfile has been changed to use entrypoint [here](e95a282)
- Install the test dependencies as well when building the image, to be able to run the tests.
  - There's no way to install the test dependencies without running the tests (which is very time-consuming to finish them all), so we have no choice but to execute `pytest --version` as the fastest command
  - or is there a better way? 😓 

### - How to verify it

```sh
$ cd /path/to/repo
$ docker build ./ -t vyper_test:1
$ docker run -it --entrypoint /bin/bash vyper_test:1
root@a72a6f6f18fb:/code#
root@a72a6f6f18fb:/code# python setup.py test
root@a72a6f6f18fb:/code# running pytest                                                                                                                                                                                                                               
... snip ...
root@a72a6f6f18fb:/code# == 861 passed in 187.89 seconds ==
root@a72a6f6f18fb:/code# exit
$ docker run vyper_test:1 -f abi examples/crowdfund.vy
[{"name": "__init__", "outputs": [], "inputs": [{"type": "address", "name": "_beneficiary"}, {"type": "uint256", "name": "_goal"}, {"type": "uint256", "name": "_timelimit"}], "constant": false, "payable": false, "type": "constructor"}, {"name": "participate", "outputs": [], "inputs": [], "constant": false, "payable": true, "type": "function", "gas": 106028}, {"name": "finalize", "outputs": [], "inputs": [], "constant": false, "payable": false, "type": "function", "gas": 26419}, {"name": "refund", "outputs": [], "inputs": [], "constant": false, "payable": false, "type": "function", "gas": 3378461}]
```

#### Short measurement of build time

```
$ time docker build --no-cache https://github.com/ethereum/vyper.git -t vyper:1
docker build --no-cache https://github.com/ethereum/vyper.git -t vyper:1  0.41s user 0.35s system 2% cpu 27.780 total

$ time docker build --no-cache https://github.com/flada-auxv/vyper.git#fix_dockerfile_to_be_able_to_run_tests -t vyper_test:1
docker build --no-cache  -t vyper_test:1  0.45s user 0.47s system 1% cpu 1:19.63 total
```

About x3 slower than before but I think the test dependencies should be installed in docker image, especially used for local development. What do you think...?

### - Cute Animal Picture

![](http://shinkaiyablog.com/wp-content/uploads/2015/09/sleep-whale-1038x5761-1024x568.jpg)

Thanks 😄 