### PR TITLE
Fix type checking of tuple types in return statements

### DIFF
--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -549,10 +549,10 @@ class Stmt(object):
             for i, ret_x in enumerate(self.context.return_type.members):
                 s_member = sub.typ.members[i]
                 sub_type = s_member if isinstance(s_member, NodeType) else s_member.typ
-                if type(sub_type) is not type(ret_x):
+                if sub_type != ret_x:
                     raise StructureException(
                         "Tuple return type does not match annotated return. {} != {}".format(
-                            type(sub_type), type(ret_x)
+                            repr(sub_type), repr(ret_x)
                         ),
                         self.stmt
                     )

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -69,7 +69,13 @@ class BaseType(NodeType):
         self.is_literal = is_literal
 
     def eq(self, other):
-        return self.typ == other.typ and self.unit == other.unit and self.positional == other.positional
+        units_are_empty = not bool(self.unit) and not bool(other.unit)
+
+        return (
+            self.typ == other.typ and
+            (self.unit == other.unit or units_are_empty) and
+            self.positional == other.positional
+        )
 
     def __repr__(self):
         subs = []


### PR DESCRIPTION
### - What I did

Fixed #1006 .

### - How I did it

Updated code in `Stmt.parse_return`.

### - How to verify it

Run the tests.

### - Description for the changelog

An issue with type checking of tuple types in return statements, which caused type checking to erroneously pass in certain cases, was fixed.

### - Cute Animal Picture

![Cute animal picture](http://4.bp.blogspot.com/_sfxFdXGVSTQ/TRyr-tzB-jI/AAAAAAAADkY/5OUQ8ISBPEc/s1600/panda.jpg)
