### PR TITLE
Fix typo in file extension

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -12,8 +12,8 @@ You can also compile to other formats such as ABI using the below format:
 It is also possible to use the `-f json` option, which is a legacy alias for `-f abi`.
 
 .. note::
-    Since .vy is not officially a language supported by any syntax highlighters or linters,
-    it is recommended to name your Vyper file ending with `.vy` in order to have Python syntax highlighting.
+    Since `.vy` is not officially a language supported by any syntax highlighters or linters,
+    it is recommended to name your Vyper file ending with `.py` in order to have Python syntax highlighting.
 
 An `online compiler <https://vyper.online/>`_ is available as well, which lets you experiment with
 the language without having to install Vyper. The online compiler allows you to compile to ``bytecode`` and/or ``LLL``.


### PR DESCRIPTION
### - What I did

Recommendation was for file extension `.vy` to have Python syntax highlighting, I assume this is meant to be `.py` and fixed it.

### - Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/a1/72/d8/a172d8325a334ba26295002069973eed.jpg)

