### PR TITLE
Cleanup loop in mk_full_signature to be easier to read

### DIFF
--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -54,11 +54,18 @@ def mk_full_signature(code, *args, **kwargs):
     abi = parser.mk_full_signature(parser.parse_to_ast(code), *args, **kwargs)
     # Add gas estimates for each function to ABI
     gas_estimates = gas_estimate(code, *args, **kwargs)
-    for idx, func in enumerate(abi):
-        func_name = func.get('name', '').split('(')[0]
-        # Skip __init__, has no estimate
+    for func in abi:
+        try:
+            func_signature = func['name']
+        except KeyError:
+            # constructor and fallback functions don't have a name
+            continue
+
+        func_name, _, _ = func_signature.partition('(')
+        # This check ensures we skip __init__ since it has no estimate
         if func_name in gas_estimates:
-            abi[idx]['gas'] = gas_estimates[func_name]
+            # TODO: mutation
+            func['gas'] = gas_estimates[func_name]
     return abi
 
 


### PR DESCRIPTION
### What was wrong

The body of the `mk_full_signature` function was a little confusing to follow, using an `enumerate` based loop and then indexing back into the main data structure being looped over.

### How I fixed it

I modified the loop to just modify the dictionary in place which is currently still taking advantage of the mutable data structures so that the changes propagate to the returned `abi` value.

I also cleaned up how the function name was being extracted and added a few comments to explain why certain control flows are in place.

### Cute Animal Picture

![18642605](https://user-images.githubusercontent.com/824194/53052444-01012a80-345c-11e9-941e-867b98a22d72.jpg)

