### PR TITLE
vyper/functions/signature.py lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,6 @@ exclude=
     tests/parser/syntax/utils/test_function_names.py
     tests/parser/syntax/utils/test_variable_names.py
     vyper/compiler.py
-    vyper/functions/signature.py
     vyper/parser/constants.py
     vyper/parser/context.py
     vyper/parser/lll_node.py


### PR DESCRIPTION
Foregoing the animal pictures and descriptions with these lint PRs.  See #1262 and #1276 .