### PR TITLE
Fix the types of name and symbol in ERC20

### DIFF
--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -4,8 +4,8 @@
 Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
 Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
-name: public(bytes32)
-symbol: public(bytes32)
+name: public(bytes[5])
+symbol: public(bytes[40])
 decimals: public(uint256)
 balances: map(address, uint256)
 allowances: map(address, map(address, uint256))
@@ -14,7 +14,7 @@ minter: address
 
 
 @public
-def __init__(_name: bytes32, _symbol: bytes32, _decimals: uint256, _supply: uint256):
+def __init__(_name: bytes[5], _symbol: bytes[40], _decimals: uint256, _supply: uint256):
     init_supply: uint256 = _supply * 10 ** _decimals
     self.name = _name
     self.symbol = _symbol

--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -4,8 +4,8 @@
 Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
 Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
-name: public(bytes[5])
-symbol: public(bytes[40])
+name: public(bytes[40])
+symbol: public(bytes[5])
 decimals: public(uint256)
 balances: map(address, uint256)
 allowances: map(address, map(address, uint256))
@@ -14,7 +14,7 @@ minter: address
 
 
 @public
-def __init__(_name: bytes[5], _symbol: bytes[40], _decimals: uint256, _supply: uint256):
+def __init__(_name: bytes[40], _symbol: bytes[5], _decimals: uint256, _supply: uint256):
     init_supply: uint256 = _supply * 10 ** _decimals
     self.name = _name
     self.symbol = _symbol

--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -4,8 +4,8 @@
 Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
 Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
-name: public(bytes[40])
-symbol: public(bytes[5])
+name: public(bytes[64])
+symbol: public(bytes[32])
 decimals: public(uint256)
 balances: map(address, uint256)
 allowances: map(address, map(address, uint256))
@@ -14,7 +14,7 @@ minter: address
 
 
 @public
-def __init__(_name: bytes[40], _symbol: bytes[5], _decimals: uint256, _supply: uint256):
+def __init__(_name: bytes[64], _symbol: bytes[32], _decimals: uint256, _supply: uint256):
     init_supply: uint256 = _supply * 10 ** _decimals
     self.name = _name
     self.symbol = _symbol

--- a/tests/examples/market_maker/test_on_chain_market_maker.py
+++ b/tests/examples/market_maker/test_on_chain_market_maker.py
@@ -37,7 +37,7 @@ def test_initiate(w3, market_maker, erc20, assert_tx_failed):
     assert market_maker.totalTokenQty() == 1 * 10**18
     assert market_maker.invariant() == 2 * 10**36
     assert market_maker.owner() == a0
-    assert erc20.name().split(b'\0', 1)[0] == TOKEN_NAME
+    assert erc20.name() == TOKEN_NAME
     assert erc20.decimals() == TOKEN_DECIMALS
 
     # Initiate cannot be called twice

--- a/tests/examples/tokens/test_erc20.py
+++ b/tests/examples/tokens/test_erc20.py
@@ -14,6 +14,7 @@ TOKEN_SYMBOL = b"FANG"
 TOKEN_DECIMALS = 18
 TOKEN_INITIAL_SUPPLY = 0
 
+
 @pytest.fixture
 def c(get_contract, w3):
     with open('examples/tokens/ERC20.vy') as f:

--- a/tests/examples/tokens/test_erc20.py
+++ b/tests/examples/tokens/test_erc20.py
@@ -9,28 +9,27 @@ from web3.exceptions import (
 
 ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 MAX_UINT256 = (2 ** 256) - 1  # Max uint256 value
-
+TOKEN_NAME = b"Vypercoin"
+TOKEN_SYMBOL = b"FANG"
+TOKEN_DECIMALS = 18
+TOKEN_INITIAL_SUPPLY = 0
 
 @pytest.fixture
-def c(get_contract, w3, bytes_helper):
+def c(get_contract, w3):
     with open('examples/tokens/ERC20.vy') as f:
         code = f.read()
-    name = bytes_helper("Vypercoin", 32)
-    symbol = bytes_helper("VYP", 32)
-    c = get_contract(code, name, symbol, 0, 0)
+    c = get_contract(code, *[TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, TOKEN_INITIAL_SUPPLY])
     return c
 
 
 @pytest.fixture
-def c_bad(get_contract, w3, bytes_helper):
+def c_bad(get_contract, w3):
     # Bad contract is used for overflow checks on totalSupply corrupted
     with open('examples/tokens/ERC20.vy') as f:
         code = f.read()
-    name = bytes_helper("Vypercoin", 32)
-    symbol = bytes_helper("VYP", 32)
     bad_code = code.replace("self.total_supply += _value", "") \
                 .replace("self.total_supply -= _value", "")
-    c = get_contract(bad_code, name, symbol, 0, 0)
+    c = get_contract(bad_code, *[TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, TOKEN_INITIAL_SUPPLY])
     return c
 
 
@@ -46,8 +45,11 @@ def get_log_args(get_logs):
 
 def test_initial_state(c, w3):
     a1, a2, a3 = w3.eth.accounts[1:4]
-    # Check total supply is 0
-    assert c.totalSupply() == 0
+    # Check total supply, name, symbol and decimals are correctly set
+    assert c.totalSupply() == TOKEN_INITIAL_SUPPLY
+    assert c.name() == TOKEN_NAME
+    assert c.symbol() == TOKEN_SYMBOL
+    assert c.decimals() == TOKEN_DECIMALS
     # Check several account balances as 0
     assert c.balanceOf(a1) == 0
     assert c.balanceOf(a2) == 0

--- a/tests/parser/features/external_contracts/test_erc20_abi.py
+++ b/tests/parser/features/external_contracts/test_erc20_abi.py
@@ -26,11 +26,11 @@ def __init__(token_addr: address):
     self.token_address = token_addr
 
 @public
-def name() -> bytes32:
+def name() -> bytes[40]:
     return self.token_address.name()
 
 @public
-def symbol() -> bytes32:
+def symbol() -> bytes[5]:
     return self.token_address.symbol()
 
 @public
@@ -60,16 +60,11 @@ def allowance(_owner: address, _spender: address) -> uint256:
     return get_contract(erc20_caller_code, *[erc20.address])
 
 
-def pad_bytes32(instr):
-    """ Pad a string \x00 bytes to return correct bytes32 representation. """
-    return instr + (32 - len(instr)) * b'\x00'
-
-
 def test_initial_state(w3, erc20_caller):
     assert erc20_caller.totalSupply() == TOKEN_TOTAL_SUPPLY == erc20_caller.balanceOf(w3.eth.accounts[0])
     assert erc20_caller.balanceOf(w3.eth.accounts[1]) == 0
-    assert erc20_caller.name() == pad_bytes32(TOKEN_NAME)
-    assert erc20_caller.symbol() == pad_bytes32(TOKEN_SYMBOL)
+    assert erc20_caller.name() == TOKEN_NAME
+    assert erc20_caller.symbol() == TOKEN_SYMBOL
     assert erc20_caller.decimals() == TOKEN_DECIMALS
 
 

--- a/tests/parser/features/external_contracts/test_erc20_abi.py
+++ b/tests/parser/features/external_contracts/test_erc20_abi.py
@@ -26,11 +26,11 @@ def __init__(token_addr: address):
     self.token_address = token_addr
 
 @public
-def name() -> bytes[40]:
+def name() -> bytes[64]:
     return self.token_address.name()
 
 @public
-def symbol() -> bytes[5]:
+def symbol() -> bytes[32]:
     return self.token_address.symbol()
 
 @public

--- a/vyper/premade_contracts.py
+++ b/vyper/premade_contracts.py
@@ -2,8 +2,8 @@ import ast
 
 erc20 = """
 class ERC20():
-    def name() -> bytes[40]: constant
-    def symbol() -> bytes[5]: constant
+    def name() -> bytes[64]: constant
+    def symbol() -> bytes[32]: constant
     def decimals() -> uint256: constant
     def balanceOf(_owner: address) -> uint256: constant
     def totalSupply() -> uint256: constant

--- a/vyper/premade_contracts.py
+++ b/vyper/premade_contracts.py
@@ -2,8 +2,8 @@ import ast
 
 erc20 = """
 class ERC20():
-    def name() -> bytes32: constant
-    def symbol() -> bytes32: constant
+    def name() -> bytes[40]: constant
+    def symbol() -> bytes[5]: constant
     def decimals() -> uint256: constant
     def balanceOf(_owner: address) -> uint256: constant
     def totalSupply() -> uint256: constant


### PR DESCRIPTION
### - What I did
Fixed the types of `name` and `symbol` in ERC20.
(Thanks @fubuloubu !)

### - How I did it
`bytes` is more appropriate as a substitute for `string` in Solidity so I changed the type of `name` and `symbol` in ERC20 example.

### - How to verify it
Tests.

### - Description for the changelog
Fixed the types of `name` and `symbol` in ERC20.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/22876645/51481300-e7c27b00-1dd6-11e9-9d73-ad9ec5e8a323.png)

