### PR TITLE
Add a --debug flag

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -37,12 +37,12 @@ parser.add_argument('--debug', help='Add compiler debugging output', action='sto
 
 args = parser.parse_args()
 
-tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
-if tb_limit:
-    sys.tracebacklimit = int(tb_limit)
-if not args.debug:
+if args.debug:
+    tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
+    if tb_limit:
+        sys.tracebacklimit = int(tb_limit)
+else:
     sys.tracebacklimit = 0
-
 
 def uniq(seq):
     exists = set()

--- a/bin/vyper
+++ b/bin/vyper
@@ -37,12 +37,12 @@ parser.add_argument('--debug', help='Add compiler debugging output', action='sto
 
 args = parser.parse_args()
 
-if args.debug:
-    tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
-    if tb_limit:
-        sys.tracebacklimit = int(tb_limit)
-else:
+tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
+if tb_limit:
+    sys.tracebacklimit = int(tb_limit)
+elif not args.debug:
     sys.tracebacklimit = 0
+# sys.traceback limit defaults to 1000
 
 def uniq(seq):
     exists = set()

--- a/bin/vyper
+++ b/bin/vyper
@@ -12,10 +12,6 @@ from vyper.parser import parser_utils
 
 
 warnings.simplefilter('always')
-sys.tracebacklimit = 0
-tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
-if tb_limit:
-    sys.tracebacklimit = int(tb_limit)
 
 format_options_help = """Format to print, one or more of:
  bytecode (default) - Deployable bytecode
@@ -37,8 +33,15 @@ parser.add_argument('input_files', help='Vyper sourcecode to compile', nargs='+'
 parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))
 parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")
 parser.add_argument('-f', help=format_options_help, default='bytecode', dest='format')
+parser.add_argument('--debug', help='Add compiler debugging output', action='store_true')
 
 args = parser.parse_args()
+
+tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
+if tb_limit:
+    sys.tracebacklimit = int(tb_limit)
+if not args.debug:
+    sys.tracebacklimit = 0
 
 
 def uniq(seq):


### PR DESCRIPTION
### - What I did
Add a `--debug` flag which doesn't set the traceback limit to 0. In the future we can add more debug info, and also remove `VYPER_TRACEBACK_LIMIT`

### - How I did it

### - How to verify it
```bash
vyper --debug /dev/stdin <<EOF
> nonsense
> EOF
```

### - Description for the changelog
Add a `--debug` flag to the vyper binary.

### - Cute Animal Picture

![](https://www.funoramic.com/wp-content/uploads/2017/06/34-Super-Cute-Animals-18.jpg)