### PR TITLE
Fix the type of the params of `concat` in docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -137,9 +137,9 @@ Returns the length of a given list of bytes.
   def concat(a, b, ...) -> c:
     """
     :param a: value to combine
-    :type a: bytes
+    :type a: bytes, bytes32
     :param b: value to combine
-    :type b: bytes
+    :type b: bytes, bytes32
 
     :output b: bytes
     """


### PR DESCRIPTION
### - What I did
Fixed the type of the params of `concat` in docs

### - How I did it

### - How to verify it

### - Description for the changelog

Fix the type of the params of `concat` in docs