### PR TITLE
Not only foor bool expressions

### DIFF
--- a/examples/voting/ballot.vy
+++ b/examples/voting/ballot.vy
@@ -24,19 +24,18 @@ voter_count: public(int128)
 chairperson: public(address)
 int128_proposals: public(int128)
 
+
 @public
 @constant
 def delegated(addr: address) -> bool:
-    # equivalent to
-        # self.voters[addr].delegate != 0x0000000000000000000000000000000000000000
-    return not not self.voters[addr].delegate
+    return self.voters[addr].delegate != ZERO_ADDRESS
+
 
 @public
 @constant
 def directly_voted(addr: address) -> bool:
-    # not <address> equivalent to
-        # <address> == 0x0000000000000000000000000000000000000000
-    return self.voters[addr].voted and not self.voters[addr].delegate
+    return self.voters[addr].voted and (self.voters[addr].delegate == ZERO_ADDRESS)
+
 
 # Setup global variables
 @public
@@ -108,7 +107,8 @@ def delegate(to: address):
     # Throws if the sender tries to delegate their vote to themselves or to
     # the default address value of 0x0000000000000000000000000000000000000000
     # (the latter might not be problematic, but I don't want to think about it).
-    assert to != msg.sender and not not to
+    assert to != msg.sender
+    assert to != ZERO_ADDRESS
 
     self.voters[msg.sender].voted = True
     self.voters[msg.sender].delegate = to

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,6 @@ setup(
         'pytest-cov',
         'eth-tester[py-evm]==0.1.0b31',
         'web3==4.4.1',
-        'py-evm==0.2.0a30',
-        # 'py-evm==0.2.0a26',
-        # 'py-evm==0.2.0a18',
-        # 'py-evm==0.2.0-alpha.26',
-        # 'eth-tester==0.1.0-beta.29',
     ],
     scripts=[
         'bin/vyper',

--- a/tests/parser/integration/test_escrow.py
+++ b/tests/parser/integration/test_escrow.py
@@ -9,7 +9,7 @@ arbitrator: address
 
 @public
 def setup(_seller: address, _arbitrator: address):
-    if not self.buyer:
+    if self.buyer == ZERO_ADDRESS:
         self.buyer = msg.sender
         self.seller = _seller
         self.arbitrator = _arbitrator
@@ -43,7 +43,7 @@ arbitrator: address
 @public
 @payable
 def __init__(_seller: address, _arbitrator: address):
-    if not self.buyer:
+    if self.buyer == ZERO_ADDRESS:
         self.buyer = msg.sender
         self.seller = _seller
         self.arbitrator = _arbitrator

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -43,6 +43,29 @@ def foo() -> bool:
 def foo() -> bool:
     a: address
     return a == 1
+    """,
+    """
+@public
+def foo(a: address) -> bool:
+    return not a
+    """,
+    """
+@public
+def foo() -> bool:
+    b: int128
+    return not b
+    """,
+    """
+@public
+def foo() -> bool:
+    b: uint256
+    return not b
+    """,
+    """
+@public
+def foo() -> bool:
+    b: uint256
+    return not b
     """
 ]
 
@@ -106,6 +129,11 @@ def foo() -> bool:
 @public
 def foo() -> bool:
     return 1 <= 1
+    """,
+    """
+@public
+def foo2(a: address) -> bool:
+    return a != ZERO_ADDRESS
     """
 ]
 

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -93,6 +93,9 @@ def optimize(node):
             return LLLnode(argz[0].value, [], node.typ, node.location, node.pos, node.annotation, add_gas_estimate=node.add_gas_estimate)
         else:
             raise Exception("Clamp always fails")
+    # [eq, x, 0] is the same as [iszero, x].
+    elif node.value == 'eq' and int_at(argz, 1) and argz[1].value == 0:
+        return LLLnode('iszero', [argz[0]], node.typ, node.location, node.pos, node.annotation, add_gas_estimate=node.add_gas_estimate)
     # Turns out this is actually not such a good optimization after all
     elif node.value == "with" and int_at(argz, 1) and not search_for_set(argz[2], argz[0].value) and False:
         o = replace_with_value(argz[2], argz[0].value, argz[1].value)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -578,9 +578,10 @@ class Expr(object):
     def unary_operations(self):
         operand = Expr.parse_value_expr(self.expr.operand, self.context)
         if isinstance(self.expr.op, ast.Not):
-            # Note that in the case of bool, num, address, decimal, uint256 AND bytes32,
-            # a zero entry represents false, all others represent true
-            return LLLnode.from_list(["iszero", operand], typ='bool', pos=getpos(self.expr))
+            if isinstance(operand.typ, BaseType) and operand.typ.typ == 'bool':
+                return LLLnode.from_list(["iszero", operand], typ='bool', pos=getpos(self.expr))
+            else:
+                raise TypeMismatchException("Only bool is supported for not operation, %r supplied." % operand.typ, self.expr)
         elif isinstance(self.expr.op, ast.USub):
             if not is_numeric_type(operand.typ):
                 raise TypeMismatchException("Unsupported type for negation: %r" % operand.typ, operand)


### PR DESCRIPTION
### - What I did
Fixes #999.

### - How I did it
Altered unary_operations function.

### - How to verify it
See tests in test_bool.py

### - Description for the changelog

not may only be used with boolean expressions.

### - Cute Animal Picture
![pp](https://user-images.githubusercontent.com/6917456/45319499-39611c00-b540-11e8-9850-8a4d42eab8ce.jpeg)
