### PR TITLE
small fix to .gitignore, now has the right reference to egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 
 # egg-related
-eth_vyper.egg-info/
+vyper.egg-info/
 build/
 dist/
 .eggs/


### PR DESCRIPTION
### - What I did
changed the reference to egg-info in .gitignore

### - How I did it
with vi

### - How to verify it
build now does not leave the vyper.egg-info with changed files. Like they did before the change.

### - Description for the changelog
update reference to egg-info from eth_vyper.egg-info to vyper.egg-info

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/7376601/45949597-ae325c80-bffc-11e8-9a09-b9549a523cfb.png)

