### PR TITLE
Fix mk_method_identifiers

### DIFF
--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -140,7 +140,7 @@ def mk_method_identifiers(code):
     for code in global_ctx._defs:
         sig = FunctionSignature.from_definition(code, sigs=global_ctx._contracts, custom_units=global_ctx._custom_units)
         if not sig.private:
-            default_sigs = generate_default_arg_sigs(code, global_ctx._contracts, global_ctx._custom_units)
+            default_sigs = generate_default_arg_sigs(code, global_ctx._contracts, global_ctx._custom_units, global_ctx._structs)
             for s in default_sigs:
                 o[s.sig] = hex(s.method_id)
 


### PR DESCRIPTION
### - What I did

Fix #1142

### - How I did it

Added `global_ctx._structs` parameter (which was introduced at ab3dd896c3682b80714dd901e8f01cdf5c7cd589) when calling `generate_default_arg_sigs` in `mk_method_identifiers`.

### - How to verify it

Send the following code to vyper-serve.

```
num: public(uint256)

@public
def set(_num : uint256):
  self.num = _num
```

### - Description for the changelog

Fix bug when calling generate_default_arg_sigs in mk_method_identifiers

### - Cute Animal Picture

![cat](https://user-images.githubusercontent.com/1025957/49920078-477e5a00-feec-11e8-80f4-1429025e9110.jpg)
