### PR TITLE
Be consistent in clamping against max/min in memory

### DIFF
--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -78,7 +78,7 @@ def to_int128(expr, args, kwargs, context):
         if in_arg.typ.is_literal and not SizeLimits.in_bounds('int128', in_arg.value):
             raise InvalidLiteralException("Number out of range: {}".format(in_arg.value), expr)
         return LLLnode.from_list(
-            ['uclample', in_arg, SizeLimits.MAXNUM],
+            ['uclample', in_arg, ['mload', MemoryPositions.MAXNUM]],
             typ=BaseType('int128', in_arg.typ.unit),
             pos=getpos(expr)
         )


### PR DESCRIPTION
### - What I did

Tiny PR, makes sure there are no lingering usages of clamping against literals in conversions. Related to #1134 (now closed).

### - How I did it

Above.

### - How to verify it

`make test`

### - Description for the changelog

No conversion clamping against literals.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49888092-4e796f80-fdfb-11e8-8833-5354f077ad75.png)
