### PR TITLE
Do not allow conversion from bytes array > 32 to int128 at compile time

### DIFF
--- a/tests/parser/functions/test_convert_int128.py
+++ b/tests/parser/functions/test_convert_int128.py
@@ -49,6 +49,7 @@ def foobar() -> int128:
         InvalidLiteralException
     )
 
+
 def test_convert_from_bool(get_contract_with_gas_estimation):
     code = """
 @public

--- a/tests/parser/functions/test_convert_int128.py
+++ b/tests/parser/functions/test_convert_int128.py
@@ -1,3 +1,53 @@
+from vyper.exceptions import (
+    InvalidLiteralException
+)
+
+
+def test_convert_bytes_to_int128(assert_compile_failed, get_contract_with_gas_estimation):
+    # Test valid bytes input for conversion
+    test_success = """
+@public
+def foo(bar: bytes[5]) -> int128:
+    return convert(bar, int128)
+    """
+
+    c = get_contract_with_gas_estimation(test_success)
+    assert c.foo(b'\x00\x00\x00\x00\x00') == 0
+    assert c.foo(b'\x00\x07\x5B\xCD\x15') == 123456789
+
+    test_success = """
+@public
+def foo(bar: bytes[32]) -> int128:
+    return convert(bar, int128)
+    """
+
+    c = get_contract_with_gas_estimation(test_success)
+    assert c.foo(b'\x00' * 32) == 0
+    assert c.foo(b'\xff' * 32) == -1
+
+    # Test overflow bytes input for conversion
+    test_fail = """
+@public
+def foo(bar: bytes[33]) -> int128:
+    return convert(bar, int128)
+    """
+
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(test_fail),
+        InvalidLiteralException
+    )
+
+    test_fail = """
+@public
+def foobar() -> int128:
+    barfoo: bytes[63] = "Hello darkness, my old friend I've come to talk with you again."
+    return convert(barfoo, int128)
+    """
+
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(test_fail),
+        InvalidLiteralException
+    )
 
 
 def test_convert_bytes32_to_num_overflow(assert_tx_failed, get_contract_with_gas_estimation):

--- a/tests/parser/types/numbers/test_int128.py
+++ b/tests/parser/types/numbers/test_int128.py
@@ -5,53 +5,6 @@ from vyper.exceptions import (
 from decimal import Decimal
 
 
-def test_convert_bytes_to_int128(assert_compile_failed, get_contract_with_gas_estimation):
-    # Test valid bytes input for conversion
-    test_success = """
-@public
-def foo(bar: bytes[5]) -> int128:
-    return convert(bar, int128)
-    """
-
-    c = get_contract_with_gas_estimation(test_success)
-    assert c.foo(b'\x00\x00\x00\x00\x00') == 0
-    assert c.foo(b'\x00\x07\x5B\xCD\x15') == 123456789
-
-    test_success = """
-@public
-def foo(bar: bytes[32]) -> int128:
-    return convert(bar, int128)
-    """
-
-    c = get_contract_with_gas_estimation(test_success)
-    assert c.foo(b'\x00' * 32) == 0
-    assert c.foo(b'\xff' * 32) == -1
-
-    # Test overflow bytes input for conversion
-    test_fail = """
-@public
-def foo(bar: bytes[33]) -> int128:
-    return convert(bar, int128)
-    """
-
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(test_fail),
-        InvalidLiteralException
-    )
-
-    test_fail = """
-@public
-def foobar() -> int128:
-    barfoo: bytes[63] = "Hello darkness, my old friend I've come to talk with you again."
-    return convert(barfoo, int128)
-    """
-
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(test_fail),
-        InvalidLiteralException
-    )
-
-
 def test_exponents_with_nums(get_contract_with_gas_estimation):
     exp_code = """
 @public

--- a/tests/parser/types/numbers/test_int128.py
+++ b/tests/parser/types/numbers/test_int128.py
@@ -1,4 +1,7 @@
-from vyper.exceptions import TypeMismatchException, InvalidLiteralException
+from vyper.exceptions import (
+    TypeMismatchException,
+    InvalidLiteralException
+)
 from decimal import Decimal
 
 
@@ -14,10 +17,20 @@ def foo(bar: bytes[5]) -> int128:
     assert c.foo(b'\x00\x00\x00\x00\x00') == 0
     assert c.foo(b'\x00\x07\x5B\xCD\x15') == 123456789
 
+    test_success = """
+@public
+def foo(bar: bytes[32]) -> int128:
+    return convert(bar, int128)
+    """
+
+    c = get_contract_with_gas_estimation(test_success)
+    assert c.foo(b'\x00' * 32) == 0
+    assert c.foo(b'\xff' * 32) == -1
+
     # Test overflow bytes input for conversion
     test_fail = """
 @public
-def foo(bar: bytes[40]) -> int128:
+def foo(bar: bytes[33]) -> int128:
     return convert(bar, int128)
     """
 

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -38,13 +38,13 @@ def to_int128(expr, args, kwargs, context):
             ['clamp', ['mload', MemoryPositions.MINNUM], in_node,
                         ['mload', MemoryPositions.MAXNUM]], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)
         )
-    
+
     elif input_type is 'bytes':
         if in_node.typ.maxlen > 32:
             raise InvalidLiteralException("Cannot convert bytes array of max length {} to int128".format(in_node.value), expr)
-        return byte_array_to_num(in_node, expr, 'int128')      
-          
-    elif typ is 'bool':
+        return byte_array_to_num(in_node, expr, 'int128')
+
+    elif input_type is 'bool':
         return LLLnode.from_list(
             ['clamp', ['mload', MemoryPositions.MINNUM], in_node,
                         ['mload', MemoryPositions.MAXNUM]], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -30,7 +30,7 @@ from vyper.utils import (
 @signature(('uint256', 'bytes32', 'bytes', 'bool'), '*')
 def to_int128(expr, args, kwargs, context):
     in_node = args[0]
-    input_type, len = get_type(in_node)
+    input_type, _ = get_type(in_node)
     if input_type in ('uint256', 'bytes32'):
         if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
@@ -57,7 +57,7 @@ def to_int128(expr, args, kwargs, context):
 @signature(('num_literal', 'int128', 'bytes32', 'address', 'bool'), '*')
 def to_uint256(expr, args, kwargs, context):
     in_node = args[0]
-    input_type, len = get_type(in_node)
+    input_type, _ = get_type(in_node)
 
     if isinstance(in_node, int):
         if not SizeLimits.in_bounds('uint256', in_node):


### PR DESCRIPTION
### - What I did

Related somewhat to conversation on #1082. Catch at compile-time if trying to convert `bytes` array of max length greater than 32 to `int128` type.

### - How I did it

Updated `convert.py` to do a check on max length when converting from bytes type (my understanding as to why `SizeLimits.in_bounds()` doesn't work for `bytes` type is that it is being passed by reference not by value?).

Added relevant tests to `test_int128.py`

### - How to verify it

`make test`

### - Description for the changelog

Patch to prevent conversion from bytes array greater than 32 bytes to int128.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/48565708-6cb08600-e8b6-11e8-9217-8a6b2927f088.png)

