### PR TITLE
Removed duplicated 'Event Logging' in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,6 @@ Glossary
     logging.rst
     vyper-in-depth.rst
     contributing.rst
-    logging.rst
     frequently-asked-questions.rst
     built-in-functions.rst
     types.rst


### PR DESCRIPTION
### What I did
Removed duplicated 'Event Logging' in side menu.

### How I did it
Edited index.rst

### How to verify it

<img width="1114" alt="vyper_ _vyper_documentation" src="https://user-images.githubusercontent.com/407843/52706765-83579d80-2fc9-11e9-9088-d883fd6553ac.png">

### Description for the changelog
Removed duplicated 'Event Logging' in side menu.

### Cute Animal Picture

![img_3541](https://user-images.githubusercontent.com/407843/52706907-cd408380-2fc9-11e9-8aec-85b1d8b40f84.jpeg)
