### PR TITLE
Update ERC721 token

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -291,14 +291,14 @@ def setApprovalForAll(_operator: address, _approved: bool):
 ### MINT & BURN FUNCTIONS ###
 
 # @dev Function to mint tokens
-#      Throws if `msg.sender`` is not the minter.
+#      Throws if `msg.sender` is not the minter.
 #      Throws if `_to` is zero address.
 # @param to The address that will receive the minted tokens.
 # @param tokenId The token id to mint.
 # @return A boolean that indicates if the operation was successful.
 @public
 def mint(_to: address, _tokenId: uint256) -> bool:
-    # Throws if `msg.sender`` is not the minter
+    # Throws if `msg.sender` is not the minter
     assert msg.sender == self.minter
     # Throws if `_to` is zero address
     assert _to != ZERO_ADDRESS

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -153,10 +153,10 @@ def _isApprovedOrOwner(_spender: address, _tokenId: uint256) -> bool:
 
 
 # @dev Add a NFT to a given address
-#      Throws if `_tokenId` is not a valid NFT.
+#      Throws if `_tokenId` is owned by someone.
 @private
 def _addTokenTo(_to: address, _tokenId: uint256):
-    # Throws if `_tokenId` is not a valid NFT
+    # Throws if `_tokenId` is owned by someone
     assert self.idToOwner[_tokenId] == ZERO_ADDRESS
     # Change the owner
     self.idToOwner[_tokenId] = _to
@@ -201,9 +201,9 @@ def _transferFrom(_from: address, _to: address, _tokenId: uint256, _sender: addr
     assert _to != ZERO_ADDRESS
     # Clear approval. Throws if `_from` is not the current owner
     self._clearApproval(_from, _tokenId)
-    # Remove NFT
+    # Remove NFT. Throws if `_tokenId` is not a valid NFT
     self._removeTokenFrom(_from, _tokenId)
-    # Add NFT and throws if `_tokenId` is not a valid NFT
+    # Add NFT
     self._addTokenTo(_to, _tokenId)
     # Log the transfer
     log.Transfer(_from, _to, _tokenId)
@@ -293,6 +293,7 @@ def setApprovalForAll(_operator: address, _approved: bool):
 # @dev Function to mint tokens
 #      Throws if `msg.sender` is not the minter.
 #      Throws if `_to` is zero address.
+#      Throws if `_tokenId` is owned by someone.
 # @param to The address that will receive the minted tokens.
 # @param tokenId The token id to mint.
 # @return A boolean that indicates if the operation was successful.
@@ -302,6 +303,7 @@ def mint(_to: address, _tokenId: uint256) -> bool:
     assert msg.sender == self.minter
     # Throws if `_to` is zero address
     assert _to != ZERO_ADDRESS
+    # Add NFT. Throws if `_tokenId` is owned by someone
     self._addTokenTo(_to, _tokenId)
     log.Transfer(ZERO_ADDRESS, _to, _tokenId)
     return True

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -252,7 +252,7 @@ def test_approve(c, w3, assert_tx_failed, get_logs):
 
     # approve token without ownership
     assert_tx_failed(lambda: c.approve(
-        operator, NEW_TOKEN_ID, transact={'from': someone}))
+        operator, OPERATOR_TOKEN_ID, transact={'from': someone}))
 
     # approve invalid token
     assert_tx_failed(lambda: c.approve(

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -1,121 +1,224 @@
 import pytest
 
-
-IDS = range(1, 65)
+SOMEONE_TOKEN_IDS = [1, 2, 3]
+OPERATOR_TOKEN_ID = 10
+NEW_TOKEN_ID = 20
+INVALID_TOKEN_ID = 99
+ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+ERC165_INTERFACE_ID = '0x0000000000000000000000000000000000000000000000000000000001ffc9a7'
+ERC721_INTERFACE_ID = '0x0000000000000000000000000000000000000000000000000000000080ac58cd'
+INVALID_INTERFACE_ID = '0x0000000000000000000000000000000000000000000000000000000012345678'
 
 
 @pytest.fixture
 def c(get_contract, w3):
-    # a0, a1 own 1 token each
-    owners = w3.eth.accounts[:3]
-    # a2 owns 2 tokens
-    owners.append(w3.eth.accounts[2])
-    # a3 owns the rest
-    owners.extend([w3.eth.accounts[3]] * 60)
     with open('examples/tokens/ERC721.vy') as f:
-        return get_contract(
-            f.read(),
-            owners, IDS
-        )
+        code = f.read()
+    c = get_contract(code)
+    minter, someone, operator = w3.eth.accounts[:3]
+    # someone owns 3 tokens
+    for i in SOMEONE_TOKEN_IDS:
+        c.mint(someone, i, transact={'from': minter})
+    # operator owns 1 tokens
+    c.mint(operator, OPERATOR_TOKEN_ID, transact={'from': minter})
+    return c
 
 
-def test_balanceOf(c, w3):
-    a0, a1, a2, a3, a4 = w3.eth.accounts[:5]
-    # Correctly lists balances
-    assert c.balanceOf(a0) == 1
-    assert c.balanceOf(a1) == 1
-    assert c.balanceOf(a2) == 2
-    assert c.balanceOf(a3) == 60
-    # Correctly reports account with no balance
-    assert c.balanceOf(a4) == 0
+def test_supportsInterface(c, assert_tx_failed):
+    assert c.supportsInterface(ERC165_INTERFACE_ID) == True
+    assert c.supportsInterface(ERC721_INTERFACE_ID) == True
+    assert c.supportsInterface(INVALID_INTERFACE_ID) == False
+
+
+def test_balanceOf(c, w3, assert_tx_failed):
+    someone = w3.eth.accounts[1]
+    assert c.balanceOf(someone) == 3
+    assert_tx_failed(lambda: c.balanceOf(ZERO_ADDRESS))
 
 
 def test_ownerOf(c, w3, assert_tx_failed):
-    a0, a1, a2, a3 = w3.eth.accounts[:4]
-    # Correctly finds ownership
-    assert c.ownerOf(IDS[0]) == a0
-    assert c.ownerOf(IDS[1]) == a1
-    assert c.ownerOf(IDS[2]) == a2
-    assert c.ownerOf(IDS[3]) == a2
-    for _id in IDS[4:]:
-        assert c.ownerOf(_id) == a3
-    # Reverts for non-existant ID
-    assert_tx_failed(lambda: c.ownerOf(99))
+    someone = w3.eth.accounts[1]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[0]) == someone
+    assert_tx_failed(lambda: c.ownerOf(INVALID_TOKEN_ID))
 
 
-def test_approve(w3, c, assert_tx_failed):
-    a0, a1, a2 = w3.eth.accounts[:3]
-    # Approval can be given and taken away
-    assert c.getApproved(IDS[0]) != a1
-    c.approve(a1, IDS[0], transact={'from': a0})
-    assert c.getApproved(IDS[0]) == a1
-    c.approve(a2, IDS[0], transact={'from': a0})
-    assert c.getApproved(IDS[0]) != a1
-    # Can't approve something you don't own
-    assert_tx_failed(lambda: c.approve(a1, IDS[1], transact={'from': a0}))
+def test_getApproved(c, w3, assert_tx_failed):
+    someone, operator = w3.eth.accounts[1:3]
+
+    assert c.getApproved(SOMEONE_TOKEN_IDS[0]) is None
+
+    c.approve(operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+
+    assert c.getApproved(SOMEONE_TOKEN_IDS[0]) == operator
 
 
-def test_approveAll(w3, c):
-    a0, a1 = w3.eth.accounts[:2]
+def test_isApprovedForAll(c, w3):
+    someone, operator = w3.eth.accounts[1:3]
 
-    assert not c.isApprovedForAll(a0, a1)
-    c.setApprovalForAll(a1, True, transact={'from': a0})
-    assert c.isApprovedForAll(a0, a1)
-    c.setApprovalForAll(a1, False, transact={'from': a0})
-    assert not c.isApprovedForAll(a0, a1)
+    assert c.isApprovedForAll(someone, operator) == False
 
+    c.setApprovalForAll(operator, True,  transact={'from': someone})
 
-def test_owner_transferFrom(w3, c, assert_tx_failed):
-    a0, a1 = w3.eth.accounts[:2]
-
-    # Basic transfer.
-    c.transferFrom(a0, a1, IDS[0], transact={'from': a0})
-    assert c.balanceOf(a0) == 0
-    assert c.balanceOf(a1) == 2
-
-    # Can't transfer one you don't own
-    assert_tx_failed(lambda: c.transferFrom(a0, a1, IDS[0], transact={'from': a0}))
+    assert c.isApprovedForAll(someone, operator) == True
 
 
-def test_approve_transferFrom(w3, c, assert_tx_failed):
-    a0, a1, a2 = w3.eth.accounts[:3]
+def test_transferFrom_by_owner(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
 
-    # Approved transfer
-    c.approve(a2, IDS[0], transact={'from': a0})
-    c.transferFrom(a0, a1, IDS[0], transact={'from': a2})
-    assert c.balanceOf(a0) == 0
-    assert c.balanceOf(a1) == 2
+    # transfer from zero address
+    assert_tx_failed(lambda: c.transferFrom(
+        ZERO_ADDRESS, operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # transfer to zero address
+    assert_tx_failed(lambda: c.transferFrom(
+        someone, ZERO_ADDRESS, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # transfer token without ownership
+    assert_tx_failed(lambda: c.transferFrom(
+        someone, operator, OPERATOR_TOKEN_ID, transact={'from': someone}))
+
+    # transfer invalid token
+    assert_tx_failed(lambda: c.transferFrom(
+        someone, operator, INVALID_TOKEN_ID, transact={'from': someone}))
+
+    # transfer by owner
+    tx_hash = c.transferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[0]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[0]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
 
 
-def test_operator_transferFrom(w3, c, assert_tx_failed):
-    a0, a1, a2 = w3.eth.accounts[:3]
+def test_transferFrom_by_approved(c, w3, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
 
-    # Approved transfer
-    c.setApprovalForAll(a2, True, transact={'from': a0})
-    c.transferFrom(a0, a1, IDS[0], transact={'from': a2})
-    assert c.balanceOf(a0) == 0
-    assert c.balanceOf(a1) == 2
+    # transfer by approved
+    c.approve(operator, SOMEONE_TOKEN_IDS[1], transact={'from': someone})
+    tx_hash = c.transferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[1], transact={'from': operator})
 
+    logs = get_logs(tx_hash, c, 'Transfer')
 
-def test_account_safeTransferFrom(w3, c, assert_tx_failed):
-    a0, a1 = w3.eth.accounts[:2]
-
-    # Basic transfer.
-    c.safeTransferFrom(a0, a1, IDS[0], transact={'from': a0})
-    assert c.balanceOf(a0) == 0
-    assert c.balanceOf(a1) == 2
-
-    # Can't transfer one you don't own
-    assert_tx_failed(lambda: c.safeTransferFrom(a0, a1, IDS[0], transact={'from': a0}))
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[1]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[1]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
 
 
-def test_contract_safeTransferFrom(w3, c, assert_tx_failed, get_contract):
-    a0, a1 = w3.eth.accounts[:2]
+def test_transferFrom_by_operator(c, w3, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # transfer by operator
+    c.setApprovalForAll(operator, True,  transact={'from': someone})
+    tx_hash = c.transferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[2], transact={'from': operator})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[2]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[2]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
+
+
+def test_safeTransferFrom_by_owner(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # transfer from zero address
+    assert_tx_failed(lambda: c.safeTransferFrom(
+        ZERO_ADDRESS, operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # transfer to zero address
+    assert_tx_failed(lambda: c.safeTransferFrom(
+        someone, ZERO_ADDRESS, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # transfer token without ownership
+    assert_tx_failed(lambda: c.safeTransferFrom(
+        someone, operator, OPERATOR_TOKEN_ID, transact={'from': someone}))
+
+    # transfer invalid token
+    assert_tx_failed(lambda: c.safeTransferFrom(
+        someone, operator, INVALID_TOKEN_ID, transact={'from': someone}))
+
+    # transfer by owner
+    tx_hash = c.safeTransferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[0]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[0]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
+
+
+def test_safeTransferFrom_by_approved(c, w3, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # transfer by approved
+    c.approve(operator, SOMEONE_TOKEN_IDS[1], transact={'from': someone})
+    tx_hash = c.safeTransferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[1], transact={'from': operator})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[1]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[1]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
+
+
+def test_safeTransferFrom_by_operator(c, w3, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # transfer by operator
+    c.setApprovalForAll(operator, True,  transact={'from': someone})
+    tx_hash = c.safeTransferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[2], transact={'from': operator})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[2]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[2]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
+
+
+def test_safeTransferFrom_to_contract(c, w3, assert_tx_failed, get_logs, get_contract):
+    someone = w3.eth.accounts[1]
 
     # Can't transfer to a contract that doesn't implement the receiver code
-    assert_tx_failed(lambda: c.safeTransferFrom(a0, c.address, IDS[0], transact={'from': a0}))
+    assert_tx_failed(lambda: c.safeTransferFrom(someone, c.address, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
 
-    # Only to an address that implements that function
+     # Only to an address that implements that function
     receiver = get_contract("""
 @public
 def onERC721Received(
@@ -126,4 +229,101 @@ def onERC721Received(
     ) -> bytes32:
     return method_id("onERC721Received(address,address,uint256,bytes)", bytes32)
     """)
-    c.safeTransferFrom(a0, receiver.address, IDS[0], transact={'from': a0})
+    tx_hash = c.safeTransferFrom(someone, receiver.address, SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == receiver.address
+    assert args._tokenId == SOMEONE_TOKEN_IDS[0]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[0]) == receiver.address
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(receiver.address) == 1
+
+
+def test_approve(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # approve myself
+    assert_tx_failed(lambda: c.approve(
+        someone, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # approve token without ownership
+    assert_tx_failed(lambda: c.approve(
+        operator, NEW_TOKEN_ID, transact={'from': someone}))
+
+    # approve invalid token
+    assert_tx_failed(lambda: c.approve(
+        operator, INVALID_TOKEN_ID, transact={'from': someone}))
+
+    tx_hash = c.approve(operator, SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+    logs = get_logs(tx_hash, c, 'Approval')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._owner == someone
+    assert args._approved == operator
+    assert args._tokenId == SOMEONE_TOKEN_IDS[0]
+
+
+def test_setApprovalForAll(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+    approved = True
+
+    # setApprovalForAll myself
+    assert_tx_failed(lambda: c.setApprovalForAll(
+        someone, approved, transact={'from': someone}))
+
+    tx_hash = c.setApprovalForAll(operator, True, transact={'from': someone})
+    logs = get_logs(tx_hash, c, 'ApprovalForAll')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._owner == someone
+    assert args._operator == operator
+    assert args._approved == approved
+
+
+def test_mint(c, w3, assert_tx_failed, get_logs):
+    minter, someone = w3.eth.accounts[:2]
+
+    # mint by non-minter
+    assert_tx_failed(lambda: c.mint(
+        someone, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
+
+    # mint to zero address
+    assert_tx_failed(lambda: c.mint(
+        ZERO_ADDRESS, SOMEONE_TOKEN_IDS[0], transact={'from': minter}))
+
+    # mint by minter
+    tx_hash = c.mint(someone, NEW_TOKEN_ID, transact={'from': minter})
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == ZERO_ADDRESS
+    assert args._to == someone
+    assert args._tokenId == NEW_TOKEN_ID
+    assert c.ownerOf(NEW_TOKEN_ID) == someone
+    assert c.balanceOf(someone) == 4
+
+
+def test_burn(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # burn token without ownership
+    assert_tx_failed(lambda: c.burn(SOMEONE_TOKEN_IDS[0], transact={'from': operator}))
+
+    # burn token by owner
+    tx_hash = c.burn(SOMEONE_TOKEN_IDS[0], transact={'from': someone})
+    logs = get_logs(tx_hash, c, 'Transfer')
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args._from == someone
+    assert args._to == ZERO_ADDRESS
+    assert args._tokenId == SOMEONE_TOKEN_IDS[0]
+    assert_tx_failed(lambda: c.ownerOf(SOMEONE_TOKEN_IDS[0]))
+    assert c.balanceOf(someone) == 2

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -276,7 +276,7 @@ def test_setApprovalForAll(c, w3, assert_tx_failed, get_logs):
     assert_tx_failed(lambda: c.setApprovalForAll(
         someone, approved, transact={'from': someone}))
 
-    tx_hash = c.setApprovalForAll(operator, True, transact={'from': someone})
+    tx_hash = c.setApprovalForAll(operator, approved, transact={'from': someone})
     logs = get_logs(tx_hash, c, 'ApprovalForAll')
 
     assert len(logs) > 0

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -25,9 +25,9 @@ def c(get_contract, w3):
 
 
 def test_supportsInterface(c, assert_tx_failed):
-    assert c.supportsInterface(ERC165_INTERFACE_ID) == True
-    assert c.supportsInterface(ERC721_INTERFACE_ID) == True
-    assert c.supportsInterface(INVALID_INTERFACE_ID) == False
+    assert c.supportsInterface(ERC165_INTERFACE_ID) == 1
+    assert c.supportsInterface(ERC721_INTERFACE_ID) == 1
+    assert c.supportsInterface(INVALID_INTERFACE_ID) == 0
 
 
 def test_balanceOf(c, w3, assert_tx_failed):
@@ -55,11 +55,11 @@ def test_getApproved(c, w3, assert_tx_failed):
 def test_isApprovedForAll(c, w3):
     someone, operator = w3.eth.accounts[1:3]
 
-    assert c.isApprovedForAll(someone, operator) == False
+    assert c.isApprovedForAll(someone, operator) == 0
 
-    c.setApprovalForAll(operator, True,  transact={'from': someone})
+    c.setApprovalForAll(operator, True, transact={'from': someone})
 
-    assert c.isApprovedForAll(someone, operator) == True
+    assert c.isApprovedForAll(someone, operator) == 1
 
 
 def test_transferFrom_by_owner(c, w3, assert_tx_failed, get_logs):
@@ -121,7 +121,7 @@ def test_transferFrom_by_operator(c, w3, get_logs):
     someone, operator = w3.eth.accounts[1:3]
 
     # transfer by operator
-    c.setApprovalForAll(operator, True,  transact={'from': someone})
+    c.setApprovalForAll(operator, True, transact={'from': someone})
     tx_hash = c.transferFrom(
         someone, operator, SOMEONE_TOKEN_IDS[2], transact={'from': operator})
 
@@ -196,7 +196,7 @@ def test_safeTransferFrom_by_operator(c, w3, get_logs):
     someone, operator = w3.eth.accounts[1:3]
 
     # transfer by operator
-    c.setApprovalForAll(operator, True,  transact={'from': someone})
+    c.setApprovalForAll(operator, True, transact={'from': someone})
     tx_hash = c.safeTransferFrom(
         someone, operator, SOMEONE_TOKEN_IDS[2], transact={'from': operator})
 
@@ -218,7 +218,7 @@ def test_safeTransferFrom_to_contract(c, w3, assert_tx_failed, get_logs, get_con
     # Can't transfer to a contract that doesn't implement the receiver code
     assert_tx_failed(lambda: c.safeTransferFrom(someone, c.address, SOMEONE_TOKEN_IDS[0], transact={'from': someone}))
 
-     # Only to an address that implements that function
+    # Only to an address that implements that function
     receiver = get_contract("""
 @public
 def onERC721Received(


### PR DESCRIPTION
### - What I did
Update example implementation of [ERC721](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md) token. Specifically, 
- supported ERC165 (it's required in the EIP)
- added mint/burn function
- made it clear that assertions required in the EIP is implemented. 
- commented about other assertions not included in the EIP but needed.
- added tests with more test cases

### - How I did it
I referred to the previous implementation and [OpenZeppelin's Solidity implementation](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/ERC721.sol).

### - How to verify it
Test. Formal verification is [WIP](https://github.com/LayerXcom/verified-vyper-contracts/tree/master/erc721). 

### - Description for the changelog
Update example ERC721 token

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/22876645/48998900-5220bb80-f198-11e8-9229-be40b0e69283.png)


