### PR TITLE
Fix tuple return

### DIFF
--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -1,3 +1,6 @@
+from vyper.exceptions import TypeMismatchException
+
+
 def test_return_type(get_contract_with_gas_estimation):
     long_string = 35 * "test"
 
@@ -113,3 +116,13 @@ def test() -> (int128, bytes[20], address, bytes[20]):
     c = get_contract_with_gas_estimation(code)
 
     assert c.out_literals() == [1, b"testtesttest", None, b"random"]
+
+
+def test_tuple_return_typecheck(assert_tx_failed, get_contract_with_gas_estimation):
+    code = """
+@public
+def getTimeAndBalance() -> (bool, address):
+    return block.timestamp, self.balance
+    """
+
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatchException)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -635,7 +635,10 @@ def gen_tuple_return(stmt, context, sub):
                 ['mload', dynamic_offset_counter]]
         ]
 
-    items = sub.typ.tuple_items()
+    if not isinstance(context.return_type, TupleLike):
+        raise TypeMismatchException('Trying to return %r when expecting %r' % (sub.typ, context.return_type), getpos(stmt))
+    items = context.return_type.tuple_items()
+
     dynamic_offset_start = 32 * len(items)  # The static list of args end.
 
     for i, (key, typ) in enumerate(items):


### PR DESCRIPTION
### - What I did
Fix #1006 

### - How I did it
Set the destination type correctly for `make_setter` to typecheck in the tuple return code

### - How to verify it
See test

### - Description for the changelog
Fix typecheck for tuple return

### - Cute Animal Picture


![](http://2.bp.blogspot.com/-rXrBUTL0CRU/TiCJs4DmpwI/AAAAAAAAAzU/OYxl3mJjJL8/s640/cute%2Bbaby%2Bpanda%2B010.jpg)

