### PR TITLE
Fix VYPER_TRACEBACK_LIMIT

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -12,7 +12,10 @@ from vyper.parser import parser_utils
 from vyper import compile_lll
 
 warnings.simplefilter('always')
-sys.tracebacklimit = os.environ.get('VYPER_TRACEBACK_LIMIT', 0)
+sys.tracebacklimit = 0
+tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
+if tb_limit:
+    sys.tracebacklimit = int(tb_limit)
 
 parser = argparse.ArgumentParser(description='Vyper programming language for Ethereum')
 parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))


### PR DESCRIPTION
### - What I did
os.environ.get returns a string, which made traceback limit not work properly.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](https://cdn.theculturetrip.com/wp-content/uploads/2018/05/39174657745_1658e6f66c_k.jpg)
