### PR TITLE
Fix bug with convert(2**256 - 1, int128)

### DIFF
--- a/tests/parser/functions/test_convert_int128.py
+++ b/tests/parser/functions/test_convert_int128.py
@@ -63,6 +63,54 @@ def from_bool(flag: bool) -> int128:
     assert c.from_bool(True) == 1
 
 
+def test_convert_from_uint256(get_contract_with_gas_estimation):
+    code = """
+@public
+def test(foo: uint256) -> int128:
+    return convert(foo, int128)
+    """
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.test(0) == 0
+    assert c.test(2**127 - 1) == 2**127 - 1
+
+
+def test_out_of_range_from_uint256(assert_tx_failed, get_contract_with_gas_estimation):
+    code = """
+@public
+def test(foo: uint256) -> int128:
+    return convert(foo, int128)
+    """
+
+    c = get_contract_with_gas_estimation(code)
+    assert_tx_failed(lambda: c.test(2**127))
+    assert_tx_failed(lambda: c.test(2**256 - 1))
+
+
+def test_out_of_range_from_uint256_at_compile(assert_compile_failed, get_contract_with_gas_estimation):
+    code = """
+@public
+def test() -> int128:
+    return convert(2**127, int128)
+    """
+
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code),
+        InvalidLiteralException
+    )
+
+    code = """
+@public
+def test() -> int128:
+    return convert(2**256 - 1, int128)
+    """
+
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code),
+        InvalidLiteralException
+    )
+
+
 def test_convert_bytes32_to_num_overflow(assert_tx_failed, get_contract_with_gas_estimation):
     code = """
 @public

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -31,7 +31,7 @@ from vyper.utils import (
 def to_int128(expr, args, kwargs, context):
     in_node = args[0]
     input_type, _ = get_type(in_node)
-    if input_type in ('uint256', 'bytes32'):
+    if input_type is 'bytes32':
         if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
         return LLLnode.from_list(
@@ -43,6 +43,13 @@ def to_int128(expr, args, kwargs, context):
         if in_node.typ.maxlen > 32:
             raise InvalidLiteralException("Cannot convert bytes array of max length {} to int128".format(in_node.value), expr)
         return byte_array_to_num(in_node, expr, 'int128')
+
+    elif input_type is 'uint256':
+        if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
+            raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
+        return LLLnode.from_list(
+            ['uclample', in_node, SizeLimits.MAXNUM], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)
+        )
 
     elif input_type is 'bool':
         return LLLnode.from_list(

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -31,7 +31,7 @@ from vyper.utils import (
 def to_int128(expr, args, kwargs, context):
     in_node = args[0]
     input_type, _ = get_type(in_node)
-    if input_type is 'bytes32':
+    if input_type == 'bytes32':
         if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
         return LLLnode.from_list(
@@ -39,19 +39,19 @@ def to_int128(expr, args, kwargs, context):
                         ['mload', MemoryPositions.MAXNUM]], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)
         )
 
-    elif input_type is 'bytes':
+    elif input_type == 'bytes':
         if in_node.typ.maxlen > 32:
             raise InvalidLiteralException("Cannot convert bytes array of max length {} to int128".format(in_node.value), expr)
         return byte_array_to_num(in_node, expr, 'int128')
 
-    elif input_type is 'uint256':
+    elif input_type == 'uint256':
         if in_node.typ.is_literal and not SizeLimits.in_bounds('int128', in_node.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_node.value), expr)
         return LLLnode.from_list(
             ['uclample', in_node, SizeLimits.MAXNUM], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)
         )
 
-    elif input_type is 'bool':
+    elif input_type == 'bool':
         return LLLnode.from_list(
             ['clamp', ['mload', MemoryPositions.MINNUM], in_node,
                         ['mload', MemoryPositions.MAXNUM]], typ=BaseType('int128', in_node.typ.unit), pos=getpos(expr)
@@ -79,7 +79,7 @@ def to_uint256(expr, args, kwargs, context):
     elif isinstance(in_node, LLLnode) and input_type in ('bytes32', 'address'):
         return LLLnode(value=in_node.value, args=in_node.args, typ=BaseType('uint256'), pos=getpos(expr))
 
-    elif isinstance(in_node, LLLnode) and input_type is 'bytes':
+    elif isinstance(in_node, LLLnode) and input_type == 'bytes':
         if in_node.typ.maxlen > 32:
             raise InvalidLiteralException("Cannot convert bytes array of max length {} to uint256".format(in_node.value), expr)
         return byte_array_to_num(in_node, expr, 'uint256')


### PR DESCRIPTION
### - What I did

In the process of starting work on a better spec-ed table of expected conversion outcomes per @fubuloubu and I's conversation on #1072, I noticed some pretty strange behavior that allowed for converting from _some_ uint256 that were outside of the maximum allowed range for `int128`.

More specifically I found that when running this test:

```python
def test_convert_from_uint256(get_contract_with_gas_estimation):
    code = """
@public
def test(foo: uint256) -> int128:
    return convert(foo, int128)
    """

    c = get_contract_with_gas_estimation(code)
    assert c.test(0) == 0
    assert c.test(2**127 - 1) == 2**127 - 1

    assert c.test(2**256 - 1) == -1 # FIXME: This line I expected to throw a runtime exception but didn't.
    assert c.test(2**127) # FIXME: Whereas this line through the expected runtime exception.
```

Can open an issue if necessary, though I think this PR may just serve as both the issue and the solution to the issue 😅 

### - How I did it

Changed psuedo-op code being used on convert to do a clamp between 0 and maximum unsigned integer.

### - How to verify it

Review the tests added to `test_convert_int128.py` and run `make test`

### - Description for the changelog

Fixed bug that allowed `convert(2**256 -1, int128)`

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/48666395-3160b380-ea7e-11e8-86aa-b9be5311a29a.png)
