### PR TITLE
Check for and disallow implicit type conversion in Assign

### DIFF
--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -2,6 +2,7 @@ from vyper.exceptions import (
     ParserException,
     ConstancyViolationException,
     InvalidLiteralException,
+    TypeMismatchException,
 )
 
 
@@ -179,3 +180,79 @@ def get() -> int128:
     c = get_contract_with_gas_estimation(code)
     assert c.set(transact={})
     assert c.get() == 111
+
+
+def test_invalid_implicit_conversions(assert_compile_failed, get_contract_with_gas_estimation):
+    contracts = [
+"""
+@public
+def foo():
+   y: int128 = 1
+   z: decimal = y
+""",
+"""
+@public
+def foo():
+    y: int128 = 1
+    z: decimal
+    z = y
+""",
+"""
+@public
+def foo():
+   y: bool = False
+   z: decimal = y
+""",
+"""
+@public
+def foo():
+    y: bool = False
+    z: decimal
+    z = y
+""",
+"""
+@public
+def foo():
+   y: uint256 = 1
+   z: int128 = y
+""",
+"""
+@public
+def foo():
+    y: uint256 = 1
+    z: int128
+    z = y
+""",
+"""
+@public
+def foo():
+   y: int128 = 1
+   z: bytes32 = y
+""",
+"""
+@public
+def foo():
+    y: int128 = 1
+    z: bytes32
+    z = y
+""",
+"""
+@public
+def foo():
+   y: uint256 = 1
+   z: bytes32 = y
+""",
+"""
+@public
+def foo():
+    y: uint256 = 1
+    z: bytes32
+    z = y
+"""
+    ]
+
+    for contract in contracts:
+        assert_compile_failed(
+            lambda: get_contract_with_gas_estimation(contract),
+            TypeMismatchException
+        )


### PR DESCRIPTION
### - What I did

Fixes #1107. Check for and disallow implicit type conversion in Assign statements.

Also did some _minor_ refactoring of the assignment validity checking logic.

### - How I did it

Added type checking step to `assign(self)` handler in `stmt.py`.

Added corresponding tests in `test_assignment.py`

### - How to verify it

`pytest -k test_assignment.py`

### - Description for the changelog

Check for and disallow implicit type conversion in Assign statements.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/49906471-5521da00-fe2f-11e8-8323-2a3f89877a5c.png)
