### PR TITLE
Remove mutable data structure as default function argument

### DIFF
--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -113,7 +113,7 @@ output_formats_map = {
 
 def compile_codes(codes, output_formats=None, output_type='list', exc_handler=None, interface_codes=None):
     if output_formats is None:
-        ouptup_formats = ('bytecode',)
+        output_formats = ('bytecode',)
 
     out = OrderedDict()
     for contract_name, code in codes.items():

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -111,7 +111,9 @@ output_formats_map = {
 }
 
 
-def compile_codes(codes, output_formats=['bytecode'], output_type='list', exc_handler=None, interface_codes=None):
+def compile_codes(codes, output_formats=None, output_type='list', exc_handler=None, interface_codes=None):
+    if output_formats is None:
+        ouptup_formats = ('bytecode',)
 
     out = OrderedDict()
     for contract_name, code in codes.items():
@@ -139,6 +141,6 @@ def compile_codes(codes, output_formats=['bytecode'], output_type='list', exc_ha
         raise Exception('Unknown output_type')
 
 
-def compile_code(code, output_formats=['bytecode']):
+def compile_code(code, output_formats=None):
     codes = {'': code}
     return compile_codes(codes, output_formats, 'list')[0]


### PR DESCRIPTION
### What was wrong

The functions `vyper.compiler.compile_code` and `vyper.compiler.compile_codes` use a list as a default for a function argument.  This is a common error.  While the current usage was benign, were this value to be mutated during the course of the function, those mutations would persist through the next function call.

### How I fixed it.

The function now uses a default argument of `None` and has new logic to put the appropriate default in place if no value has been explicitly provided.

### Description for the changelog

- Remove usage of mutable default for function argument in `vyper.compiler.compile_code` and `cyper.compiler.compile_codes`

### Cute Animal Picture

![baby-fox_624](https://user-images.githubusercontent.com/824194/53032973-35a9bd80-342d-11e9-978a-ebdc4ca05ab4.jpg)

