### PR TITLE
Remove int256 and clean up code for readability

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -455,8 +455,6 @@ Here you can find a list of all types and default values:
      - ``False``
    * - ``int128``
      - ``0``
-   * - ``int256``
-     - ``0``
    * - ``uint256``
      - ``0``
    * - ``decimal``

--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -1,10 +1,23 @@
 import ast
 
-from vyper.types import get_size_of_type, canonicalize_type, parse_type, \
+from vyper.types import (
+    get_size_of_type,
+    canonicalize_type,
+    parse_type,
     ByteArrayType
-from vyper.utils import sha3, is_varname_valid, bytes_to_int, ceil32
+)
+from vyper.utils import (
+    sha3,
+    is_varname_valid,
+    bytes_to_int,
+    ceil32
+)
 from vyper.signatures.function_signature import VariableRecord
-from vyper.exceptions import InvalidTypeException, VariableDeclarationException, EventDeclarationException
+from vyper.exceptions import (
+    InvalidTypeException,
+    VariableDeclarationException,
+    EventDeclarationException
+)
 
 
 # Event signature object

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -217,8 +217,8 @@ def parse_unit(item, custom_units):
 # Parses an expression representing a type. Annotation refers to whether
 # the type is to be located in memory or storage
 def parse_type(item, location, sigs=None, custom_units=None):
-    custom_units = [] if custom_units is None else custom_units
-    sigs = {} if sigs is None else sigs
+    custom_units = custom_units or []
+    sigs = sigs or {}
 
     # Base types, e.g. num
     if isinstance(item, ast.Name):

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -175,8 +175,6 @@ def canonicalize_type(t, is_indexed=False):
         return 'bool'
     elif t == 'uint256':
         return 'uint256'
-    elif t == 'int256':
-        return 'int256'
     elif t == 'address' or t == 'bytes32':
         return t
     raise Exception("Invalid or unsupported type: " + repr(t))

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -130,7 +130,7 @@ RLP_DECODER_ADDRESS = hex_to_int('0x5185D17c44699cecC3133114F8df70753b856709')
 # This is the contract address: 0xCb969cAAad21A78a24083164ffa81604317Ab603
 
 # Available base types
-base_types = ['int128', 'decimal', 'bytes32', 'uint256', 'int256', 'bool', 'address']
+base_types = ['int128', 'decimal', 'bytes32', 'uint256', 'bool', 'address']
 
 # Keywords available for ast.Call type
 valid_call_keywords = ['uint256', 'int128', 'decimal', 'address', 'contract', 'indexed']
@@ -143,7 +143,7 @@ valid_global_keywords = ['public', 'modifying', 'event'] + valid_units + valid_c
 
 # Cannot be used for variable or member naming
 reserved_words = [
-    'int128', 'int256', 'uint256', 'address', 'bytes32',
+    'int128', 'uint256', 'address', 'bytes32',
     'if', 'for', 'while', 'until',
     'pass', 'def', 'push', 'dup', 'swap', 'send', 'call',
     'selfdestruct', 'assert', 'stop', 'throw',


### PR DESCRIPTION
### - What I did
Remove instances of `int256` and clean up code (for readability).

### - How I did it
Ran `grep -rw 'int256' *` to find all instances of `int256` and removed unnecessary occurrences. Formatted some additional code for easier readability.

### - How to verify it
Ran the full suite of tests and confirmed they all still pass. Visually examined each change and confirmed that they would not break anything. 

### - Description for the changelog
Remove int256 and clean up code for readability

### - Cute Animal Picture

![cute-pic](https://user-images.githubusercontent.com/9441295/44950459-50479600-adfd-11e8-8238-73dca036f32c.jpg)