### PR TITLE
Added types to iterator variables

### DIFF
--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -1,6 +1,77 @@
 import pytest
 
+from pytest import raises
 from vyper import compiler
+
+fail_list = [
+    """
+@public
+def foo():
+    for i in range(10, type=int32):
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in range(10, type=random):
+        pass
+    """,
+    """
+@public
+def foo():
+    x: int128 = 5
+    for i in range(10, type=uint256):
+        y: int128 = i + x
+    """,
+    """
+@public
+def foo():
+    for i in range(10, type=int128):
+        y: int128 = floor(i)
+    """
+]
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_type_fail(bad_code):
+
+    with raises(Exception):
+        compiler.compile(bad_code)
+
+
+valid_list = [
+    """
+@public
+def foo():
+    for i in range(10, 20, type=int128):
+        pass
+    """,
+    """
+@public
+def foo():
+    x: uint256 = 5
+    for i in range(x, x + 10, type=uint256):
+        pass
+    """,
+    """
+@public
+def foo():
+    x: uint256 = 5
+    for i in range(10, type=uint256):
+        y: uint256 = i + x
+    """,
+    """
+@public
+def foo():
+    for i in range(10.0, type=decimal):
+        y: int128 = floor(i)
+    """
+]
+
+
+@pytest.mark.parametrize('good_code', valid_list)
+def test_type_success(good_code):
+    assert compiler.compile(good_code) is not None
+
 
 valid_list = [
     """
@@ -20,18 +91,6 @@ def foo():
 def foo():
     x: int128 = 5
     for i in range(x, x + 10):
-        pass
-    """,
-    """
-@public
-def foo():
-    for i in range(10, type=int128):
-        pass
-    """,
-    """
-@public
-def foo():
-    for i in range(10, 20, type=uint256):
         pass
     """
 ]

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -21,6 +21,18 @@ def foo():
     x: int128 = 5
     for i in range(x, x + 10):
         pass
+    """,
+    """
+@public
+def foo():
+    for i in range(10, type=int128):
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in range(10, 20, type=uint256):
+        pass
     """
 ]
 

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -70,6 +70,10 @@ class LLLnode():
         if isinstance(self.value, int):
             self.valency = 1
             self.gas = 5
+        elif isinstance(self.value, float):
+            # are these the right values for float?
+            self.valency = 1
+            self.gas = 5
         elif isinstance(self.value, str):
             # Opcodes and pseudo-opcodes (e.g. clamp)
             if self.value.upper() in comb_opcodes:


### PR DESCRIPTION
### - What I did
Added types to iterator variables, to close #1039 

Example:
`for x in range(N, type=bytes32):`

### - How I did it
Parsed the for loop object for keyword "type", and if it exists, uses that as the type for the iterator. If not, type defaults to int128 for backwards compatibility
Checks to make sure that the type is valid as well

### - How to verify it
Added two extra blocks to tests/parser/syntax/test_for_range.py and they compile. Also tested by modifying examples/crowdfund.vy loop to have types and it compiles (did not commit those tests)

### - Description for the changelog
Added types to iterator objects

### - Cute Animal Picture

![giraffe](https://user-images.githubusercontent.com/6580613/47259210-5a3c5b80-d474-11e8-86ec-f1e753c61f98.jpg)

