### PR TITLE
Use functools.wraps for decorators

### DIFF
--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -1,3 +1,5 @@
+import functools
+
 from vyper.parser.parser import LLLnode
 from .opcodes import opcodes
 from vyper.utils import MemoryPositions
@@ -52,6 +54,7 @@ class instruction(str):
 
 
 def apply_line_numbers(func):
+    @functools.wraps(func)
     def apply_line_no_wrapper(*args, **kwargs):
         code = args[0]
         ret = func(*args, **kwargs)

--- a/vyper/functions/signature.py
+++ b/vyper/functions/signature.py
@@ -1,4 +1,5 @@
 import ast
+import functools
 
 from vyper.parser.parser_utils import (
     get_original_if_0_prefixed,
@@ -94,6 +95,7 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
 
 def signature(*argz, **kwargz):
     def decorator(f):
+        @functools.wraps(f)
         def g(element, context):
             function_name = element.func.id
             if len(element.args) > len(argz):


### PR DESCRIPTION
### What was wrong?

Two decorator functions which didn't use `functools.wraps` which means that the resulting functions will all end up having the same `__name__`, thus making them a bit harder to reason about when digging around in the vyper code from a CLI.

### How I fixed it.

Ensure that the inner functions are decorated with `functools.wraps`

### Cute Animal Picture

![ff821fa7d7e83a6d25514c36ec032f49](https://user-images.githubusercontent.com/824194/53051689-f3e33c00-3459-11e9-96bd-bacbe5825ade.jpg)

