### PR TITLE
Documentation: Virtual environment without virtual env option

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -87,6 +87,12 @@ To create a new virtual environment for Vyper run the following commands:
 To find out more about virtual environments, check out:
 `virtualenv guide <https://virtualenv.pypa.io/en/stable/>`_.
 
+
+You can also create a virtual environment without virtualenv:
+::
+   python3.6 -m venv vyper-env
+   source ~/vyper-env/bin/activate
+
 ************
 Installation
 ************


### PR DESCRIPTION
### - What I did
Added documentation to specify another way to create virtual environments
### - How I did it
Added a few lines to the "Installing Vyper" section of the documentation
### - How to verify it
While installing vyper, use the given option to create a virtual environment.
### - Description for the changelog
None.
### - Cute Animal Picture
![cute-baby-pig](https://user-images.githubusercontent.com/395294/47679244-31197a80-db9a-11e8-98cf-afae4e8461ec.jpg)

