### PR TITLE
Fix test assert refund.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     tests_require=[
         'pytest',
         'pytest-cov',
-        'eth-tester[py-evm]==0.1.0b31',
+        'py-evm==0.2.0a32',
+        'eth-tester[py-evm]==0.1.0b32',
         'web3==4.4.1',
     ],
     scripts=[

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -13,16 +13,18 @@ def test_assert_refund(w3, get_contract_with_gas_estimation, assert_tx_failed):
 @public
 def foo():
     assert 1 == 2
-"""
+    """
     c = get_contract_with_gas_estimation(code)
     a0 = w3.eth.accounts[0]
     pre_balance = w3.eth.getBalance(a0)
-    # assert_tx_failed(lambda: c.foo(transact={'from': a0, 'gas': 10**6, 'gasPrice': 10}))
-    assert_tx_failed(lambda: c.foo())
+    tx_hash = c.foo(transact={'from': a0, 'gas': 10**6, 'gasPrice': 10})
+    assert w3.eth.getTransactionReceipt(tx_hash)['status'] == 0
+    # More info on receipt status:
+    # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md#specification.
     post_balance = w3.eth.getBalance(a0)
     # Checks for gas refund from revert
     # 10**5 is added to account for gas used before the transactions fails
-    assert pre_balance < post_balance + 10**5
+    assert pre_balance > post_balance
 
 
 def test_assert_reason(w3, get_contract_with_gas_estimation, assert_tx_failed):


### PR DESCRIPTION
### - What I did
- Using transactionReceipt with a transact={}, is clearer and shows web3 usage as well.
- Bump eth tester versions.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](https://static.boredpanda.com/blog/wp-content/uploads/2016/01/cute-possums-23__700.jpg)