### PR TITLE
Fix "Unknown interface" exceptions

### DIFF
--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -84,11 +84,11 @@ def get_asm(asm_list):
 
 def get_source_map(code, contract_name, interface_codes=None):
     asm_list = compile_lll.compile_to_assembly(
-            optimizer.optimize(
-                parser.parse_to_lll(
-                    code,
-                    runtime_only=True,
-                    interface_codes=interface_codes)))
+        optimizer.optimize(
+            parser.parse_to_lll(
+                code,
+                runtime_only=True,
+                interface_codes=interface_codes)))
     c, line_number_map = compile_lll.assembly_to_evm(asm_list)
     # Sort line_number_map
     out = OrderedDict()

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -53,7 +53,7 @@ def gas_estimate(origcode, *args, **kwargs):
 def mk_full_signature(code, *args, **kwargs):
     abi = parser.mk_full_signature(parser.parse_to_ast(code), *args, **kwargs)
     # Add gas estimates for each function to ABI
-    gas_estimates = gas_estimate(code)
+    gas_estimates = gas_estimate(code, *args, **kwargs)
     for idx, func in enumerate(abi):
         func_name = func['name'].split('(')[0]
         # Skip __init__, has no estimate
@@ -82,13 +82,13 @@ def get_asm(asm_list):
     return output_string
 
 
-def get_source_map(code, interface_codes=None):
+def get_source_map(code, contract_name, interface_codes=None):
     asm_list = compile_lll.compile_to_assembly(
             optimizer.optimize(
                 parser.parse_to_lll(
                     code,
                     runtime_only=True,
-                    interface_codes=interfaces_codes)))
+                    interface_codes=interface_codes)))
     c, line_number_map = compile_lll.assembly_to_evm(asm_list)
     # Sort line_number_map
     out = OrderedDict()
@@ -104,7 +104,7 @@ output_formats_map = {
     'bytecode_runtime': lambda code, contract_name, interface_codes: '0x' + __compile(code, bytecode_runtime=True, interface_codes=interface_codes).hex(),
     'ir': lambda code, contract_name, interface_codes: optimizer.optimize(parser.parse_to_lll(code, interface_codes=interface_codes)),
     'asm': lambda code, contract_name, interface_codes: get_asm(compile_lll.compile_to_assembly(optimizer.optimize(parser.parse_to_lll(code, interface_codes=interface_codes)))),
-    'source_map': lambda code, _, interface_codes: get_source_map(code, interface_codes=interface_codes),
+    'source_map': lambda code, contract_name, interface_codes: get_source_map(code, contract_name, interface_codes=interface_codes),
     'method_identifiers': lambda code, contract_name, interface_codes: parser.mk_method_identifiers(code, interface_codes=interface_codes),
     'interface': lambda code, contract_name, interface_codes: extract_interface_str(code, contract_name, interface_codes=interface_codes),
     'external_interface': lambda code, contract_name, interface_codes: extract_external_interface(code, contract_name, interface_codes=interface_codes),

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -36,7 +36,7 @@ def __compile(code, interface_codes=None, *args, **kwargs):
 
 def gas_estimate(origcode, *args, **kwargs):
     o = {}
-    code = optimizer.optimize(parser.parse_to_lll(origcode))
+    code = optimizer.optimize(parser.parse_to_lll(origcode, *args, **kwargs))
 
     # Extract the stuff inside the LLL bracket
     if code.value == 'seq':
@@ -51,7 +51,7 @@ def gas_estimate(origcode, *args, **kwargs):
 
 
 def mk_full_signature(code, *args, **kwargs):
-    abi = parser.mk_full_signature(parser.parse_to_ast(code))
+    abi = parser.mk_full_signature(parser.parse_to_ast(code), *args, **kwargs)
     # Add gas estimates for each function to ABI
     gas_estimates = gas_estimate(code)
     for idx, func in enumerate(abi):
@@ -82,8 +82,13 @@ def get_asm(asm_list):
     return output_string
 
 
-def get_source_map(code):
-    asm_list = compile_lll.compile_to_assembly(optimizer.optimize(parser.parse_to_lll(code, runtime_only=True)))
+def get_source_map(code, interface_codes=None):
+    asm_list = compile_lll.compile_to_assembly(
+            optimizer.optimize(
+                parser.parse_to_lll(
+                    code,
+                    runtime_only=True,
+                    interface_codes=interfaces_codes)))
     c, line_number_map = compile_lll.assembly_to_evm(asm_list)
     # Sort line_number_map
     out = OrderedDict()
@@ -94,15 +99,15 @@ def get_source_map(code):
 
 
 output_formats_map = {
-    'abi': lambda code, contract_name, interface_codes: mk_full_signature(code),
+    'abi': lambda code, contract_name, interface_codes: mk_full_signature(code, interface_codes=interface_codes),
     'bytecode': lambda code, contract_name, interface_codes: '0x' + __compile(code, interface_codes=interface_codes).hex(),
     'bytecode_runtime': lambda code, contract_name, interface_codes: '0x' + __compile(code, bytecode_runtime=True, interface_codes=interface_codes).hex(),
-    'ir': lambda code, contract_name, interface_codes: optimizer.optimize(parser.parse_to_lll(code)),
-    'asm': lambda code, contract_name, interface_codes: get_asm(compile_lll.compile_to_assembly(optimizer.optimize(parser.parse_to_lll(code)))),
-    'source_map': get_source_map,
-    'method_identifiers': lambda code, contract_name, interface_codes: parser.mk_method_identifiers(code),
-    'interface': lambda code, contract_name, interface_codes: extract_interface_str(code, contract_name),
-    'external_interface': lambda code, contract_name, interface_codes: extract_external_interface(code, contract_name),
+    'ir': lambda code, contract_name, interface_codes: optimizer.optimize(parser.parse_to_lll(code, interface_codes=interface_codes)),
+    'asm': lambda code, contract_name, interface_codes: get_asm(compile_lll.compile_to_assembly(optimizer.optimize(parser.parse_to_lll(code, interface_codes=interface_codes)))),
+    'source_map': lambda code, _, interface_codes: get_source_map(code, interface_codes=interface_codes),
+    'method_identifiers': lambda code, contract_name, interface_codes: parser.mk_method_identifiers(code, interface_codes=interface_codes),
+    'interface': lambda code, contract_name, interface_codes: extract_interface_str(code, contract_name, interface_codes=interface_codes),
+    'external_interface': lambda code, contract_name, interface_codes: extract_external_interface(code, contract_name, interface_codes=interface_codes),
 }
 
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -134,14 +134,14 @@ def generate_default_arg_sigs(code, contracts, global_ctx):
 
 
 # Get ABI signature
-def mk_full_signature(code, sig_formatter=None):
+def mk_full_signature(code, sig_formatter=None, interface_codes=None):
 
     if sig_formatter is None:
         # Use default JSON style ouptu.
         sig_formatter = lambda sig, custom_units_descriptions: sig.to_abi_dict(custom_units_descriptions)
 
     o = []
-    global_ctx = GlobalContext.get_global_context(code)
+    global_ctx = GlobalContext.get_global_context(code, interface_codes=interface_codes)
 
     # Produce event signatues.
     for code in global_ctx._events:
@@ -163,9 +163,9 @@ def mk_full_signature(code, sig_formatter=None):
     return o
 
 
-def mk_method_identifiers(code):
+def mk_method_identifiers(code, interface_codes=None):
     o = {}
-    global_ctx = GlobalContext.get_global_context(parse_to_ast(code))
+    global_ctx = GlobalContext.get_global_context(parse_to_ast(code), interface_codes=interface_codes)
 
     for code in global_ctx._defs:
         sig = FunctionSignature.from_definition(code, sigs=global_ctx._contracts, custom_units=global_ctx._custom_units, constants=global_ctx._constants)
@@ -233,8 +233,8 @@ def parse_other_functions(o, otherfuncs, sigs, external_contracts, origcode, glo
 
 
 # Main python parse tree => LLL method
-def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None,):
-    global_ctx = GlobalContext.get_global_context(code, interface_codes)
+def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None):
+    global_ctx = GlobalContext.get_global_context(code, interface_codes=interface_codes)
     _names_def = [_def.name for _def in global_ctx._defs]
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
@@ -861,6 +861,6 @@ def pack_logging_data(expected_data, args, context, pos):
     return holder, maxlen, dynamic_offset_counter, datamem_start
 
 
-def parse_to_lll(kode, runtime_only=False):
+def parse_to_lll(kode, runtime_only=False, interface_codes=None):
     code = parse_to_ast(kode)
-    return parse_tree_to_lll(code, kode, runtime_only=runtime_only)
+    return parse_tree_to_lll(code, kode, runtime_only=runtime_only, interface_codes=interface_codes)

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -31,8 +31,8 @@ def extract_sigs(code):
     return sigs
 
 
-def extract_interface_str(code, contract_name):
-    sigs = parser.mk_full_signature(parser.parse_to_ast(code), sig_formatter=lambda x, y: (x, y))
+def extract_interface_str(code, contract_name, interface_codes=None):
+    sigs = parser.mk_full_signature(parser.parse_to_ast(code), sig_formatter=lambda x, y: (x, y), interface_codes=interface_codes)
     events = [sig for sig, _ in sigs if isinstance(sig, EventSignature)]
     functions = [sig for sig, _ in sigs if isinstance(sig, FunctionSignature)]
     out = ""
@@ -69,8 +69,8 @@ def extract_interface_str(code, contract_name):
     return out
 
 
-def extract_external_interface(code, contract_name):
-    sigs = parser.mk_full_signature(parser.parse_to_ast(code), sig_formatter=lambda x, y: (x, y))
+def extract_external_interface(code, contract_name, interface_codes=None):
+    sigs = parser.mk_full_signature(parser.parse_to_ast(code), sig_formatter=lambda x, y: (x, y), interface_codes=interface_codes)
     functions = [sig for sig, _ in sigs if isinstance(sig, FunctionSignature)]
     cname = os.path.basename(contract_name).split('.')[0].capitalize()
 


### PR DESCRIPTION
### What I did
Fix some "Unknown interface" exceptions (from gitter, cf. https://gitter.im/ethereum/vyper?at=5c61fbf3adf6cb0b2ca19a72)

### How I did it
Pass interface_codes for other compiler flags

### How to verify it
```bash
$ cat repro_impl.vy 
import repro_iface as Interface
implements: Interface
@public
@constant
def method1(addr: address) -> bool:
    return msg.sender == addr
$ cat repro_iface.vy 
@public
@constant
def method1(addr: address) -> bool:
    pass
$ vyper -f abi repro_impl.vy # repeat for abi,asm,source_map,method_identifiers,interface,external_interface
```

### Description for the changelog
Enable imports for other compiler outputs

### Cute Animal Picture

![](https://wallpaperbrowse.com/media/images/Augusta-has-reached-one-million-views.jpg)
