### PR TITLE
Fix the input and output type of ecadd and ecmul in docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -206,9 +206,9 @@ Takes two elliptical curves and adds them together.
   def ecmul(a, b) -> product:
     """
     :param a: pair to be multiplied
-    :type a: num252[2]
-    :param b: pair to be multiplied
-    :type b: num252[2]
+    :type a: uint256[2]
+    :param b: number to be multiplied
+    :type b: uint256
 
     :output product: uint256[2]
     """

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -190,9 +190,9 @@ Takes a signed hash and vrs and returns the public key of the signer.
   def ecadd(a, b) -> sum:
     """
     :param a: pair to be added
-    :type a: num252[2]
+    :type a: uint256[2]
     :param b: pair to be added
-    :type b: num252[2]
+    :type b: uint256[2]
 
     :output sum: uint256[2]
     """


### PR DESCRIPTION
### - What I did
Fixed the input and output type of ecadd and ecmul in docs.

### - How I did it
Modified the docs.

### - How to verify it
Checked the compiler.

### - Description for the changelog
Fix the input and output type of ecadd and ecmul.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/22876645/49005821-01ff2480-f1ab-11e8-95fc-ad99e63042dc.png)

