### PR TITLE
Add returner for TupleType return.

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -704,7 +704,6 @@ def test(addr: address) -> (int128, address, bytes[10]):
     a: int128
     b: address
     c: bytes[10]
-    # (a, b, c) = self.out_literals()
     (a, b, c) = Test(addr).out_literals()
     return a, b,c
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -38,6 +38,7 @@ from vyper.types import (
     BaseType,
     ByteArrayType,
     ListType,
+    TupleType
 )
 from vyper.types import (
     get_size_of_type,
@@ -600,6 +601,8 @@ def get_external_contract_call_output(sig, context):
         returner = [0, output_placeholder]
     elif isinstance(sig.output_type, ByteArrayType):
         returner = [0, output_placeholder + 32]
+    elif isinstance(sig.output_type, TupleType):
+        returner = [0, output_placeholder]
     else:
         raise TypeMismatchException("Invalid output type: %s" % sig.output_type)
     return output_placeholder, output_size, returner


### PR DESCRIPTION
### - What I did
Fixes external contract call calling breaking parser if a typle is returned.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture

![](http://cdn.kickvick.com/wp-content/uploads/2015/09/cutest-bunny-rabbits-06.jpg)
