### PR TITLE
Fix some final lint errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,30 +30,4 @@ exclude=
     .tox
     docs
     build
-    bin/vyper
-    bin/vyper-lll
     scripts/rlp_decoder.se.py
-    tests/conftest.py
-    tests/parser/exceptions/test_invalid_literal_exception.py
-    tests/parser/exceptions/test_invalid_same_variable_assignment.py
-    tests/parser/globals/test_setters.py
-    tests/parser/integration/test_basics.py
-    tests/parser/types/test_bytes.py
-    tests/parser/types/test_lists.py
-    vyper/compile_lll.py
-    vyper/functions/functions.py
-    vyper/functions/signature.py
-    vyper/optimizer.py
-    vyper/parser/constants.py
-    vyper/parser/context.py
-    vyper/parser/expr.py
-    vyper/parser/external_call.py
-    vyper/parser/global_context.py
-    vyper/parser/parser.py
-    vyper/parser/parser_utils.py
-    vyper/parser/pre_parser.py
-    vyper/parser/stmt.py
-    vyper/signatures/event_signature.py
-    vyper/signatures/interface.py
-    vyper/types/convert.py
-    vyper/utils.py

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -489,7 +489,6 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                     pos=getpos(self.expr),
                 )
 
-
         # Only allow explicit conversions to occur.
         if left.typ.typ != right.typ.typ:
             raise TypeMismatchException(

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -348,8 +348,8 @@ def to_address(expr, args, kwargs, context):
         pos=getpos(expr)
     )
 
-def _to_bytelike(expr, args, kwargs, context, bytetype):
 
+def _to_bytelike(expr, args, kwargs, context, bytetype):
     if bytetype == 'string':
         ReturnType = StringType
     elif bytetype == 'bytes':
@@ -363,6 +363,7 @@ def _to_bytelike(expr, args, kwargs, context, bytetype):
             f'Cannot convert as input {bytetype} are larger than max length',
             expr,
         )
+
     return LLLnode(
         value=in_arg.value,
         args=in_arg.args,


### PR DESCRIPTION
I think because of all the rebasing/merging, some files accidentally got left in the lint whitelist.  Also, there were a couple of final little lint errors that needed fixing.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://image.pbs.org/video-assets/x1WLcZn-asset-mezzanine-16x9-6kkb4dA.jpg)
