### PR TITLE
Use sets not lists in utils.py

### DIFF
--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -48,7 +48,7 @@ class GlobalContext:
         self._globals = dict()
         self._defs = list()
         self._getters = list()
-        self._custom_units = list()
+        self._custom_units = set()
         self._custom_units_descriptions = dict()
         self._constants = dict()
 
@@ -306,7 +306,7 @@ class GlobalContext:
                         raise VariableDeclarationException("Custom unit name may only be used once", key)
                     if not is_varname_valid(key.id, custom_units=self._custom_units, custom_structs=self._structs):
                         raise VariableDeclarationException("Custom unit may not be a reserved keyword", key)
-                    self._custom_units.append(key.id)
+                    self._custom_units.add(key.id)
                     self._custom_units_descriptions[key.id] = value.s
             else:
                 raise VariableDeclarationException("Custom units can only be defined once", item.target)

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -244,7 +244,7 @@ special_types = {
 # Parse an expression representing a unit
 def parse_unit(item, custom_units):
     if isinstance(item, ast.Name):
-        if item.id not in valid_units + custom_units:
+        if item.id not in valid_units | custom_units:
             raise InvalidTypeException("Invalid base unit", item)
         return {item.id: 1}
     elif isinstance(item, ast.Num) and item.n == 1:
@@ -278,7 +278,7 @@ def make_struct_type(name, location, members, custom_units, custom_structs):
 
 # Parses an expression representing a type. Annotation refers to whether
 # the type is to be located in memory or storage
-def parse_type(item, location, sigs={}, custom_units=[], custom_structs={}):
+def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None):
 
     # Base and custom types, e.g. num
     if isinstance(item, ast.Name):
@@ -286,7 +286,7 @@ def parse_type(item, location, sigs={}, custom_units=[], custom_structs={}):
             return BaseType(item.id)
         elif item.id in special_types:
             return special_types[item.id]
-        elif item.id in custom_structs:
+        elif (not custom_structs is None) and (item.id in custom_structs):
             return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs)
         else:
             raise InvalidTypeException("Invalid base type: " + item.id, item)
@@ -305,7 +305,7 @@ def parse_type(item, location, sigs={}, custom_units=[], custom_structs={}):
             if sigs and item.args[0].id in sigs:
                 return ContractType(item.args[0].id)
         # Struct types
-        if item.func.id in custom_structs:
+        if (not custom_structs is None) and (item.func.id in custom_structs):
             return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs)
         if not isinstance(item.func, ast.Name):
             raise InvalidTypeException("Malformed unit type:", item)

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -244,7 +244,7 @@ special_types = {
 # Parse an expression representing a unit
 def parse_unit(item, custom_units):
     if isinstance(item, ast.Name):
-        if item.id not in valid_units | custom_units:
+        if (item.id not in valid_units) and (custom_units is not None) and (item.id not in custom_units):
             raise InvalidTypeException("Invalid base unit", item)
         return {item.id: 1}
     elif isinstance(item, ast.Num) and item.n == 1:
@@ -286,7 +286,7 @@ def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None
             return BaseType(item.id)
         elif item.id in special_types:
             return special_types[item.id]
-        elif (not custom_structs is None) and (item.id in custom_structs):
+        elif (custom_structs is not None) and (item.id in custom_structs):
             return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs)
         else:
             raise InvalidTypeException("Invalid base type: " + item.id, item)
@@ -305,7 +305,7 @@ def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None
             if sigs and item.args[0].id in sigs:
                 return ContractType(item.args[0].id)
         # Struct types
-        if (not custom_structs is None) and (item.func.id in custom_structs):
+        if (custom_structs is not None) and (item.func.id in custom_structs):
             return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs)
         if not isinstance(item.func, ast.Name):
             raise InvalidTypeException("Malformed unit type:", item)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -130,19 +130,20 @@ RLP_DECODER_ADDRESS = hex_to_int('0x5185D17c44699cecC3133114F8df70753b856709')
 # This is the contract address: 0xCb969cAAad21A78a24083164ffa81604317Ab603
 
 # Available base types
-base_types = ['int128', 'decimal', 'bytes32', 'uint256', 'bool', 'address']
+base_types = {'int128', 'decimal', 'bytes32', 'uint256', 'bool', 'address'}
 
 # Keywords available for ast.Call type
-valid_call_keywords = ['uint256', 'int128', 'decimal', 'address', 'contract', 'indexed']
+valid_call_keywords = {'uint256', 'int128', 'decimal', 'address', 'contract', 'indexed'}
 
 # Valid base units
-valid_units = ['wei', 'sec']
+valid_units = {'wei', 'sec'}
 
 # Valid attributes for global variables
-valid_global_keywords = ['public', 'modifying', 'event', 'constant'] + valid_units + valid_call_keywords
+valid_global_keywords = {'public', 'modifying', 'event', 'constant'} | valid_units | valid_call_keywords
+
 
 # Cannot be used for variable or member naming
-reserved_words = [
+reserved_words = {
     'int128', 'uint256', 'address', 'bytes32', 'map',
     'if', 'for', 'while', 'until',
     'pass', 'def', 'push', 'dup', 'swap', 'send', 'call',
@@ -152,16 +153,16 @@ reserved_words = [
     'ether', 'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada', 'babbage', 'gwei', 'kwei', 'mwei', 'twei', 'pwei', 'contract',
     'units',
     'zero_address', 'empty_bytes32' 'max_int128', 'min_int128', 'max_decimal', 'min_decimal', 'max_uint256',  # constants
-]
+}
 
 # List of valid LLL macros.
-valid_lll_macros = [
+valid_lll_macros = {
     'assert', 'break', 'ceil32', 'clamp', 'clamp', 'clamp_nonzero', 'clampge',
     'clampgt', 'clample', 'clamplt', 'codeload', 'continue', 'debugger', 'ge',
     'if', 'le', 'lll', 'ne', 'pass', 'repeat', 'seq', 'set', 'sge', 'sha3_32',
     'sha3_64', 'sle', 'uclampge', 'uclampgt', 'uclample', 'uclamplt', 'with',
     '~codelen', 'label', 'goto'
-]
+}
 
 
 # Is a variable or member variable name valid?
@@ -171,8 +172,8 @@ def is_varname_valid(varname, custom_units, custom_structs):
     built_in_functions = [x for x in stmt_dispatch_table.keys()] + \
       [x for x in dispatch_table.keys()]
     if custom_units is None:
-        custom_units = []
-    if varname.lower() in [cu.lower() for cu in custom_units]:
+        custom_units = set()
+    if varname.lower() in {cu.lower() for cu in custom_units}:
         return False
     # struct names are case sensitive.
     if varname in custom_structs:


### PR DESCRIPTION
### - What I did

This is a very minor improvement, replaces the lists being used in `utils.py` with sets. Given that they are used for testing the membership of a given item against the set, this will be slightly faster.

### - How I did it

See above.

### - How to verify it

`make test`

### - Description for the changelog

Use sets not lists in utils.py

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49848545-c3fd2580-fd92-11e8-91ed-60ff9f28e088.png)
