### PR TITLE
Allow conversion from bytes to address

### DIFF
--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -4,6 +4,32 @@ from vyper.exceptions import (
 )
 
 
+def test_address_bytes_converstion(get_contract_with_gas_estimation):
+    # Shared values for test addresses and bytes
+    test_address = "0xF5D4020dCA6a62bB1efFcC9212AAF3c9819E30D7"
+    test_bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xF5\xD4\x02\x0d\xCA\x6a\x62\xbB\x1e\xfF\xcC\x92\x12\xAA\xF3\xc9\x81\x9E\x30\xD7"
+
+    # This block tests conversion from address to bytes
+    test_address_to_bytes = """
+@public
+def test_address_to_bytes(x: address) -> bytes32:
+    return convert(x, bytes32)
+    """
+
+    c = get_contract_with_gas_estimation(test_address_to_bytes)
+    assert c.test_address_to_bytes(test_address) == test_bytes
+
+    # This block tests conversion from bytes to address
+    test_bytes_to_address = """
+@public
+def test_bytes_to_address(x: bytes32) -> address:
+    return convert(x, address)
+    """
+
+    c = get_contract_with_gas_estimation(test_bytes_to_address)
+    assert c.test_bytes_to_address(test_bytes) == test_address
+
+
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
     test_bytes = """
 @public

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -103,6 +103,13 @@ def to_bytes32(expr, args, kwargs, context):
         return LLLnode(value=in_arg.value, args=in_arg.args, typ=BaseType('bytes32'), pos=getpos(expr))
 
 
+@signature(('bytes32'), '*')
+def to_address(expr, args, kwargs, context):
+    in_arg = args[0]
+
+    return LLLnode(value=in_arg.value, args=in_arg.args, typ=BaseType('address'), pos=getpos(expr))
+
+
 def convert(expr, context):
 
     if isinstance(expr.args[1], ast.Str):
@@ -128,4 +135,5 @@ conversion_table = {
     'uint256': to_uint256,
     'decimal': to_decimal,
     'bytes32': to_bytes32,
+    'address': to_address,
 }


### PR DESCRIPTION
### - What I did

Fixes #1074

### - How I did it

Updated `convert.py` to allow for conversion from bytes to address. Added tests to `test_bytes.py` to test both the existing functionality of converting from address to bytes and also test new functionality of converting from bytes to address.

### - How to verify it

`make test`

### - Description for the changelog

Added functionality to allow conversion from bytes to address.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/48446785-72438a00-e757-11e8-9c83-c650095d21c3.png)

