### PR TITLE
Allow convert to bytes arrays smaller 32 bytes.

### DIFF
--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -123,12 +123,19 @@ def bytes_to_bytes32(inp: bytes[32]) -> (bytes32, bytes32):
     memory: bytes32 = convert(inp, bytes32)
     storage: bytes32 = convert(self.d, bytes32)
     return  memory, storage
-"""
+
+@public
+def bytes_to_bytes32_from_smaller(inp: bytes[10]) -> bytes32:
+    memory: bytes32 = convert(inp, bytes32)
+    return memory
+    """
+
     c = get_contract_with_gas_estimation(code)
     assert c.int128_to_bytes32(1) == [bytes_helper('', 31) + b'\x01'] * 3
     assert c.uint256_to_bytes32(1) == [bytes_helper('', 31) + b'\x01'] * 3
     assert c.address_to_bytes32(w3.eth.accounts[0]) == [bytes_helper('', 12) + w3.toBytes(hexstr=w3.eth.accounts[0])] * 2
     assert c.bytes_to_bytes32(bytes_helper('', 32)) == [bytes_helper('', 32)] * 2
+    assert c.bytes_to_bytes32_from_smaller(b'hello') == bytes_helper('hello', 32)
 
 
 def test_uint256_decimal(assert_tx_failed, get_contract_with_gas_estimation):

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -82,21 +82,25 @@ def to_decimal(expr, args, kwargs, context):
 
 @signature(('int128', 'uint256', 'address', 'bytes'), '*')
 def to_bytes32(expr, args, kwargs, context):
-    input = args[0]
-    typ, len = get_type(input)
+    in_arg = args[0]
+    typ, _len = get_type(in_arg)
+
     if typ == 'bytes':
-        if len != 32:
-            raise TypeMismatchException("Unable to convert bytes[{}] to bytes32".format(len))
-        if input.location == "memory":
+
+        if _len > 32:
+            raise TypeMismatchException("Unable to convert bytes[{}] to bytes32, max length is too large.".format(len))
+
+        if in_arg.location == "memory":
             return LLLnode.from_list(
-            ['mload', ['add', input, 32]], typ=BaseType('bytes32')
+            ['mload', ['add', in_arg, 32]], typ=BaseType('bytes32')
             )
-        elif input.location == "storage":
+        elif in_arg.location == "storage":
             return LLLnode.from_list(
-                ['sload', ['add', ['sha3_32', input], 1]], typ=BaseType('bytes32')
+                ['sload', ['add', ['sha3_32', in_arg], 1]], typ=BaseType('bytes32')
             )
+
     else:
-        return LLLnode(value=input.value, args=input.args, typ=BaseType('bytes32'), pos=getpos(expr))
+        return LLLnode(value=in_arg.value, args=in_arg.args, typ=BaseType('bytes32'), pos=getpos(expr))
 
 
 def convert(expr, context):


### PR DESCRIPTION
### - What I did

Allow bytes that have a smaller max length on bytes, to be converted to `bytes32`.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](https://cache.desktopnexus.com/thumbseg/2355/2355136-bigthumbnail.jpg)

