### PR TITLE
Ensure that import doesn't leak sys and pkg_resources

### DIFF
--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -1,13 +1,13 @@
-import sys
-import pkg_resources
+import sys as _sys
+import pkg_resources as _pkg_resources
 
 
-if (sys.version_info.major, sys.version_info.minor) < (3, 6):
+if (_sys.version_info.major, _sys.version_info.minor) < (3, 6):
     # Can't be tested, as our test harness is using python3.6.
     raise Exception("Requires python3.6+")  # pragma: no cover
 
 
 try:
-    __version__ = pkg_resources.get_distribution('vyper').version
-except pkg_resources.DistributionNotFound:
+    __version__ = _pkg_resources.get_distribution('vyper').version
+except _pkg_resources.DistributionNotFound:
     __version__ = '0.0.0development'


### PR DESCRIPTION
### - What I did
`sys` and `pkg_resources` were showing up if you imported `vyper` as a module, so I made them *disappear*

### - How I did it
underscores and magic

### - How to verify it
`import vyper` does not import anything
NOTE: We should probably change that :)