### PR TITLE
Bump pyevm versions for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	python setup.py install
 
 test:
-	python setup.py test
+	python setup.py test --addopts "-n auto"
 
 lint:
 	flake8 vyper tests --ignore=E122,E124,E127,E128,E501,E731,W504

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	python setup.py install
 
 test:
-	python setup.py test --addopts "-n auto"
+	python setup.py test
 
 lint:
 	flake8 vyper tests --ignore=E122,E124,E127,E128,E501,E731,W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov-report term --cov-report html --cov=vyper
+addopts = -n auto --cov-report term --cov-report html --cov=vyper
 python_files = test_*.py
 testpaths = tests
 

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ from setuptools import setup, find_packages
 test_deps = [
     'pytest',
     'pytest-cov',
-    'py-evm==0.2.0a34',
-    'eth-tester==0.1.0b33',
-    'web3==4.8.2',
+    'pytest-xdist==1.26.1',
+    'py-evm==0.2.0a39',
+    'eth-tester==0.1.0b37',
+    'web3==5.0.0a6'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup, find_packages
 
 
 test_deps = [
-    'pytest',
-    'pytest-cov',
-    'pytest-xdist==1.26.1',
+    'pytest>=3.6',
+    'pytest-cov==2.4.0',
+    'pytest-xdist==1.18.1',
     'py-evm==0.2.0a39',
     'eth-tester==0.1.0b37',
     'web3==5.0.0a6'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def w3(tester):
 
 @pytest.fixture
 def keccak():
-    return Web3.sha3
+    return Web3.keccak
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import eth_tester
 import logging
 import pytest
 
@@ -63,8 +62,8 @@ class VyperContract(ConciseContract):
 # PATCHING #
 ############
 
-setattr(eth_tester.backends.pyevm.main, 'GENESIS_GAS_LIMIT', 10**9)
-setattr(eth_tester.backends.pyevm.main, 'GENESIS_DIFFICULTY', 1)
+# setattr(eth_tester.backends.pyevm.main, 'GENESIS_GAS_LIMIT', 10**9)
+# setattr(eth_tester.backends.pyevm.main, 'GENESIS_DIFFICULTY', 1)
 
 
 def set_evm_verbose_logging():
@@ -73,12 +72,12 @@ def set_evm_verbose_logging():
 
 
 # Useful options to comment out whilst working:
-set_evm_verbose_logging()
+# set_evm_verbose_logging()
 # from vdb import vdb
 # vdb.set_evm_opcode_debugger()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tester():
     t = EthereumTester()
     return t
@@ -88,7 +87,7 @@ def zero_gas_price_strategy(web3, transaction_params=None):
     return 0  # zero gas price makes testing simpler.
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def w3(tester):
     w3 = Web3(EthereumTesterProvider(tester))
     w3.eth.setGasPriceStrategy(zero_gas_price_strategy)

--- a/tests/examples/auctions/test_blind_auction.py
+++ b/tests/examples/auctions/test_blind_auction.py
@@ -39,7 +39,7 @@ def test_late_bid(w3, auction_contract, assert_tx_failed):
 
     # Try to bid after bidding has ended
     assert_tx_failed(lambda: auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (200).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (8675309).to_bytes(32, byteorder='big')
@@ -54,7 +54,7 @@ def test_too_many_bids(w3, auction_contract, assert_tx_failed):
     # First 128 bids should be able to be placed successfully
     for i in range(MAX_BIDS):
         auction_contract.bid(
-            w3.sha3(b''.join([
+            w3.keccak(b''.join([
                 (i).to_bytes(32, byteorder='big'),
                 (1).to_bytes(32, byteorder='big'),
                 (8675309).to_bytes(32, byteorder='big')
@@ -64,7 +64,7 @@ def test_too_many_bids(w3, auction_contract, assert_tx_failed):
 
     # 129th bid should fail
     assert_tx_failed(lambda: auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (128).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (8675309).to_bytes(32, byteorder='big')
@@ -78,7 +78,7 @@ def test_early_reval(w3, auction_contract, assert_tx_failed):
 
     # k1 places 1 real bid
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (100).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (8675309).to_bytes(32, byteorder='big')
@@ -116,7 +116,7 @@ def test_late_reveal(w3, auction_contract, assert_tx_failed):
 
     # k1 places 1 real bid
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (100).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (8675309).to_bytes(32, byteorder='big')
@@ -184,7 +184,7 @@ def test_blind_auction(w3, auction_contract):
 
     # k1 places 1 real bid
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (100).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (8675309).to_bytes(32, byteorder='big')
@@ -194,7 +194,7 @@ def test_blind_auction(w3, auction_contract):
 
     # k2 places 1 real bid (highest) and 2 fake
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (150).to_bytes(32, byteorder='big'),
             (1).to_bytes(32, byteorder='big'),
             (1234567).to_bytes(32, byteorder='big')
@@ -202,7 +202,7 @@ def test_blind_auction(w3, auction_contract):
         transact={'value': 150, 'from': k2}
     )
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (200).to_bytes(32, byteorder='big'),
             (0).to_bytes(32, byteorder='big'),
             (1234567).to_bytes(32, byteorder='big')
@@ -210,7 +210,7 @@ def test_blind_auction(w3, auction_contract):
         transact={'value': 250, 'from': k2}
     )
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (300).to_bytes(32, byteorder='big'),
             (1).to_bytes(32, byteorder='big'),
             (1234567).to_bytes(32, byteorder='big')
@@ -220,7 +220,7 @@ def test_blind_auction(w3, auction_contract):
 
     # k3 places 2 fake bids
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (175).to_bytes(32, byteorder='big'),
             (1).to_bytes(32, byteorder='big'),
             (9876543).to_bytes(32, byteorder='big')
@@ -228,7 +228,7 @@ def test_blind_auction(w3, auction_contract):
         transact={'value': 175, 'from': k3}
     )
     auction_contract.bid(
-        w3.sha3(b''.join([
+        w3.keccak(b''.join([
             (275).to_bytes(32, byteorder='big') +
             (1).to_bytes(32, byteorder='big') +
             (9876543).to_bytes(32, byteorder='big')

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -9,11 +9,6 @@
 import pytest
 
 
-# Inital balance of accounts
-INIT_BAL_a0 = 1000000000000000000000000
-INIT_BAL_a1 = 1000000000000000000000000
-
-
 @pytest.fixture
 def contract_code(get_contract):
     with open("examples/safe_remote_purchase/safe_remote_purchase.vy") as f:
@@ -22,20 +17,19 @@ def contract_code(get_contract):
 
 
 @pytest.fixture
-def check_balance(w3, tester):
-    def check_balance():
+def get_balance(w3, tester):
+    def get_balance():
         a0, a1 = w3.eth.accounts[:2]
         # balance of a1 = seller, a2 = buyer
         return w3.eth.getBalance(a0), w3.eth.getBalance(a1)
-    return check_balance
+    return get_balance
 
 
-def test_initial_state(w3, assert_tx_failed, get_contract, check_balance, contract_code):
-    assert check_balance() == (INIT_BAL_a0, INIT_BAL_a1)
+def test_initial_state(w3, assert_tx_failed, get_contract, get_balance, contract_code):
     # Inital deposit has to be divisible by two
     assert_tx_failed(lambda: get_contract(contract_code, value=13))
     # Seller puts item up for sale
-    a0_pre_bal, a1_pre_bal = check_balance()
+    a0_pre_bal, a1_pre_bal = get_balance()
     c = get_contract(contract_code, value_in_eth=2)
     # Check that the seller is set correctly
     assert c.seller() == w3.eth.accounts[0]
@@ -44,26 +38,29 @@ def test_initial_state(w3, assert_tx_failed, get_contract, check_balance, contra
     # Check if unlocked() works correctly after initialization
     assert c.unlocked() is True
     # Check that sellers (and buyers) balance is correct
-    assert check_balance() == ((INIT_BAL_a0 - w3.toWei(2, 'ether')), INIT_BAL_a1)
+    assert get_balance() == ((a1_pre_bal - w3.toWei(2, 'ether')), a1_pre_bal)
 
 
-def test_abort(w3, assert_tx_failed, check_balance, get_contract, contract_code):
+def test_abort(w3, assert_tx_failed, get_balance, get_contract, contract_code):
     a0, a1, a2 = w3.eth.accounts[:3]
-    c = get_contract(contract_code, value=2)
+
+    a0_pre_bal, a1_pre_bal = get_balance()
+    c = get_contract(contract_code, value=w3.toWei(2, 'ether'))
+    assert c.value() == w3.toWei(1, 'ether')
     # Only sender can trigger refund
     assert_tx_failed(lambda: c.abort(transact={'from': a2}))
     # Refund works correctly
     c.abort(transact={'from': a0, 'gasPrice': 0})
-    assert check_balance() == (INIT_BAL_a0 - w3.toWei(2, 'ether'), INIT_BAL_a1)
+    assert get_balance() == (a0_pre_bal, a1_pre_bal)
     # Purchase in process, no refund possible
     c = get_contract(contract_code, value=2)
     c.purchase(transact={'value': 2, 'from': a1, 'gasPrice': 0})
     assert_tx_failed(lambda: c.abort(transact={'from': a0}))
 
 
-def test_purchase(w3, get_contract, assert_tx_failed, check_balance, contract_code):
+def test_purchase(w3, get_contract, assert_tx_failed, get_balance, contract_code):
     a0, a1, a2, a3 = w3.eth.accounts[:4]
-    init_bal_a0, init_bal_a1 = check_balance()
+    init_bal_a0, init_bal_a1 = get_balance()
     c = get_contract(contract_code, value=2)
     # Purchase for too low/high price
     assert_tx_failed(lambda: c.purchase(transact={'value': 1, 'from': a1}))
@@ -75,14 +72,14 @@ def test_purchase(w3, get_contract, assert_tx_failed, check_balance, contract_co
     # Check if contract is locked correctly
     assert c.unlocked() is False
     # Check balances, both deposits should have been deducted
-    assert check_balance() == (init_bal_a0 - 2, init_bal_a1 - 2)
+    assert get_balance() == (init_bal_a0 - 2, init_bal_a1 - 2)
     # Allow nobody else to purchase
     assert_tx_failed(lambda: c.purchase(transact={'value': 2, 'from': a3}))
 
 
-def test_received(w3, get_contract, assert_tx_failed, check_balance, contract_code):
+def test_received(w3, get_contract, assert_tx_failed, get_balance, contract_code):
     a0, a1 = w3.eth.accounts[:2]
-    init_bal_a0, init_bal_a1 = check_balance()
+    init_bal_a0, init_bal_a1 = get_balance()
     c = get_contract(contract_code, value=2)
     # Can only be called after purchase
     assert_tx_failed(lambda: c.received(transact={'from': a1, 'gasPrice': 0}))
@@ -93,10 +90,10 @@ def test_received(w3, get_contract, assert_tx_failed, check_balance, contract_co
     # Check if buyer can call receive
     c.received(transact={'from': a1, 'gasPrice': 0})
     # Final check if everything worked. 1 value has been transferred
-    assert check_balance() == (init_bal_a0 + 1, init_bal_a1 - 1)
+    assert get_balance() == (init_bal_a0 + 1, init_bal_a1 - 1)
 
 
-def test_received_reentrancy(w3, get_contract, assert_tx_failed, check_balance, contract_code):
+def test_received_reentrancy(w3, get_contract, assert_tx_failed, get_balance, contract_code):
 
     buyer_contract_code = """
 contract PurchaseContract:

--- a/tests/examples/wallet/test_wallet.py
+++ b/tests/examples/wallet/test_wallet.py
@@ -89,8 +89,8 @@ def test_javascript_signatures(w3, get_contract):
         ) for x in map(lambda z: w3.toBytes(hexstr=z[2:]), raw_sigs)
     ]
 
-    h = w3.sha3((0).to_bytes(32, "big") + b'\x00' * 12 + w3.toBytes(hexstr=recipient[2:]) + (25).to_bytes(32, "big") + b'')
-    h2 = w3.sha3(b"\x19Ethereum Signed Message:\n32" + h)
+    h = w3.keccak((0).to_bytes(32, "big") + b'\x00' * 12 + w3.toBytes(hexstr=recipient[2:]) + (25).to_bytes(32, "big") + b'')
+    h2 = w3.keccak(b"\x19Ethereum Signed Message:\n32" + h)
 
     # Check to make sure the signatures are valid
     assert is_same_address(Account.recoverHash(h2, sigs[0]), accounts[0])

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -48,15 +48,15 @@ def test2(a: int128, b: int128) -> int128:
     with pytest.raises(TransactionFailed) as e_info:
         c.test(0)
 
-    assert e_info.value.args[0] == b'larger than one please'
+    assert e_info.value.args[0] == 'larger than one please'
     # a = 0, b = 1
     with pytest.raises(TransactionFailed) as e_info:
         c.test2(0, 1)
-    assert e_info.value.args[0] == b'a is not large enough'
+    assert e_info.value.args[0] == 'a is not large enough'
     # a = 1, b = 0
     with pytest.raises(TransactionFailed) as e_info:
         c.test2(2, 2)
-    assert e_info.value.args[0] == b'b may only be 1'
+    assert e_info.value.args[0] == 'b may only be 1'
     # return correct value
     assert c.test2(5, 1) == 17
 

--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -110,15 +110,10 @@ def bar(a: int128, b: int128 = -1) -> (int128, int128):
     assert c.bar(-123) == [-123, -1]
     assert c.bar(100, 100) == [100, 100]
 
-    # bypass abi encoding checking:
-    def utils_abi_is_encodable(_type, value):
-        return True
-
     def validate_value(cls, value):
         pass
 
     monkeypatch.setattr('eth_abi.encoding.NumberEncoder.validate_value', validate_value)
-    monkeypatch.setattr('web3.utils.abi.is_encodable', utils_abi_is_encodable)
 
     assert c.bar(200, 2**127 - 1) == [200, 2**127 - 1]
     assert_tx_failed(lambda: c.bar(200, 2**127))


### PR DESCRIPTION
### What I did

- Fixes #1273 - wasn't stake leakage but pytest scope.
- Bumps pyevm, eth-tester, web3py versions.
- Enables pytest-xdist for `make test`.

### How I did it

### How to verify it

### Description for the changelog
Faster tests.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.guinealynx.info/images/swannie.jpg)
