### PR TITLE
Whitelist the `send` keyword for function definitions

### DIFF
--- a/tests/parser/syntax/test_send.py
+++ b/tests/parser/syntax/test_send.py
@@ -82,6 +82,17 @@ def foo():
 @public
 def foo():
     send(0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe, 5)
+    """,
+    """
+# Test custom send method
+@public
+def send(a: address, w: wei_value):
+    send(0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe, 1)
+
+@public
+@payable
+def foo():
+    self.send(msg.sender, msg.value)
     """
 ]
 

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -19,6 +19,7 @@ from vyper.types import (
 from vyper.utils import (
     fourbytes_to_int,
     is_varname_valid,
+    function_whitelist,
     sha3,
 )
 from vyper.parser.lll_node import LLLnode
@@ -76,7 +77,7 @@ class FunctionSignature():
         name = code.name
         pos = 0
 
-        if not is_varname_valid(name, custom_units=custom_units, custom_structs=custom_structs):
+        if (not name.lower() in function_whitelist) and (not is_varname_valid(name, custom_units=custom_units, custom_structs=custom_structs)):
             raise FunctionDeclarationException("Function name invalid: " + name)
         # Determine the arguments, expects something of the form def foo(arg1: int128, arg2: int128 ...
         args = []

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -154,6 +154,11 @@ reserved_words = [
     'zero_address', 'empty_bytes32' 'max_int128', 'min_int128', 'max_decimal', 'min_decimal', 'max_uint256',  # constants
 ]
 
+# Otherwise reserved words that are whitelisted for function declarations
+function_whitelist = {
+    'send'
+}
+
 # List of valid LLL macros.
 valid_lll_macros = [
     'assert', 'break', 'ceil32', 'clamp', 'clamp', 'clamp_nonzero', 'clampge',


### PR DESCRIPTION
### - What I did

Fix #1068

### - How I did it

Created new set in `utils.py` called `function_whitelist` for whitelisting for function names words that are otherwise reserved words. 

### - How to verify it

I added a test case that tests this to `tests/parser/syntax/test_send.py`.

Test with `pytest -k tests/parser/syntax/test_send.py`.

### - Description for the changelog

Whitelist the `send` keyword for function definitions

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49848339-e773a080-fd91-11e8-8706-ce0e32db150c.png)
