### PR TITLE
Fix Pre-Parser for contract & struct.

### DIFF
--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -12,7 +12,7 @@ x: bat
 x: 5
     """,
     """
-x: int128[int]
+x: map(int, int128)
     """,
     """
 x: int128[-1]
@@ -49,16 +49,10 @@ struct B:
     address: address
     """,
     """
-b: int128[int128, decimal]
+b: map((int128, decimal), int128)
     """,
     """
 b: int128[int128: address]
-    """,
-    """
-x: int128[address[bool]]
-@public
-def foo() -> int128(wei / sec):
-    pass
     """,
     """
 struct Foo:

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -28,7 +28,7 @@ from vyper.parser.parser_utils import (
     make_setter,
     base_type_conversion,
     byte_array_to_num,
-    decorate_ast_with_source,
+    decorate_ast,
     getpos,
     make_byte_array_copier,
     resolve_negative_literals,
@@ -62,9 +62,9 @@ if not hasattr(ast, 'AnnAssign'):
 
 # Converts code to parse tree
 def parse(code):
-    code = pre_parse(code)
-    o = ast.parse(code)
-    decorate_ast_with_source(o, code)
+    class_names, code = pre_parse(code)
+    o = ast.parse(code)  # python ast
+    decorate_ast(o, code, class_names)  # decorated python ast
     o = resolve_negative_literals(o)
     return o.body
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -492,14 +492,19 @@ def make_setter(left, right, location, pos):
         raise Exception("Invalid type for setters")
 
 
-# Decorate every node of an AST tree with the original source code.
-# This is necessary to facilitate error pretty-printing.
-def decorate_ast_with_source(_ast, code):
+def decorate_ast(_ast, code, class_names=None):
+    if class_names is None:
+        class_names = {}
 
     class MyVisitor(ast.NodeVisitor):
         def visit(self, node):
             self.generic_visit(node)
+            # Decorate every node of an AST tree with the original source code.
+            # This is necessary to facilitate error pretty-printing.
             node.source_code = code
+            # Decorate class definition with the type of classes they are.
+            if isinstance(node, ast.ClassDef):
+                node.class_type = class_names.get(node.name)
 
     MyVisitor().visit(_ast)
 

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -297,7 +297,7 @@ def parse_type(item, location, sigs={}, custom_units=[], custom_structs={}):
                 raise InvalidTypeException("No mappings allowed for in-memory types, only fixed-size arrays", item)
             keytype = parse_type(item.args[0], None)
             if not isinstance(keytype, (BaseType, ByteArrayType)):
-                raise InvalidTypeException("Mapping keys must be base or bytes types", item.slice.value)
+                raise InvalidTypeException("Mapping keys must be base or bytes types", item)
             return MappingType(keytype, parse_type(item.args[1], location, custom_units=custom_units, custom_structs=custom_structs))
         # Contract_types
         if item.func.id == 'address':


### PR DESCRIPTION
### - What I did
As we know handling of class types was really a kludge, and caused a error on master if defined as `class ClassName()` (with parenthesis).

This approach is much cleaner and maintainable, and fixes the bug (was nearly impossible to do without it).

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](https://i.ytimg.com/vi/kB4_5ORF1b8/maxresdefault.jpg)
