### PR TITLE
Fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test link clean clean-pyc clean-build clean-test docs docker-build
+.PHONY: test lint clean clean-pyc clean-build clean-test docs docker-build
 
 init:
 	python setup.py install

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -15,7 +15,7 @@ def compile(code, *args, **kwargs):
             return any([find_nested_opcode(x, key) for x in sublists])
 
     if find_nested_opcode(asm, 'DEBUG'):
-        print('Please not this code contains DEBUG opcode.')
+        print('Please note this code contains DEBUG opcode.')
         print('This will only work in a support EVM. This FAIL on any other nodes.')
 
     return compile_lll.assembly_to_evm(asm)


### PR DESCRIPTION
### - What I did
+ Fix a typo in `Makefile`
+ Fix a typo when printing msg for DEBUG opcode alert

### - How I did it
Change `link` to `lint` in `Makefile`
Change `not` to `note` in `vyper/compiler.go`

### - How to verify it
`make lint`
