### PR TITLE
vyper/parser/pre_parser.py lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,6 @@ exclude=
     vyper/parser/lll_node.py
     vyper/parser/parser.py
     vyper/parser/parser_utils.py
-    vyper/parser/pre_parser.py
     vyper/parser/self_call.py
     vyper/parser/stmt.py
     vyper/signatures/event_signature.py

--- a/vyper/parser/pre_parser.py
+++ b/vyper/parser/pre_parser.py
@@ -60,7 +60,10 @@ def pre_parse(code):
                 parse_version_pragma(token.string[1:])
 
             if token.type == NAME and string == "class" and start[1] == 0:
-                raise StructureException("The `class` keyword is not allowed. Perhaps you meant `contract` or `struct`?", token.start)
+                raise StructureException(
+                    "The `class` keyword is not allowed. Perhaps you meant `contract` or `struct`?",
+                    token.start,
+                )
 
             if token.type == NAME and fetch_name:
                 class_names[string] = fetch_name


### PR DESCRIPTION
Foregoing the animal pictures and descriptions with these lint PRs.  See #1262 and #1276 .