### PR TITLE
Clarify the third param of `extract32` is optional in docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -239,7 +239,7 @@ Takes two elliptical curves and multiplies them together.
     :type a: bytes
     :param b: start point of bytes to be extracted
     :type b: int128
-    :param c: type of output
+    :param c: type of output (Optional, default: bytes32)
     :type c: either bytes32, int128, or address
 
     :output d: either bytes32, int128, or address


### PR DESCRIPTION
### - What I did
Clarified the third param of `extract32` is optional in docs

### - How I did it

### - How to verify it

### - Description for the changelog
Clarify the third param of `extract32` is optional in docs