### PR TITLE
Optimized conversion clamping

### DIFF
--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -153,9 +153,9 @@ def byte_array_to_num(arg, expr, out_type, offset=32,):
         first_el_getter = LLLnode.from_list(['sload', ['add', 1, ['sha3_32', '_sub']]], typ=BaseType('int128'))
     if out_type == 'int128':
         result = ['clamp',
-                     ['mload', MemoryPositions.MINNUM],
+                     SizeLimits.MINNUM,
                      ['div', '_el1', ['exp', 256, ['sub', 32, '_len']]],
-                     ['mload', MemoryPositions.MAXNUM]]
+                     SizeLimits.MAXNUM]
     elif out_type == 'uint256':
         result = ['div', '_el1', ['exp', 256, ['sub', offset, '_len']]]
     return LLLnode.from_list(['with', '_sub', arg,

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -22,7 +22,6 @@ from vyper.types import (
 )
 from vyper.utils import (
     DECIMAL_DIVISOR,
-    MemoryPositions,
     SizeLimits
 )
 

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -36,8 +36,7 @@ def to_int128(expr, args, kwargs, context):
         if in_arg.typ.is_literal and not SizeLimits.in_bounds('int128', in_arg.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_arg.value), expr)
         return LLLnode.from_list(
-            ['clamp', ['mload', MemoryPositions.MINNUM],
-            in_arg, ['mload', MemoryPositions.MAXNUM]],
+            ['clamp', SizeLimits.MINNUM, in_arg, SizeLimits.MAXNUM],
             typ=BaseType('int128', in_arg.typ.unit),
             pos=getpos(expr)
         )
@@ -122,8 +121,7 @@ def to_decimal(expr, args, kwargs, context):
 
     if input_type == 'uint256':
         return LLLnode.from_list(
-            ['uclample', ['mul', in_arg, DECIMAL_DIVISOR],
-            ['mload', MemoryPositions.MAXDECIMAL]],
+            ['uclample', ['mul', in_arg, DECIMAL_DIVISOR], SizeLimits.MAXDECIMAL],
             typ=BaseType('decimal', _unit, _positional),
             pos=getpos(expr)
         )


### PR DESCRIPTION
### - What I did

Optimized clamping for conversions. Work towards #1093 

### - How I did it

Removed unnecessary `mload` instructions.

### - How to verify it

Tests haven't changed, so:

`make test`

### - Description for the changelog

Optimized conversion clamping.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49776836-05ba9d00-fcbb-11e8-8de1-b0b4a352fb85.png)
