### PR TITLE
Make check for nested opcodes in compiler run lazy

### DIFF
--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -24,7 +24,7 @@ def __compile(code, interface_codes=None, *args, **kwargs):
             return True
         else:
             sublists = [sub for sub in asm_list if isinstance(sub, list)]
-            return any([find_nested_opcode(x, key) for x in sublists])
+            return any(find_nested_opcode(x, key) for x in sublists)
 
     if find_nested_opcode(asm, 'DEBUG'):
         print('Please note this code contains DEBUG opcode.')


### PR DESCRIPTION
### What was wrong

The `find_nested_opcodes` used a list comprehension inside of the `any` check, which meant that the list would need to be fully evaluated before the `any` check executed.  However, since `any` only needs a single value to be truthy, this does extra work.t

### how it was fixed

Removed the `[]` from the comprehension to convert it to a lazy generator, which allows `any` to exit early as soon as it finds any truthy value.

### Description for the changelog

- Minor performance improvement to compilation by making nested opcode check lazy.

### Cute Animal Picture

![cute-baby-fox](https://user-images.githubusercontent.com/824194/53032230-afd94280-342b-11e9-9317-62329c08c555.jpg)


