### PR TITLE
vyper/compile_lll.py lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,6 @@ exclude=
     tests/parser/syntax/utils/test_variable_names.py
     tests/parser/types/test_bytes.py
     tests/parser/types/test_lists.py
-    vyper/compile_lll.py
     vyper/compiler.py
     vyper/functions/functions.py
     vyper/functions/signature.py


### PR DESCRIPTION
Foregoing the animal pictures and descriptions with these lint PRs.  See #1262 and #1276 .