### PR TITLE
Add source map

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -6,6 +6,7 @@ import sys
 import vyper
 import warnings
 
+from collections import OrderedDict
 from vyper import compiler, optimizer
 from vyper.parser.parser import parse_to_lll
 from vyper.parser import parser_utils
@@ -48,6 +49,31 @@ def get_asm(asm_list):
     return output_string
 
 
+def get_source_map(code):
+    asm_list = compile_lll.compile_to_assembly(optimizer.optimize(parse_to_lll(code, runtime_only=True)))
+    c, line_number_map = compile_lll.assembly_to_evm(asm_list)
+    # Sort line_number_map
+    out = OrderedDict()
+    keylist = line_number_map.keys()
+    for k in sorted(keylist):
+        out[k] = line_number_map[k]
+    return json.dumps(out)
+
+
+def get_source_map_asm_list(code):
+    line_no_width = 6
+    asm_list = compile_lll.compile_to_assembly(optimizer.optimize(parse_to_lll(code, runtime_only=True)))
+    for node in asm_list:
+        line_no = ''
+        if isinstance(node, compile_lll.instruction):
+            line_no = node.lineno or ''
+
+        print('{}{}'.format(
+            str(line_no).ljust(line_no_width),
+            node
+        ))
+
+
 if __name__ == '__main__':
 
     output_format = {}
@@ -58,6 +84,8 @@ if __name__ == '__main__':
     output_format['bytecode_runtime'] = lambda code: '0x' + compiler.compile(code, bytecode_runtime=True).hex()
     output_format['ir'] = lambda code: optimizer.optimize(parse_to_lll(code))
     output_format['asm'] = lambda code: get_asm(compile_lll.compile_to_assembly(optimizer.optimize(parse_to_lll(code))))
+    output_format['source_map'] = get_source_map
+    output_format['source_map_asm_list'] = get_source_map_asm_list
 
     with open(args.input_file) as fh:
         code = fh.read()

--- a/bin/vyper-serve
+++ b/bin/vyper-serve
@@ -88,6 +88,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             out_dict = {
                 'abi': compiler.mk_full_signature(code),
                 'bytecode': '0x' + compiler.compile(code).hex(),
+                'bytecode_runtime': '0x' + compiler.compile(code, bytecode_runtime=True).hex(),
                 'ir': str(optimizer.optimize(parse_to_lll(code)))
             }
         except ParserException as e:

--- a/scripts/rlp_decoder.py
+++ b/scripts/rlp_decoder.py
@@ -107,4 +107,4 @@ rlp_decoder_lll = LLLnode.from_list(['seq',
     ]])
 
 rlp_decoder_lll = optimizer.optimize(rlp_decoder_lll)
-rlp_decoder_bytes = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(rlp_decoder_lll))
+rlp_decoder_bytes, _ = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(rlp_decoder_lll))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def bytes_helper():
 def get_contract_from_lll(w3):
     def lll_compiler(lll, *args, **kwargs):
         lll = optimizer.optimize(LLLnode.from_list(lll))
-        bytecode = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll))
+        bytecode, _ = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll))
         abi = kwargs.get('abi') or []
         contract = w3.eth.contract(bytecode=bytecode, abi=abi)
         deploy_transaction = {

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -39,7 +39,32 @@ def get_revert(mem_start=None, mem_len=None):
     return o
 
 
+class instruction(str):
+
+    def __new__(cls, sstr, *args, **kwargs):
+        return super().__new__(cls, sstr)
+
+    def __init__(self, sstr, pos=None):
+        if pos is not None:
+            self.lineno, self.col_offset = pos
+        else:
+            self.lineno, self.col_offset = None, None
+
+
+def apply_line_numbers(func):
+    def apply_line_no_wrapper(*args, **kwargs):
+        code = args[0]
+        ret = func(*args, **kwargs)
+        new_ret = [
+            instruction(i, code.pos) if isinstance(i, str) and not isinstance(i, instruction) else i
+            for i in ret
+        ]
+        return new_ret
+    return apply_line_no_wrapper
+
+
 # Compiles LLL to assembly
+@apply_line_numbers
 def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=None, height=0):
     if withargs is None:
         withargs = {}

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -358,7 +358,6 @@ def not_breakpoint(line_number_map, item, pos):
 # Assembles assembly into EVM
 def assembly_to_evm(assembly, map_line_numbers=True):
     line_number_map = {'breakpoints': [], 'pc_pos_map': {}}
-    current_line_no = 0
     posmap = {}
     sub_assemblies = []
     codes = []

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -357,6 +357,7 @@ def assembly_to_evm(assembly, map_line_numbers=True):
     codes = []
     pos = 0
     for i, item in enumerate(assembly):
+        note_line_num(line_number_map, item, pos)
         if is_symbol(item):
             if assembly[i + 1] == 'JUMPDEST' or assembly[i + 1] == 'BLANK':
                 posmap[item] = pos  # Don't increment position as the symbol itself doesn't go into code
@@ -371,7 +372,6 @@ def assembly_to_evm(assembly, map_line_numbers=True):
             pos += len(c)
         else:
             pos += 1
-        note_line_num(line_number_map, item, pos)
 
     posmap['_sym_codeend'] = pos
     o = b''

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -337,7 +337,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
         ]
     # inject debug opcode.
     elif code.value == 'debugger':
-        return ['PUSH1', code.pos[0], 'DEBUG']
+        return ['DEBUG']
     else:
         raise Exception("Weird code element: " + repr(code))
 
@@ -345,12 +345,19 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
 def note_line_num(line_number_map, item, pos):
     # Record line number attached to pos.
     if isinstance(item, instruction) and item.lineno is not None:
-        line_number_map[pos] = item.lineno, item.col_offset
+        line_number_map['pc_pos_map'][pos] = item.lineno, item.col_offset
+    not_breakpoint(line_number_map, item, pos)
+
+
+def not_breakpoint(line_number_map, item, pos):
+    # Record line number attached to pos.
+    if item == 'DEBUG' and item.lineno not in line_number_map['breakpoints']:
+        line_number_map['breakpoints'].append(item.lineno + 1)
 
 
 # Assembles assembly into EVM
 def assembly_to_evm(assembly, map_line_numbers=True):
-    line_number_map = {}
+    line_number_map = {'breakpoints': [], 'pc_pos_map': {}}
     current_line_no = 0
     posmap = {}
     sub_assemblies = []
@@ -358,6 +365,8 @@ def assembly_to_evm(assembly, map_line_numbers=True):
     pos = 0
     for i, item in enumerate(assembly):
         note_line_num(line_number_map, item, pos)
+        if item == 'DEBUG':
+            continue  # skip debug
         if is_symbol(item):
             if assembly[i + 1] == 'JUMPDEST' or assembly[i + 1] == 'BLANK':
                 posmap[item] = pos  # Don't increment position as the symbol itself doesn't go into code
@@ -376,7 +385,10 @@ def assembly_to_evm(assembly, map_line_numbers=True):
     posmap['_sym_codeend'] = pos
     o = b''
     for i, item in enumerate(assembly):
-        if is_symbol(item):
+        note_line_num(line_number_map, item, pos)
+        if item == 'DEBUG':
+            continue  # skip debug
+        elif is_symbol(item):
             if assembly[i + 1] != 'JUMPDEST' and assembly[i + 1] != 'BLANK':
                 o += bytes([PUSH_OFFSET + 2, posmap[item] // 256, posmap[item] % 256])
         elif isinstance(item, int):
@@ -399,7 +411,6 @@ def assembly_to_evm(assembly, map_line_numbers=True):
         else:
             # Should never reach because, assembly is create in compile_to_assembly.
             raise Exception("Weird symbol in assembly: " + str(item))  # pragma: no cover
-        note_line_num(line_number_map, item, pos)
 
     assert len(o) == pos
     return o, line_number_map

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -21,6 +21,7 @@ def compile(code, *args, **kwargs):
     c, line_number_map = compile_lll.assembly_to_evm(asm)
     return c
 
+
 def gas_estimate(origcode, *args, **kwargs):
     o = {}
     code = optimizer.optimize(parser.parse_to_lll(origcode))

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -18,8 +18,8 @@ def compile(code, *args, **kwargs):
         print('Please not this code contains DEBUG opcode.')
         print('This will only work in a support EVM. This FAIL on any other nodes.')
 
-    return compile_lll.assembly_to_evm(asm)
-
+    c, line_number_map = compile_lll.assembly_to_evm(asm)
+    return c
 
 def gas_estimate(origcode, *args, **kwargs):
     o = {}

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -791,6 +791,6 @@ def pack_logging_data(expected_data, args, context, pos):
     return holder, maxlen, dynamic_offset_counter, datamem_start
 
 
-def parse_to_lll(kode):
+def parse_to_lll(kode, runtime_only=False):
     code = parse(kode)
-    return parse_tree_to_lll(code, kode)
+    return parse_tree_to_lll(code, kode, runtime_only=runtime_only)


### PR DESCRIPTION
### - What I did
Fixes #870.

Add vyper source map. `-f source_map`.
I spent quite a bit of time to try and get something like solidity's, but came to the conclusion that we should do our own version first. Mostly because python ast outputs line_no/col_offset.

Also as part of the vyper debug changes, it came clear that we should probably move the global/locals part of the source map here. But left that out as this would be out of scope.
https://github.com/status-im/vyper-debug/blob/master/vdb/source_map.py#L39

The source map linenumber map format is: `{148: [1, 0]}` / `{pc_pos: [line_no, col_offset]}`.
The breakpoints are just a list of line numbers, one would want to insert a breakpoint, which is currently also produced by the `vdb` statement.

### - How I did it

### - How to verify it
Best way is to wait for vyper-debug to be updated (6_use_pc branch to be merged) ;)

### - Description for the changelog

### - Cute Animal Picture
![](http://cdn.akc.org/content/article-body-image/shiba_inu_cute_puppies.jpg)
