### PR TITLE
Basic make.cmd for Windows

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,23 @@
+@echo off
+if "%1"=="init" goto :init
+if "%1"=="test" goto :test
+rem Default
+if "%1"=="" goto :init
+
+:error
+echo Unknown parameters: %*
+echo Expected: init test 
+rem echo Expect: test lint clean clean-pyc clean-build clean-test docs docker-build
+goto :end
+
+:init
+python setup.py install
+goto :end
+
+:test
+python setup.py test
+goto :end
+
+rem TODO: clean, etc (for recursive delete, use robocopy to move to temp dir, then delete temp dir)
+
+:end


### PR DESCRIPTION
Basic make.cmd that only has init and test, so initial instructions work on Windows.

Fixes #1127 
Also partially addresses #1079 (it will install, but will have to be run manually as the python script installed is a shell script; there is another bug to fix that)

### - What I did

Add a make.cmd file to the root, with very basic handling for init and test, which call the same python commands as Makefile.

Windows does not have make, so the basic instructions, to call `make` and then `make test` do not work on Windows.

This file implements those two commands, with a structure for adding the others. Some of the others (e.g. recursive delete of files matching a pattern) are more complicated. Powershell would be better, but there are ways in Cmd (e.g. robocopy the pattern to MOV to a temp dir, then delete the temp dir).

But, I am not sure if these are necessary. May not be doing full development on Windows, just compiling enough following the basic instructions so it will run.

### - How I did it

Added the cmd file.

### - How to verify it

On Windows, open CMD and enter the following on the command prompt:
 `make`

Then 
 `make test`

Because Windows automatically runs certain extensions, and looks in the current directory, these will run make.cmd, which then calls the same commands as Makefile (i.e. will build and install the vyper tool in python).

Can also check that it still works in linux (because of the extension, it should not interfere with normal make).

### - Description for the changelog

Basic make.cmd that only has init and test, so initial instructions work on Windows.

### - Cute Animal Picture

> put a cute animal picture here.
