### PR TITLE
Fixing documentation formatting for unit types

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -252,25 +252,25 @@ Unit Types
 Vyper allows the definition of types with discrete units e.g. meters, seconds, wei, ... . These types may only be based on either ``uint256``, ``int128`` or ``decimal``.
 Vyper has 3 unit types built in, which are the following:
 
-=============  =====  =========  ==========================
 Time
 -----------------------------------------------------------
-Keyword        Unit   Base type  Description
-=============  =====  =========  ==========================
-``timestamp``  1 sec  ``uint256``    This represents a point in time.
-``timedelta``  1 sec  ``uint256``    This is a number of seconds.
-=============  =====  =========  ==========================
+=============  =====  ===========  ==========================
+Keyword        Unit   Base type    Description
+=============  =====  ===========  ==========================
+``timestamp``  1 sec  ``uint256``  This represents a point in time.
+``timedelta``  1 sec  ``uint256``  This is a number of seconds.
+=============  =====  ===========  ==========================
 
 .. note::
     Two ``timedelta`` can be added together, as can a ``timedelta`` and a ``timestamp``, but not two ``timestamps``.
 
-===================  ===========  =========  ====================================================================================
 Wei
 ---------------------------------------------------------------------------------------------------------------------------------
-Keyword              Unit         Base type  Description
-===================  ===========  =========  ====================================================================================
+===================  ===========  ===========  ====================================================================================
+Keyword              Unit         Base type    Description
+===================  ===========  ===========  ====================================================================================
 ``wei_value``        1 wei        ``uint256``    This is an amount of `Ether <http://ethdocs.org/en/latest/ether.html#denominations>`_ in wei.
-===================  ===========  =========  ====================================================================================
+===================  ===========  ===========  ====================================================================================
 
 Custom Unit Types
 =================
@@ -278,7 +278,6 @@ Custom Unit Types
 Vyper allows you to add additional not-provided unit label to either ``uint256``, ``int128`` or ``decimal``.
 
 **Custom units example:**
-
 ::
   # specify units used in the contract.
   units: {


### PR DESCRIPTION
### - What I did
Tables containing unit types in the docs are currently not [displaying](https://vyper.readthedocs.io/en/latest/types.html#unit-types), so I fixed it.

### - How I did it
Updated formatting so it would render properly.

### - How to verify it
Screenshot [here](https://imgur.com/a/P8VMG2K).

### - Description for the changelog
Minor update to unit type docs to display tables.

### - Cute Animal Picture
![hello 20world](https://user-images.githubusercontent.com/6132167/47760837-9e0d3d00-dc8c-11e8-8639-dd5527a1bb02.jpg)