### PR TITLE
Support BoolOps for > 2 arguments

### DIFF
--- a/tests/parser/syntax/test_bool_ops.py
+++ b/tests/parser/syntax/test_bool_ops.py
@@ -18,6 +18,6 @@ def foobar() -> bool:
     """
 
     c = get_contract_with_gas_estimation(code)
-    assert c.foo() == False
-    assert c.bar() == True
-    assert c.foobar() == False
+    assert c.foo() is False
+    assert c.bar() is True
+    assert c.foobar() is False

--- a/tests/parser/syntax/test_bool_ops.py
+++ b/tests/parser/syntax/test_bool_ops.py
@@ -1,0 +1,23 @@
+
+def test_convert_from_bool(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> bool:
+    val: bool = True and True and False
+    return val
+
+@public
+def bar() -> bool:
+    val: bool = True or True or False
+    return val
+
+@public
+def foobar() -> bool:
+    val: bool = False and True or False
+    return val
+    """
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == False
+    assert c.bar() == True
+    assert c.foobar() == False

--- a/tests/parser/syntax/test_bool_ops.py
+++ b/tests/parser/syntax/test_bool_ops.py
@@ -15,9 +15,27 @@ def bar() -> bool:
 def foobar() -> bool:
     val: bool = False and True or False
     return val
+
+@public
+def oof() -> bool:
+    val: bool = False and True or False and True or False and False or True
+    return val
+
+@public
+def rab() -> bool:
+    val: bool = False and True or False and True or False and False
+    return val
+
+@public
+def oofrab() -> bool:
+    val: bool = True or False and True or False and False
+    return val
     """
 
     c = get_contract_with_gas_estimation(code)
     assert c.foo() is False
     assert c.bar() is True
     assert c.foobar() is False
+    assert c.oof() is True
+    assert c.rab() is False
+    assert c.oofrab() is True

--- a/tests/parser/syntax/test_bool_ops.py
+++ b/tests/parser/syntax/test_bool_ops.py
@@ -18,17 +18,17 @@ def foobar() -> bool:
 
 @public
 def oof() -> bool:
-    val: bool = False and True or False and True or False and False or True
+    val: bool = False or False or False or False or False or True
     return val
 
 @public
 def rab() -> bool:
-    val: bool = False and True or False and True or False and False
+    val: bool = True and True and True and True and True and False
     return val
 
 @public
 def oofrab() -> bool:
-    val: bool = True or False and True or False and False
+    val: bool = False and True or False and True or False and False or True
     return val
     """
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -586,22 +586,47 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             raise TypeMismatchException("Unsupported types for comparison: %r %r" % (left_type, right_type), self.expr)
 
     def boolean_operations(self):
-        if len(self.expr.values) != 2:
-            raise StructureException("Expected two arguments for a bool op", self.expr)
-        if self.context.in_assignment and (isinstance(self.expr.values[0], ast.Call) or isinstance(self.expr.values[1], ast.Call)):
-            raise StructureException("Boolean operations with calls may not be performed on assignment", self.expr)
+        # Iterate through values
+        for value in self.expr.values:
+            # Check for calls at assignment
+            if self.context.in_assignment and isinstance(value, ast.Call):
+                raise StructureException("Boolean operations with calls may not be performed on assignment", self.expr)
 
-        left = Expr.parse_value_expr(self.expr.values[0], self.context)
-        right = Expr.parse_value_expr(self.expr.values[1], self.context)
-        if not is_base_type(left.typ, 'bool') or not is_base_type(right.typ, 'bool'):
-            raise TypeMismatchException("Boolean operations can only be between booleans!", self.expr)
+            # Check for boolean operations with non-boolean inputs
+            _expr = Expr.parse_value_expr(value, self.context)
+            if not is_base_type(_expr.typ, 'bool'):
+                raise TypeMismatchException("Boolean operations can only be between booleans!", self.expr)
+
+            # TODO: Handle special case of literals and simplify at compile time
+
+        # Check for valid ops
         if isinstance(self.expr.op, ast.And):
             op = 'and'
         elif isinstance(self.expr.op, ast.Or):
             op = 'or'
         else:
             raise Exception("Unsupported bool op: " + self.expr.op)
-        return LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
+
+        # Handle different numbers of inputs
+        count = len(self.expr.values)
+        if count < 2:
+            raise StructureException("Expected at least two arguments for a bool op", self.expr)
+        elif count == 2:
+            left = Expr.parse_value_expr(self.expr.values[0], self.context)
+            right = Expr.parse_value_expr(self.expr.values[1], self.context)
+            return LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
+        else:
+            left = Expr.parse_value_expr(self.expr.values[0], self.context)
+            right = Expr.parse_value_expr(self.expr.values[1], self.context)
+
+            p = ['seq', [op, left, right]]
+            values = self.expr.values[2:]
+            while len(values) > 0:
+                value = Expr.parse_value_expr(values[0], self.context)
+                p = [op, value, p]
+                values = values[1:]
+
+            return LLLnode.from_list(p, typ='bool', pos=getpos(self.expr))
 
     # Unary operations (only "not" supported)
     def unary_operations(self):


### PR DESCRIPTION
### - What I did

Implemented support for BoolOps with greater than two arguments. Closes #1075 

### - How I did it

Made sure all expressions in [BoolOps `values`](https://docs.python.org/3.7/library/ast.html#abstract-grammar) were iterated through and handled.

### - How to verify it

Review test file `test_bool_ops.py` and run `make test`.

### - Description for the changelog

Add support for BoolOps with greater than two arguments

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/48888567-5d6a9480-edf0-11e8-95e4-80a5a3799bba.png)
