### PR TITLE
Make built-in constant op code generation more efficient

### DIFF
--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -54,6 +54,59 @@ def test_arithmetic(a: int128) -> int128:
     assert c.test_arithmetic(5000) == 2**127 - 1 - 5000
 
 
+def test_builtin_constants_assignment(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> int128:
+    bar: int128 = MAX_INT128
+    return bar
+
+@public
+def goo() -> int128:
+    bar: int128 = MIN_INT128
+    return bar
+
+@public
+def hoo() -> bytes32:
+    bar: bytes32 = EMPTY_BYTES32
+    return bar
+
+@public
+def joo() -> address:
+    bar: address = ZERO_ADDRESS
+    return bar
+
+@public
+def koo() -> decimal:
+    bar: decimal = MAX_DECIMAL
+    return bar
+
+@public
+def loo() -> decimal:
+    bar: decimal = MIN_DECIMAL
+    return bar
+
+@public
+def zoo() -> uint256:
+    bar: uint256 = MAX_UINT256
+    return bar
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.foo() == 2**127 - 1
+    assert c.goo() == -2**127
+
+    assert c.hoo() == b"\x00" * 32
+
+    assert c.joo() is None
+
+    assert c.koo() == Decimal(2**127 - 1)
+    assert c.loo() == Decimal(-2**127)
+
+    assert c.zoo() == 2**256 - 1
+
+
 def test_reserved_keyword(get_contract, assert_compile_failed):
     code = """
 @public

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -152,13 +152,41 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
     # Variable names
     def variables(self):
         builtin_constants = {
-            'EMPTY_BYTES32': LLLnode.from_list([0], typ=BaseType('bytes32', None, is_literal=True), pos=getpos(self.expr)),
-            'ZERO_ADDRESS': LLLnode.from_list([0], typ=BaseType('address', None, is_literal=True), pos=getpos(self.expr)),
-            'MAX_INT128': LLLnode.from_list(['mload', MemoryPositions.MAXNUM], typ=BaseType('int128', None, is_literal=True), pos=getpos(self.expr)),
-            'MIN_INT128': LLLnode.from_list(['mload', MemoryPositions.MINNUM], typ=BaseType('int128', None, is_literal=True), pos=getpos(self.expr)),
-            'MAX_DECIMAL': LLLnode.from_list(['mload', MemoryPositions.MAXDECIMAL], typ=BaseType('decimal', None, is_literal=True), pos=getpos(self.expr)),
-            'MIN_DECIMAL': LLLnode.from_list(['mload', MemoryPositions.MINDECIMAL], typ=BaseType('decimal', None, is_literal=True), pos=getpos(self.expr)),
-            'MAX_UINT256': LLLnode.from_list([2**256 - 1], typ=BaseType('uint256', None, is_literal=True), pos=getpos(self.expr)),
+            'EMPTY_BYTES32': LLLnode.from_list(
+                [0],
+                typ=BaseType('bytes32', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'ZERO_ADDRESS': LLLnode.from_list(
+                [0],
+                typ=BaseType('address', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'MAX_INT128': LLLnode.from_list(
+                [SizeLimits.MAXNUM],
+                typ=BaseType('int128', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'MIN_INT128': LLLnode.from_list(
+                [SizeLimits.MINNUM],
+                typ=BaseType('int128', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'MAX_DECIMAL': LLLnode.from_list(
+                [SizeLimits.MAXDECIMAL],
+                typ=BaseType('decimal', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'MIN_DECIMAL': LLLnode.from_list(
+                [SizeLimits.MINDECIMAL],
+                typ=BaseType('decimal', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
+            'MAX_UINT256': LLLnode.from_list(
+                [SizeLimits.MAX_UINT256],
+                typ=BaseType('uint256', None, is_literal=True),
+                pos=getpos(self.expr)
+            ),
         }
 
         if self.expr.id == 'self':


### PR DESCRIPTION
### - What I did

Added better tests, refactored, and made op-code generation for built-in constants more efficient.

This also fixes #1121

### - How I did it

Built-in constants should use the values from `SizeLimits` in `utils.py`

### - How to verify it

`make test`

### - Description for the changelog

Make built-in constant op code generation more efficient.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49631880-f97bca80-f9b0-11e8-9618-ea19e5f6c2de.png)

