### PR TITLE
Containers (and CircleCI) don't detect allocated cpu count correctly.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -n auto --cov-report term --cov-report html --cov=vyper
+addopts = -n 4 --cov-report term --cov-report html --cov=vyper
 python_files = test_*.py
 testpaths = tests
 


### PR DESCRIPTION
### What I did
-n4 runs will run just as fast, and save on process spawning time.

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture
^.^
