### PR TITLE
Fix vyper-lll binary

### DIFF
--- a/bin/vyper-lll
+++ b/bin/vyper-lll
@@ -35,6 +35,6 @@ if __name__ == "__main__":
         asm = compile_lll.compile_to_assembly(lll)
         if 'asm' in format_set:
             print(asm)
-        bytecode = '0x' + compile_lll.assembly_to_evm(asm).hex()
+        (bytecode, _srcmap) = compile_lll.assembly_to_evm(asm)
         if 'bytecode' in format_set:
-            print(bytecode)
+            print('0x' + bytecode.hex())


### PR DESCRIPTION
### - What I did

### - How I did it
Handle the new format for `assembly_to_evm`

### - How to verify it
```bash
vyper-lll -f bytecode /dev/stdin <<EOF
(mstore 0 (pop pass))
EOF
<outputs 0x50600052>
```

### - Description for the changelog
Fix `bytecode` output for `vyper-lll`

### - Cute Animal Picture
![](http://www.kickvick.com/wp-content/uploads/2014/11/cute-baby-animals-a-47.jpg)
