### PR TITLE
Resolve issue #1043

### DIFF
--- a/tests/parser/exceptions/test_invalid_same_variable_assignment.py
+++ b/tests/parser/exceptions/test_invalid_same_variable_assignment.py
@@ -1,0 +1,49 @@
+import pytest
+from pytest import raises
+
+from vyper import compiler
+from vyper.exceptions import VariableDeclarationException
+
+fail_list = [
+  """
+@public
+def test1(b: uint256) -> uint256:
+    a: uint256 = a + b
+    return a
+  """,
+  """
+@public
+def test2(b: uint256, c: uint256) -> uint256:
+    a: uint256 = a + b + c
+  """,
+  """
+@public
+def test3(b: uint256, c: uint256) -> uint256:
+    a: uint256 = - a
+    return a
+  """,
+  """
+@public
+def test4(b: bool) -> bool:
+    a: bool = b or a
+    return a
+  """,
+  """
+@public
+def test5(b: bool) -> bool:
+    a: bool = a != b
+    return a
+  """,
+  """
+@public
+def test6(b:bool, c: bool) -> bool:
+    a: bool = (a and b) and c
+    return a
+  """
+]
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_invalid_type_exception(bad_code):
+    with raises(VariableDeclarationException):
+        compiler.compile(bad_code)
+


### PR DESCRIPTION
### - What I did
- Update parser to raise `VariableDeclarationException` for same variable assignment issue `a = a +b ` #1043 

### - How I did it
- Added two functions to stmt.py `_check_same_variable_assign` and `_check_rhs_var_assn_recur`.
- Additional check `_check_same_variable_assign` will be run when `ann_assign` function is called in the parser.
### - How to verify it
- pytests tests/parser/exceptions/test_invalid_same_variable_assignment.py
### - Description for the changelog
- None
### - Cute Animal Picture
![joey1](https://user-images.githubusercontent.com/26575376/47599605-3208ab80-d9e4-11e8-9bcb-9211eca54dd8.jpg)

