### PR TITLE
Change doc due to the changes on #1042

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -114,7 +114,7 @@ Values
 Integer values between 0 and (2\ :sup:`256`-1).
 
 .. note::
-    Integer literals are interpreted as ``int128`` by default. In cases where ``uint256`` is more appropriate, such as assignment, the literal might be interpreted as ``uint256``. Example: ``_variable: uint256 = _literal``. In order to explicitly cast a literal to a ``uint256`` use ``convert(_literal, 'uint256')``.
+    Integer literals are interpreted as ``int128`` by default. In cases where ``uint256`` is more appropriate, such as assignment, the literal might be interpreted as ``uint256``. Example: ``_variable: uint256 = _literal``. In order to explicitly cast a literal to a ``uint256`` use ``convert(_literal, uint256)``.
 
 Operators
 ---------


### PR DESCRIPTION
#1042 has changed the convert function to include type as itself.

### - What I did
I changed the doc's content

### - How I did it
I removed '' from the argument for destination of ``convert()``

### - How to verify it

Check #1042 


### - Cute Animal Picture

![](https://i.imgur.com/Jvh1OQm.jpg)