### PR TITLE
Create forwarder to

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -376,11 +376,11 @@ Note: To give it a more Python like syntax, the assert function can be called wi
 
 Emits a log without specifying the abi type, with the arguments entered as the first input.
 
-**create_with_code_of**
+**create_forwarder_to**
 -----------------------
 ::
 
-  def create_with_code_of(a, value=b):
+  def create_forwarder_to(a, value=b):
     """
     :param a: the address of the contract to duplicate.
     :type a: address

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,8 @@ Following the principles and goals, Vyper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
-* **2019.02.14**: Creating a persistent contract address can only be done using the _address_ syntax: `bar_contact: address(ERC20)`.
+* **2019.03.04**: `create_with_code_of` has been renamed to `create_forwarder_to`. (`#1177 <https://github.com/ethereum/vyper/issues/1177>`_)
+* **2019.02.14**: Assigning a persistent contract address can only be done using the `bar_contact = ERC20(<address>)` syntax.
 * **2019.02.12**: ERC20 interface has to be imported using `from vyper.interfaces import ERC20` to use.
 * **2019.01.30**: Byte array literals need to be annoted using `b""`, strings are represented as `""`.
 * **2018.12.12**: Disallow use of `None`, disallow use of `del`, implemented `clear()` built-in function.

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -45,7 +45,7 @@ def foo() -> int128:
 @public
 @constant
 def foo() -> int128:
-    x = create_with_code_of(0x1234567890123456789012345678901234567890, value=9)
+    x = create_forwarder_to(0x1234567890123456789012345678901234567890, value=9)
     return 5
     """,
     """

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -55,7 +55,7 @@ def foo():
     """
 @public
 def foo():
-    x = create_with_code_of(0x123456789012345678901234567890123456789)
+    x = create_forwarder_to(0x123456789012345678901234567890123456789)
     """,
     """
 @public

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -98,7 +98,7 @@ def foo():
     """
 @public
 def foo():
-    x = create_with_code_of(0x1234567890123456789012345678901234567890, b"cow")
+    x = create_forwarder_to(0x1234567890123456789012345678901234567890, b"cow")
     """,
     """
 @public
@@ -108,7 +108,7 @@ def foo():
     """
 @public
 def foo():
-    x = create_with_code_of(0x1234567890123456789012345678901234567890, outsize=4)
+    x = create_forwarder_to(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
 x: public()

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -121,7 +121,7 @@ def test():
     code = """
 @public
 def test():
-    assert create_with_code_of(self) == 1
+    assert create_forwarder_to(self) == 1
     """
     assert_compile_failed(lambda: get_contract(code), ConstancyViolationException)
 

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -1,12 +1,12 @@
 
 
-def test_create_with_code_of_create(get_contract):
+def test_create_forwarder_to_create(get_contract):
     code = """
 main: address
 
 @public
 def test() -> address:
-    self.main = create_with_code_of(self)
+    self.main = create_forwarder_to(self)
     return self.main
     """
 
@@ -15,7 +15,7 @@ def test() -> address:
     assert c.test() == '0x4F9DA333DCf4E5A53772791B95c161B2FC041859'
 
 
-def test_create_with_code_of_call(get_contract, w3):
+def test_create_forwarder_to_call(get_contract, w3):
     code = """
 
 contract SubContract:
@@ -28,7 +28,7 @@ other: public(address)
 
 @public
 def test() -> address:
-    self.other = create_with_code_of(self)
+    self.other = create_forwarder_to(self)
     return self.other
 
 
@@ -63,7 +63,7 @@ other: public(address)
 
 @public
 def test() -> address:
-    self.other = create_with_code_of(self)
+    self.other = create_forwarder_to(self)
     return self.other
 
 

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -1,4 +1,4 @@
-from vyper.functions import get_create_with_code_of_bytecode
+from vyper.functions import get_create_forwarder_to_bytecode
 
 
 def test_caller_code(get_contract_with_gas_estimation):
@@ -36,13 +36,13 @@ def returnten() -> int128:
     outer_code = """
 @public
 def create_and_call_returnten(inp: address) -> int128:
-    x: address = create_with_code_of(inp)
+    x: address = create_forwarder_to(inp)
     o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", bytes[4]), outsize=32, gas=50000), 0, type=int128)  # noqa: E501
     return o
 
 @public
 def create_and_return_forwarder(inp: address) -> address:
-    x: address = create_with_code_of(inp)
+    x: address = create_forwarder_to(inp)
     return x
     """
 
@@ -50,7 +50,7 @@ def create_and_return_forwarder(inp: address) -> address:
     assert c2.create_and_call_returnten(c.address) == 10
     c2.create_and_call_returnten(c.address, transact={})
 
-    expected_forwarder_code_mask = get_create_with_code_of_bytecode()[12:]
+    expected_forwarder_code_mask = get_create_forwarder_to_bytecode()[12:]
 
     c3 = c2.create_and_return_forwarder(c.address, call={})
     c2.create_and_return_forwarder(c.address, transact={})
@@ -78,13 +78,13 @@ def returnten() -> int128:
     outer_code = """
 @public
 def create_and_call_returnten(inp: address) -> int128:
-    x: address = create_with_code_of(inp)
+    x: address = create_forwarder_to(inp)
     o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", bytes[4]), outsize=32, gas=50000), 0, type=int128)  # noqa: E501
     return o
 
 @public
 def create_and_return_forwarder(inp: address) -> address:
-    return create_with_code_of(inp)
+    return create_forwarder_to(inp)
     """
 
     c2 = get_contract_with_gas_estimation(outer_code)

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -9,7 +9,7 @@ fail_list = [
     """
 @public
 def foo() -> int128:
-    x: address = create_with_code_of(
+    x: address = create_forwarder_to(
         0x1234567890123456789012345678901234567890,
         value=block.timestamp,
     )

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -8,7 +8,7 @@ fail_list = [
     """
 @public
 def foo():
-    x: address = create_with_code_of(0x1234567890123456789012345678901234567890, value=4, value=9)
+    x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, value=4, value=9)
     """
 ]
 
@@ -23,12 +23,12 @@ valid_list = [
     """
 @public
 def foo():
-    x: address = create_with_code_of(0x1234567890123456789012345678901234567890)
+    x: address = create_forwarder_to(0x1234567890123456789012345678901234567890)
     """,
     """
 @public
 def foo():
-    x: address = create_with_code_of(
+    x: address = create_forwarder_to(
         0x1234567890123456789012345678901234567890,
         value=as_wei_value(9, "wei")
     )
@@ -36,7 +36,7 @@ def foo():
     """
 @public
 def foo():
-    x: address = create_with_code_of(0x1234567890123456789012345678901234567890, value=9)
+    x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, value=9)
     """
 ]
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1007,7 +1007,7 @@ def shift(expr, args, kwargs, context):
     )
 
 
-def get_create_with_code_of_bytecode():
+def get_create_forwarder_to_bytecode():
     from vyper.compile_lll import (
         assembly_to_evm,
         num_to_bytearray
@@ -1047,7 +1047,7 @@ def get_create_with_code_of_bytecode():
 
 
 @signature('address', value=Optional('uint256', zero_value))
-def create_with_code_of(expr, args, kwargs, context):
+def create_forwarder_to(expr, args, kwargs, context):
 
     value = kwargs['value']
     if value != zero_value:
@@ -1060,7 +1060,7 @@ def create_with_code_of(expr, args, kwargs, context):
         )
     placeholder = context.new_placeholder(ByteArrayType(96))
 
-    kode = get_create_with_code_of_bytecode()
+    kode = get_create_forwarder_to_bytecode()
     high = bytes_to_int(kode[:32])
     low = bytes_to_int((kode + b'\x00' * 32)[47:79])
 
@@ -1159,7 +1159,7 @@ dispatch_table = {
     'uint256_addmod': uint256_addmod,
     'uint256_mulmod': uint256_mulmod,
     'shift': shift,
-    'create_with_code_of': create_with_code_of,
+    'create_forwarder_to': create_forwarder_to,
     'min': _min,
     'max': _max,
 }
@@ -1170,5 +1170,5 @@ stmt_dispatch_table = {
     'selfdestruct': selfdestruct,
     'raw_call': raw_call,
     'raw_log': raw_log,
-    'create_with_code_of': create_with_code_of,
+    'create_forwarder_to': create_forwarder_to,
 }


### PR DESCRIPTION
### What I did
Fixes #1177.
Rename create_with_code_of to create_forwarder_to.

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lovelyplanner.com/wp-content/uploads/2018/09/IMG_36091-768x576.jpg)
