### PR TITLE
Remove the description of `None` from docs

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -488,6 +488,7 @@ Initial Values
 **************
 
 In Vyper, there is no ``null`` option like most programing languages have. Thus, every variable type has a default value. In order to check if a variable is empty, you will need to compare it to its type's default value.
+If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.  
 
 Here you can find a list of all types and default values:
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -483,12 +483,11 @@ Custom constants can be defined at a global level in Vyper. To define a constant
       return MAX_SHARES * SHARE_PRICE
 
 
-***********************
-Initial Values and None
-***********************
+**************
+Initial Values
+**************
 
-In Vyper, there is no ``null`` option like most programing languages have. Thus, every variable type has a default value.
-Nevertheless Vyper has the option to declare ``None`` which represent the default value of the type. Note that there is no option to assign ``None`` when initiating a variable. Also, note that you can't make comparisons to None. In order to check if a variable is empty, you will need to compare it to its type's default value.
+In Vyper, there is no ``null`` option like most programing languages have. Thus, every variable type has a default value. In order to check if a variable is empty, you will need to compare it to its type's default value.
 
 Here you can find a list of all types and default values:
 


### PR DESCRIPTION
### - What I did
`None` is not supported (#1106) so I removed the description from docs.

### - How I did it

### - How to verify it

### - Description for the changelog
Removed the description of `None` from docs