### PR TITLE
Fix constants in internal function calls

### DIFF
--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -81,6 +81,19 @@ test_a : constant(int128) = 2188824287183927522224640574525
     """,
     """
 test_a: constant(uint256) = MAX_UINT256
+    """,
+    """
+TEST_C: constant(int128) = 1
+TEST_WEI: constant(uint256(wei)) = 1
+
+@private
+def test():
+   raw_call(0x0000000000000000000000000000000000000005, 'hello', outsize=TEST_C, gas=2000)
+
+@private
+def test1():
+    # Expecting num_literal for argument 'outsize' of raw_call
+    raw_call(0x0000000000000000000000000000000000000005, 'hello', outsize=256, gas=TEST_WEI)
     """
 ]
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -70,6 +70,18 @@ def test() -> int128:
     """
 TREE_FIDDY: constant(uint256(wei))  = as_wei_value(350, 'ether')
     """
+    """
+FOO: constant(int128) = 100
+    """,
+    """
+test_a : constant(uint256) = 21888242871839275222246405745257275088696311157297823662689037894645226208583
+    """,
+    """
+test_a : constant(int128) = 2188824287183927522224640574525
+    """,
+    """
+test_a: constant(uint256) = MAX_UINT256
+    """
 ]
 
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -364,7 +364,13 @@ def as_wei_value(expr, args, kwargs, context):
             denomination = denom
             break
     else:
-        raise InvalidLiteralException("Invalid denomination: %s" % args[1], expr.args[1])
+        raise InvalidLiteralException(
+            "Invalid denomination: %s, valid denominations are: %s" % (
+                args[1],
+                ",".join(x[0].decode() for x in names_denom)
+            ),
+            expr.args[1]
+        )
     # Compute the amount of wei and return that value
     if isinstance(args[0], (int, float)):
         numstring, num, den = get_number_as_fraction(expr.args[0], context)

--- a/vyper/functions/signature.py
+++ b/vyper/functions/signature.py
@@ -39,6 +39,8 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
     vsub = None
     for expected_arg in expected_arg_typelist:
         if expected_arg == 'num_literal':
+            if context.is_constant_of_base_type(arg, ('uint256', 'int128')):
+                return context.get_constant(arg.id).value
             if isinstance(arg, ast.Num) and get_original_if_0_prefixed(arg, context) is None:
                 return arg.n
         elif expected_arg == 'str_literal':

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -129,7 +129,7 @@ class Context():
         # check if value is compatible with
         const = self.constants[const_name]
         if isinstance(const, ast.AnnAssign):  # Handle ByteArrays.
-            expr = Expr(const.value, self.context).lll_node
+            expr = Expr(const.value, self).lll_node
             return expr
         # Other types are already unwrapped, no need
         return self.constants[const_name]

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -197,14 +197,8 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             return LLLnode.from_list(var.pos, typ=var.typ, location='memory', pos=getpos(self.expr), annotation=self.expr.id, mutable=var.mutable)
         elif self.expr.id in builtin_constants:
             return builtin_constants[self.expr.id]
-        elif self.expr.id in self.context.constants:
-            # check if value is compatible with
-            const = self.context.constants[self.expr.id]
-            if isinstance(const, ast.AnnAssign):  # Handle ByteArrays.
-                expr = Expr(const.value, self.context).lll_node
-                return expr
-            # Other types are already unwrapped, no need
-            return self.context.constants[self.expr.id]
+        elif self.context.ast_is_constant(self.expr):
+            return self.context.get_constant(self.expr.id)
         else:
             raise VariableDeclarationException("Undeclared variable: " + self.expr.id, self.expr)
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -348,11 +348,8 @@ class Stmt(object):
         valid = False
         if isinstance(arg, ast.Num):
             valid = True
-        if isinstance(arg, ast.Name) and arg.id in self.context.constants:
-            const = self.context.constants[arg.id]
-            if isinstance(const.typ, BaseType) and const.typ.typ in ('uint256', 'int128'):
-                valid = True
-
+        if self.context.is_constant_of_base_type(arg, ('uint256', 'int128')):
+            valid = True
         if not valid and raise_exception:
             raise StructureException("Range only accepts literal (constant) values", arg)
 


### PR DESCRIPTION
### - What I did
Fixes #1187.
- Improves the the lookup and verification of constant types.

### - How I did it

### - How to verify it

### - Description for the changelog

### - Cute Animal Picture
![](https://tse2.mm.bing.net/th?id=OIP.zgg43tFX2X64stTsqEGZUQHaJx&w=190&h=251&c=8&o=5&pid=1.7)