### PR TITLE
Ensure call to function make_struct_type has correct number of arguments

### DIFF
--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -327,7 +327,7 @@ def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None
                 return ContractType(item.args[0].id)
         # Struct types
         if (custom_structs is not None) and (item.func.id in custom_structs):
-            return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs)
+            return make_struct_type(item.id, location, custom_structs[item.id], custom_units, custom_structs, constants)
         if not isinstance(item.func, ast.Name):
             raise InvalidTypeException("Malformed unit type:", item)
         base_type = item.func.id


### PR DESCRIPTION
The call to <make_struct_type> has a missing argument, which may cause a run-time failure. This commit fixes the call to include the correct number of arguments.

### - What I did

I added the missing <constants> parameter to the call to <make_struct_type>

### - Friendly disclaimer

I work for Semmle, and noticed the bug with our LGTM code analyzer:
https://lgtm.com/projects/g/ethereum/vyper/snapshot/dist-1506710546241-1548102310071/files/vyper/types/types.py?sort=name&dir=ASC&mode=heatmap#x62d2d89c83c310e4:1

I helped develop LGTM's code quality algorithms, and I'm interested in knowing how much fixing and clean-up effort is required to move a project up a grade. E.g., Vyper is doing great for JavaScript but has a few issues in Python.
[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/ethereum/vyper.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ethereum/vyper/context:javascript)
[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/ethereum/vyper.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ethereum/vyper/context:python)
https://lgtm.com/projects/g/ethereum/vyper/

If you enable LGTM automated code review on Vyper you can prevent these issues prior to merging.
https://lgtm.com/projects/g/ethereum/vyper/ci/

Best wishes!
Ian.