### PR TITLE
fix docker build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     py_modules=['vyper'],
     install_requires=[
         'pycryptodome>=3.5.1,<4',
+        'rlp<2.0.0,>=1.0.3'
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
### What I did
- Fix docker build. Getting the following error when running : 

> docker build .


```
error : 
Traceback (most recent call last):
  File "setup.py", line 52, in <module>
    'Programming Language :: Python :: 3.6',
  File "/usr/local/lib/python3.6/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/code/.eggs/pytest_runner-4.2-py3.6.egg/ptr.py", line 169, in run
    installed_dists = self.install_dists(dist)
  File "/code/.eggs/pytest_runner-4.2-py3.6.egg/ptr.py", line 130, in install_dists
    orig.test.install_dists(dist),
  File "/usr/local/lib/python3.6/site-packages/setuptools/command/test.py", line 208, in install_dists
    tr_d = dist.fetch_build_eggs(dist.tests_require or [])
  File "/usr/local/lib/python3.6/site-packages/setuptools/dist.py", line 724, in fetch_build_eggs
    replace_conflicting=True,
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (rlp 1.0.2 (/code/.eggs/rlp-1.0.2-py3.6.egg), Requirement.parse('rlp<2.0.0,>=1.0.3'), {'py-evm'})
The command '/bin/sh -c python setup.py install &&     python setup.py test --addopts "--version" &&     apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev' returned a non-zero code: 1
```

### How I did it

- rlp to install dependencies 

### How to verify it

- docker build .

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/1436105/52956611-941c6080-3387-11e9-86f1-fc5eb91f517d.png)
