### PR TITLE
Update types section of docs

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -138,22 +138,22 @@ Operator    Description
 Arithmetic Operators
 ^^^^^^^^^^^^^^^^^^^^
 
-=======================  ======================
-Operator                 Description
-=======================  ======================
-``uint256_add(x, y)``     Addition
-``uint256_sub(x, y)``     Subtraction
-``uint256_addmod(x, y)``  Modular addition
-``uint256_mul(x, y)``     Multiplication
-``uint256_mulmod(x, y)``  Modular multiplication
-``uint256_div(x, y)``     Division
-``uint256_exp(x, y)``     Exponentiation
-``uint256_mod(x, y)``     Modulo
-``min(x, y)``            Minimum
-``max(x, y)``            Maximum
-=======================  ======================
+===========================  ======================
+Operator                     Description
+===========================  ======================
+``x + y``                    Addition
+``x - y``                    Subtraction
+``uint256_addmod(x, y, z)``  Modular addition
+``x * y``                    Multiplication
+``uint256_mulmod(x, y, z)``  Modular multiplication
+``x / y``                    Division
+``x**y``                     Exponentiation
+``x % y``                    Modulo
+``min(x, y)``                Minimum
+``max(x, y)``                Maximum
+===========================  ======================
 
-``x`` and ``y`` must be of the type ``uint256``.
+``x``, ``y`` and ``z`` must be of the type ``uint256``.
 
 Bitwise Operators
 ^^^^^^^^^^^^^^^^^

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -143,9 +143,9 @@ Operator                     Description
 ===========================  ======================
 ``x + y``                    Addition
 ``x - y``                    Subtraction
-``uint256_addmod(x, y, z)``  Modular addition
+``uint256_addmod(x, y, z)``  Addition modulo ``z``
 ``x * y``                    Multiplication
-``uint256_mulmod(x, y, z)``  Modular multiplication
+``uint256_mulmod(x, y, z)``  Multiplication modulo ``z``
 ``x / y``                    Division
 ``x**y``                     Exponentiation
 ``x % y``                    Modulo

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -218,7 +218,7 @@ Operator       Description
 ``min(x, y)``  Minimum
 ``max(x, y)``  Maximum
 ``floor(x)``   Largest integer <= ``x``. Returns ``int128``.
-``ceil(x)``   Smallest integer >= ``x``. Returns ``int128``.
+``ceil(x)``    Smallest integer >= ``x``. Returns ``int128``.
 =============  ==========================================
 
 ``x`` and ``y`` must be of the type ``decimal``.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -122,16 +122,16 @@ Comparisons
 ^^^^^^^^^^^
 Comparisons return a boolean value.
 
-===================  ================
-Operator             Description
-===================  ================
-``uint256_lt(x, y)``  Less than
-``uint256_le(x, y)``  Less than or equal to
-``x == y``           Equals
-``x != y``           Does not equal
-``uint256_ge(x, y)``  Greater than or equal to
-``uint256_gt(x, y)``  Greater than
-===================  ================
+==========  ================
+Operator    Description
+==========  ================
+``x < y``   Less than
+``x <= y``  Less than or equal to
+``x == y``  Equals
+``x != y``  Does not equal
+``x >= y``  Greater than or equal to
+``x > y``   Greater than
+==========  ================
 
 ``x`` and ``y`` must be of the type ``uint256``.
 


### PR DESCRIPTION
### - What I did
Updated types section of docs.

The tables of `uint256`and `decimal` operators were not displayed correctly.

![image](https://user-images.githubusercontent.com/22876645/50641972-19e97580-0fad-11e9-9465-68a25f601fea.png)


### - How I did it

### - How to verify it

### - Description for the changelog

Update types section of docs
