### PR TITLE
vyper/parser/constants.py lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,6 @@ exclude=
     vyper/functions/functions.py
     vyper/functions/signature.py
     vyper/optimizer.py
-    vyper/parser/constants.py
     vyper/parser/context.py
     vyper/parser/expr.py
     vyper/parser/external_call.py


### PR DESCRIPTION
Foregoing the animal pictures and descriptions with these lint PRs.  See #1262 and #1276 .