### PR TITLE
Correct typos ✔️

### DIFF
--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -32,21 +32,21 @@ def test_bid(w3, tester, auction_contract, assert_tx_failed):
     assert_tx_failed(lambda: auction_contract.bid(transact={"value": 0, "from": k1}))
     # Bidder can bid
     auction_contract.bid(transact={"value": 1, "from": k1})
-    # Check that higest bidder and highest bid have changed accordingly
+    # Check that highest bidder and highest bid have changed accordingly
     assert auction_contract.highestBidder() == k1
     assert auction_contract.highestBid() == 1
     # Bidder bid cannot equal current highest bid
     assert_tx_failed(lambda: auction_contract.bid(transact={"value": 0, "from": k1}))
     # Higher bid can replace current highest bid
     auction_contract.bid(transact={"value": 2, "from": k2})
-    # Check that higest bidder and highest bid have changed accordingly
+    # Check that highest bidder and highest bid have changed accordingly
     assert auction_contract.highestBidder() == k2
     assert auction_contract.highestBid() == 2
     # Multiple bidders can bid
     auction_contract.bid(transact={"value": 3, "from": k3})
     auction_contract.bid(transact={"value": 4, "from": k4})
     auction_contract.bid(transact={"value": 5, "from": k5})
-    # Check that higest bidder and highest bid have changed accordingly
+    # Check that highest bidder and highest bid have changed accordingly
     assert auction_contract.highestBidder() == k5
     assert auction_contract.highestBid() == 5
     auction_contract.bid(transact={"value": 1 * 10**10, "from": k1})

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -172,7 +172,7 @@ def concat(expr, context):
             elif arg.location == "storage":
                 length = LLLnode.from_list(['sload', ['sha3_32', '_arg']], typ=BaseType('int128'))
                 argstart = LLLnode.from_list(['add', ['sha3_32', '_arg'], 1], typ=arg.typ, location=arg.location)
-            # Make a copier to copy over data from that argyument
+            # Make a copier to copy over data from that argument
             seq.append(['with', '_arg', arg,
                             ['seq',
                                 make_byte_slice_copier(placeholder_node_plus_32,

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -45,7 +45,7 @@ class Context():
         self.function_return_count = 0
         # Current block scope
         self.blockscopes = set()
-        # In assignment. Whether expressiong is currently evaluating an assignment expression.
+        # In assignment. Whether expression is currently evaluating an assignment expression.
         self.in_assignment = False
         # List of custom units that have been defined.
         self.custom_units = global_ctx._custom_units


### PR DESCRIPTION
### - What I did

I corrected a small typo that I saw in a comment in 
/functions/functions.py. 
1 x (argyument -> argument)

/tests/examples/auctions/test_simple_open_auction.py
3 x (higest-> highest)

/parser/context.py
1x (expressiong -> expression)