### PR TITLE
Update docs and help for compiler options

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -21,7 +21,9 @@ format_options_help = """Format to print, one or more of:
  bytecode (default) - Deployable bytecode
  bytecode_runtime   - Bytecode at runtime
  abi                - ABI in JSON format
- python_abi         - ABI in python format
+ abi_python         - Identical to --abi
+ ir                 - Intermediate representation (Vyper's dialect of LLL)
+ asm                - EVM Assembly
  source_map         - Vyper source map
  method_identifiers - Dictionary of method signature to method identifier.
  combined_json      - All of the above format options combined as single JSON output.

--- a/bin/vyper
+++ b/bin/vyper
@@ -22,7 +22,7 @@ format_options_help = """Format to print, one or more of:
  bytecode_runtime   - Bytecode at runtime
  abi                - ABI in JSON format
  abi_python         - Identical to --abi
- ir                 - Intermediate representation (Vyper's dialect of LLL)
+ ir                 - Vyper IR (a dialect of LLL)
  asm                - EVM Assembly
  source_map         - Vyper source map
  method_identifiers - Dictionary of method signature to method identifier.

--- a/bin/vyper
+++ b/bin/vyper
@@ -21,7 +21,7 @@ format_options_help = """Format to print, one or more of:
  bytecode (default) - Deployable bytecode
  bytecode_runtime   - Bytecode at runtime
  abi                - ABI in JSON format
- abi_python         - Identical to --abi
+ abi_python         - ABI in Python format
  ir                 - Vyper IR (a dialect of LLL)
  asm                - EVM Assembly
  source_map         - Vyper source map
@@ -78,13 +78,14 @@ if __name__ == '__main__':
             'json': 'abi'
         }
         formats = []
-        for f in uniq(args.format.split(',')):
+        orig_args = uniq(args.format.split(','))
+        for f in orig_args:
             formats.append(translate_map.get(f, f))
 
         out_list = vyper.compile_codes(codes, formats, output_type='list', exc_handler=exc_handler)
         for out in out_list:
-            for f in formats:
-                o = out[f]
+            for f in orig_args:
+                o = out[translate_map.get(f, f)]
                 if f in ('abi', 'json'):
                     print(json.dumps(o))
                 elif f == 'abi_python':

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -7,7 +7,7 @@ To compile a contract, use:
 
 You can also compile to other formats such as ABI using the below format:
 ::
-    vyper -f ['abi', 'abi_python', 'bytecode', 'bytecode_runtime', 'ir', 'asm'] yourFileName.vy
+    vyper -f ['abi', 'bytecode', 'bytecode_runtime', 'ir', 'asm', 'source_map', 'method_identifiers', 'combined_json'] yourFileName.vy
 
 It is also possible to use the `-f json` option, which is a legacy alias for `-f abi`.
 


### PR DESCRIPTION
Just docs changes: `--asm` and `--ir` were missing from compiler help.

Also it looks like `--python_abi` was renamed to `--abi_python` at some
point and is identical to `--abi`.

### - What I did
Updated compiler help and docs

### - How to verify it
```
$ vyper -h
$ vyper -f abi_python <foo.vy>
```

### - Cute Animal Picture
![](https://tailandfur.com/wp-content/uploads/2014/09/beautiful-and-cute-animals-wallpaper-2.jpg)

