### PR TITLE
Add isort to lint checks and sort imports

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 import argparse
+from collections import (
+    OrderedDict,
+)
 import json
 import os
 import sys
-import vyper
 import warnings
 
-from collections import OrderedDict
-from vyper.parser import parser_utils
-from vyper.signatures.interface import extract_file_interface_imports
+import vyper
+from vyper.parser import (
+    parser_utils,
+)
+from vyper.signatures.interface import (
+    extract_file_interface_imports,
+)
 
 warnings.simplefilter('always')
 

--- a/bin/vyper-lll
+++ b/bin/vyper-lll
@@ -2,9 +2,16 @@
 import argparse
 
 import vyper
-from vyper import compile_lll, optimizer
-from vyper.parser.parser_utils import LLLnode
-from vyper.parser.s_expressions import parse_s_exp
+from vyper import (
+    compile_lll,
+    optimizer,
+)
+from vyper.parser.parser_utils import (
+    LLLnode,
+)
+from vyper.parser.s_expressions import (
+    parse_s_exp,
+)
 
 parser = argparse.ArgumentParser(description='Vyper LLL for Ethereum')
 parser.add_argument(

--- a/bin/vyper-serve
+++ b/bin/vyper-serve
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
+from http.server import (
+    BaseHTTPRequestHandler,
+    HTTPServer,
+)
 import json
-
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from socketserver import ThreadingMixIn
+from socketserver import (
+    ThreadingMixIn,
+)
+import sys
 
 import vyper
-
-from vyper.parser import lll_node
-from vyper.exceptions import ParserException
-
+from vyper.exceptions import (
+    ParserException,
+)
+from vyper.parser import (
+    lll_node,
+)
 
 parser = argparse.ArgumentParser(
     description='Serve Vyper compiler as an HTTP Service'

--- a/scripts/fixed_address_creator.py
+++ b/scripts/fixed_address_creator.py
@@ -1,7 +1,15 @@
-from ethereum import transactions, utils
-from ethereum.tools import tester as t
-from rlp_decoder import rlp_decoder_bytes
 import rlp
+
+from ethereum import (
+    transactions,
+    utils,
+)
+from ethereum.tools import (
+    tester as t,
+)
+from rlp_decoder import (
+    rlp_decoder_bytes,
+)
 
 config_string = (
     ':info,eth.vm.log:trace,eth.vm.op:trace,eth.vm.stack'

--- a/scripts/forwarder.py
+++ b/scripts/forwarder.py
@@ -1,4 +1,6 @@
-from ethereum import utils
+from ethereum import (
+    utils,
+)
 
 
 def mk_forwarder(address):

--- a/scripts/rlp_decoder.py
+++ b/scripts/rlp_decoder.py
@@ -1,5 +1,10 @@
-from vyper import optimizer, compile_lll
-from vyper.parser.parser_utils import LLLnode
+from vyper import (
+    compile_lll,
+    optimizer,
+)
+from vyper.parser.parser_utils import (
+    LLLnode,
+)
 
 
 def call_data_char(position):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,3 @@ testpaths = tests
 
 [aliases]
 test = pytest
-
-[flake8]
-exclude = docs

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ test_deps = [
 lint_deps = [
     'coveralls>=1.6,<2',
     'flake8>=3.7,<4',
-    'flake8-bugbear==18.8.0'
+    'flake8-bugbear==18.8.0',
+    'isort>=4.2.15,<5',
 ]
 
 

--- a/tests/compiler/LLL/test_compile_lll.py
+++ b/tests/compiler/LLL/test_compile_lll.py
@@ -1,8 +1,11 @@
 import pytest
 
-from vyper.parser.parser import LLLnode
-from vyper.parser.s_expressions import parse_s_exp
-
+from vyper.parser.parser import (
+    LLLnode,
+)
+from vyper.parser.s_expressions import (
+    parse_s_exp,
+)
 
 fail_list = [
     [-2**255 - 3],

--- a/tests/compiler/test_pre_parser.py
+++ b/tests/compiler/test_pre_parser.py
@@ -1,5 +1,10 @@
-from vyper.exceptions import StructureException
-from pytest import raises
+from pytest import (
+    raises,
+)
+
+from vyper.exceptions import (
+    StructureException,
+)
 
 
 def test_semicolon_prohibited(get_contract):

--- a/tests/compiler/test_sha3_32.py
+++ b/tests/compiler/test_sha3_32.py
@@ -1,5 +1,10 @@
-from vyper.parser.parser_utils import LLLnode
-from vyper import compile_lll, optimizer
+from vyper import (
+    compile_lll,
+    optimizer,
+)
+from vyper.parser.parser_utils import (
+    LLLnode,
+)
 
 
 def test_sha3_32():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,16 @@
+from functools import (
+    wraps,
+)
 import logging
-import pytest
-
-from functools import wraps
 
 from eth_tester import (
     EthereumTester,
 )
 from eth_tester.exceptions import (
-    TransactionFailed
+    TransactionFailed,
 )
-from web3.providers.eth_tester import (
-    EthereumTesterProvider,
-)
-
-from web3 import (
-    Web3,
-)
+import pytest
+from web3 import Web3
 from web3._utils.toolz import (
     compose,
 )
@@ -23,13 +18,17 @@ from web3.contract import (
     Contract,
     mk_collision_prop,
 )
-from vyper.parser.parser_utils import (
-    LLLnode
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
 )
+
 from vyper import (
     compile_lll,
     compiler,
     optimizer,
+)
+from vyper.parser.parser_utils import (
+    LLLnode,
 )
 
 

--- a/tests/examples/auctions/test_blind_auction.py
+++ b/tests/examples/auctions/test_blind_auction.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 MAX_BIDS = 128
 
 BIDDING_TIME = 150

--- a/tests/examples/tokens/test_erc20.py
+++ b/tests/examples/tokens/test_erc20.py
@@ -2,9 +2,8 @@
 # Modified from Philip Daian's tests:
 # https://github.com/ethereum/vyper/blob/v0.1.0-beta.5/tests/examples/tokens/ERC20_solidity_compatible/test/erc20_tests_1.py
 import pytest
-
 from web3.exceptions import (
-    ValidationError
+    ValidationError,
 )
 
 ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/tests/examples/wallet/test_wallet.py
+++ b/tests/examples/wallet/test_wallet.py
@@ -1,8 +1,13 @@
+from eth_account import (
+    Account,
+)
+from eth_keys import (
+    KeyAPI,
+)
+from eth_utils import (
+    is_same_address,
+)
 import pytest
-
-from eth_keys import KeyAPI
-from eth_account import Account
-from eth_utils import is_same_address
 
 
 @pytest.fixture

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import ConstancyViolationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    ConstancyViolationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_function_declaration_exception.py
+++ b/tests/parser/exceptions/test_function_declaration_exception.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import FunctionDeclarationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    FunctionDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_insufficient_arguments.py
+++ b/tests/parser/exceptions/test_insufficient_arguments.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import StructureException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import InvalidLiteralException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    InvalidLiteralException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_invalid_payable.py
+++ b/tests/parser/exceptions/test_invalid_payable.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import NonPayableViolationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    NonPayableViolationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_invalid_same_variable_assignment.py
+++ b/tests/parser/exceptions/test_invalid_same_variable_assignment.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import VariableDeclarationException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
 
 fail_list = [  # noqa: E122
 """

--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import InvalidTypeException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    InvalidTypeException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_parser_exception_pos.py
+++ b/tests/parser/exceptions/test_parser_exception_pos.py
@@ -1,6 +1,10 @@
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper.exceptions import ParserException
+from vyper.exceptions import (
+    ParserException,
+)
 
 
 def test_type_exception_pos():

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import StructureException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_type_mismatch_exception.py
+++ b/tests/parser/exceptions/test_type_mismatch_exception.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/exceptions/test_undef_function.py
+++ b/tests/parser/exceptions/test_undef_function.py
@@ -1,7 +1,13 @@
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import StructureException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
 
 
 def test_undef_toplevel():

--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import VariableDeclarationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/features/arithmetic/test_modulo.py
+++ b/tests/parser/features/arithmetic/test_modulo.py
@@ -1,5 +1,10 @@
-from vyper.exceptions import TypeMismatchException
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
+
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 
 def test_modulo(get_contract_with_gas_estimation):

--- a/tests/parser/features/decorators/test_constant.py
+++ b/tests/parser/features/decorators/test_constant.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import StructureException
+from vyper.exceptions import (
+    StructureException,
+)
 
 
 def test_constant_test(get_contract_with_gas_estimation_for_constants):

--- a/tests/parser/features/decorators/test_public.py
+++ b/tests/parser/features/decorators/test_public.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import StructureException
+from vyper.exceptions import (
+    StructureException,
+)
 
 
 def test_invalid_if_both_public_and_internal(assert_compile_failed,

--- a/tests/parser/features/external_contracts/test_erc20_abi.py
+++ b/tests/parser/features/external_contracts/test_erc20_abi.py
@@ -1,6 +1,7 @@
 import pytest
-from web3.exceptions import ValidationError
-
+from web3.exceptions import (
+    ValidationError,
+)
 
 TOKEN_NAME = "Vypercoin"
 TOKEN_SYMBOL = "FANG"

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -1,8 +1,8 @@
 from vyper.exceptions import (
-    StructureException,
-    VariableDeclarationException,
     InvalidTypeException,
-    TypeMismatchException
+    StructureException,
+    TypeMismatchException,
+    VariableDeclarationException,
 )
 
 

--- a/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
@@ -1,4 +1,7 @@
-from vyper.exceptions import StructureException, InvalidTypeException
+from vyper.exceptions import (
+    InvalidTypeException,
+    StructureException,
+)
 
 
 def test_external_contract_call_declaration_expr(get_contract, assert_tx_failed):

--- a/tests/parser/features/iteration/test_break.py
+++ b/tests/parser/features/iteration/test_break.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_break_test(get_contract_with_gas_estimation):

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -1,5 +1,11 @@
-from vyper.exceptions import StructureException, VariableDeclarationException
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
+
+from vyper.exceptions import (
+    StructureException,
+    VariableDeclarationException,
+)
 
 
 def test_basic_for_in_list(get_contract_with_gas_estimation):

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import TypeMismatchException
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 
 def test_basic_in_list(get_contract_with_gas_estimation):

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -1,11 +1,11 @@
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
 import pytest
 
 from vyper.exceptions import (
-    StructureException,
     ConstancyViolationException,
-)
-from eth_tester.exceptions import (
-    TransactionFailed
+    StructureException,
 )
 
 

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -1,7 +1,7 @@
 from vyper.exceptions import (
-    ParserException,
     ConstancyViolationException,
     InvalidLiteralException,
+    ParserException,
     TypeMismatchException,
 )
 

--- a/tests/parser/features/test_bytes_map_keys.py
+++ b/tests/parser/features/test_bytes_map_keys.py
@@ -1,5 +1,8 @@
 import pytest
-from vyper.exceptions import TypeMismatchException
+
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 
 def test_basic_bytes_keys(w3, get_contract):

--- a/tests/parser/features/test_constructor.py
+++ b/tests/parser/features/test_constructor.py
@@ -1,6 +1,6 @@
 import pytest
 from web3.exceptions import (
-    ValidationError
+    ValidationError,
 )
 
 

--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -1,5 +1,9 @@
-from vyper.parser.parser import parse_to_lll
-from vyper.parser import parser_utils
+from vyper.parser import (
+    parser_utils,
+)
+from vyper.parser.parser import (
+    parse_to_lll,
+)
 
 
 def test_gas_call(get_contract_with_gas_estimation):

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -1,5 +1,10 @@
-from decimal import Decimal
-from vyper.exceptions import StructureException
+from decimal import (
+    Decimal,
+)
+
+from vyper.exceptions import (
+    StructureException,
+)
 
 
 def test_selfcall_code(get_contract_with_gas_estimation):

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,6 +1,11 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
-from vyper.exceptions import TypeMismatchException, EventDeclarationException
+from vyper.exceptions import (
+    EventDeclarationException,
+    TypeMismatchException,
+)
 
 
 def test_empty_event_logging(w3, tester, keccak, get_contract_with_gas_estimation):

--- a/tests/parser/features/test_units.py
+++ b/tests/parser/features/test_units.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import InvalidLiteralException
+from vyper.exceptions import (
+    InvalidLiteralException,
+)
 
 
 def test_function_with_units(get_contract_with_gas_estimation):

--- a/tests/parser/functions/rlp/conftest.py
+++ b/tests/parser/functions/rlp/conftest.py
@@ -1,7 +1,9 @@
-import pytest
 import eth_tester
+import pytest
 
-from vyper import utils as vyper_utils
+from vyper import (
+    utils as vyper_utils,
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/parser/functions/test_abi.py
+++ b/tests/parser/functions/test_abi.py
@@ -1,4 +1,6 @@
-from vyper.compiler import mk_full_signature
+from vyper.compiler import (
+    mk_full_signature,
+)
 
 
 def test_only_init_function():

--- a/tests/parser/functions/test_ceil.py
+++ b/tests/parser/functions/test_ceil.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_ceil(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_convert_to_decimal.py
+++ b/tests/parser/functions/test_convert_to_decimal.py
@@ -1,8 +1,10 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 from vyper.exceptions import (
-    TypeMismatchException,
     InvalidLiteralException,
+    TypeMismatchException,
 )
 
 

--- a/tests/parser/functions/test_convert_to_uint256.py
+++ b/tests/parser/functions/test_convert_to_uint256.py
@@ -1,5 +1,5 @@
 from vyper.exceptions import (
-    InvalidLiteralException
+    InvalidLiteralException,
 )
 
 

--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -1,4 +1,6 @@
-from eth_account import Account
+from eth_account import (
+    Account,
+)
 
 
 def test_ecrecover_test(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_floor.py
+++ b/tests/parser/functions/test_floor.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_floor(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -1,13 +1,18 @@
-from vyper.exceptions import StructureException
 from vyper.compiler import (
+    compile_code,
     compile_codes,
-    compile_code
+)
+from vyper.exceptions import (
+    StructureException,
+)
+from vyper.interfaces import (
+    ERC20,
+    ERC721,
 )
 from vyper.signatures.interface import (
     extract_file_interface_imports,
     extract_sigs,
 )
-from vyper.interfaces import ERC20, ERC721
 
 
 def test_basic_extract_interface():

--- a/tests/parser/functions/test_minmax.py
+++ b/tests/parser/functions/test_minmax.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_minmax(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -1,4 +1,6 @@
-from vyper.functions import get_create_forwarder_to_bytecode
+from vyper.functions import (
+    get_create_forwarder_to_bytecode,
+)
 
 
 def test_caller_code(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_return_struct.py
+++ b/tests/parser/functions/test_return_struct.py
@@ -1,4 +1,6 @@
-from vyper.compiler import compile_code
+from vyper.compiler import (
+    compile_code,
+)
 
 
 def test_struct_return_abi(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import TypeMismatchException
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 
 def test_return_type(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_send.py
+++ b/tests/parser/functions/test_send.py
@@ -1,4 +1,6 @@
-from web3.exceptions import ValidationError
+from web3.exceptions import (
+    ValidationError,
+)
 
 
 def test_send(assert_tx_failed, get_contract):

--- a/tests/parser/globals/test_globals.py
+++ b/tests/parser/globals/test_globals.py
@@ -1,5 +1,10 @@
-from pytest import raises
-from vyper.exceptions import VariableDeclarationException
+from pytest import (
+    raises,
+)
+
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
 
 
 def test_permanent_variables_test(get_contract_with_gas_estimation):

--- a/tests/parser/syntax/test_ann_assign.py
+++ b/tests/parser/syntax/test_ann_assign.py
@@ -1,13 +1,16 @@
 import pytest
-from pytest import raises
-
-from vyper import compiler
-from vyper.exceptions import (
-    VariableDeclarationException,
-    TypeMismatchException,
-    StructureException
+from pytest import (
+    raises,
 )
 
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+    TypeMismatchException,
+    VariableDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_as_uint256.py
+++ b/tests/parser/syntax/test_as_uint256.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_as_wei_value.py
+++ b/tests/parser/syntax/test_as_wei_value.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_blockscope.py
+++ b/tests/parser/syntax/test_blockscope.py
@@ -1,10 +1,15 @@
 
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import VariableDeclarationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_byte_string.py
+++ b/tests/parser/syntax/test_byte_string.py
@@ -1,7 +1,8 @@
 import pytest
 
-from vyper import compiler
-
+from vyper import (
+    compiler,
+)
 
 valid_list = [
     """

--- a/tests/parser/syntax/test_bytes.py
+++ b/tests/parser/syntax/test_bytes.py
@@ -1,10 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
+    InvalidLiteralException,
     TypeMismatchException,
-    InvalidLiteralException
 )
 
 fail_list = [

--- a/tests/parser/syntax/test_code_size.py
+++ b/tests/parser/syntax/test_code_size.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_concat.py
+++ b/tests/parser/syntax/test_concat.py
@@ -1,9 +1,14 @@
 import pytest
+from pytest import (
+    raises,
+)
 
-from pytest import raises
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_conditionals.py
+++ b/tests/parser/syntax/test_conditionals.py
@@ -1,5 +1,8 @@
 import pytest
-from vyper import compiler
+
+from vyper import (
+    compiler,
+)
 
 valid_list = [
     """

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -1,14 +1,17 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
+    FunctionDeclarationException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
-    FunctionDeclarationException
 )
-
 
 fail_list = [
     # no value

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -1,8 +1,11 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-
+from vyper import (
+    compiler,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_custom_units.py
+++ b/tests/parser/syntax/test_custom_units.py
@@ -1,12 +1,15 @@
 import pytest
-from pytest import raises
-
-from vyper import compiler
-from vyper.exceptions import (
-    VariableDeclarationException,
-    InvalidTypeException
+from pytest import (
+    raises,
 )
 
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    InvalidTypeException,
+    VariableDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_extract32.py
+++ b/tests/parser/syntax/test_extract32.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -1,6 +1,8 @@
 import pytest
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 
 valid_list = [
     """

--- a/tests/parser/syntax/test_functions_call.py
+++ b/tests/parser/syntax/test_functions_call.py
@@ -1,10 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
     ParserException,
-    StructureException
+    StructureException,
 )
 
 fail_list = [

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -1,11 +1,15 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
-    TypeMismatchException,
+    InvalidLiteralException,
     StructureException,
-    InvalidLiteralException
+    TypeMismatchException,
 )
 
 # These functions register test cases

--- a/tests/parser/syntax/test_len.py
+++ b/tests/parser/syntax/test_len.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -1,9 +1,15 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException, StructureException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_logging.py
+++ b/tests/parser/syntax/test_logging.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_minmax.py
+++ b/tests/parser/syntax/test_minmax.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_missing_return.py
+++ b/tests/parser/syntax/test_missing_return.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import FunctionDeclarationException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    FunctionDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -1,9 +1,15 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException, StructureException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_no_none.py
+++ b/tests/parser/syntax/test_no_none.py
@@ -1,5 +1,5 @@
 from vyper.exceptions import (
-    InvalidLiteralException
+    InvalidLiteralException,
 )
 
 

--- a/tests/parser/syntax/test_public.py
+++ b/tests/parser/syntax/test_public.py
@@ -1,7 +1,8 @@
 import pytest
 
-from vyper import compiler
-
+from vyper import (
+    compiler,
+)
 
 valid_list = [
     """

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     ("""

--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import StructureException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_rlplist.py
+++ b/tests/parser/syntax/test_rlplist.py
@@ -1,9 +1,15 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException, StructureException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_selfdestruct.py
+++ b/tests/parser/syntax/test_selfdestruct.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_send.py
+++ b/tests/parser/syntax/test_send.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_sha3.py
+++ b/tests/parser/syntax/test_sha3.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_slice.py
+++ b/tests/parser/syntax/test_slice.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_string.py
+++ b/tests/parser/syntax/test_string.py
@@ -1,7 +1,8 @@
 import pytest
 
-from vyper import compiler
-
+from vyper import (
+    compiler,
+)
 
 valid_list = [
     """

--- a/tests/parser/syntax/test_structs.py
+++ b/tests/parser/syntax/test_structs.py
@@ -1,12 +1,15 @@
 import pytest
-from pytest import raises
-
-from vyper import compiler
-from vyper.exceptions import (
-    TypeMismatchException,
-    VariableDeclarationException
+from pytest import (
+    raises,
 )
 
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+    VariableDeclarationException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_timestamp_timedelta.py
+++ b/tests/parser/syntax/test_timestamp_timedelta.py
@@ -1,9 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
-
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -1,10 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
+    TypeMismatchException,
     VariableDeclarationException,
-    TypeMismatchException
 )
 
 fail_list = [

--- a/tests/parser/syntax/test_unit_exponents.py
+++ b/tests/parser/syntax/test_unit_exponents.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import TypeMismatchException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    TypeMismatchException,
+)
 
 fail_list = [
     """

--- a/tests/parser/syntax/utils/test_event_names.py
+++ b/tests/parser/syntax/utils/test_event_names.py
@@ -1,12 +1,15 @@
 import pytest
-from pytest import raises
-
-from vyper import compiler
-from vyper.exceptions import (
-    EventDeclarationException,
-    InvalidTypeException
+from pytest import (
+    raises,
 )
 
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    EventDeclarationException,
+    InvalidTypeException,
+)
 
 fail_list = [  # noqa: E122
     """

--- a/tests/parser/syntax/utils/test_function_names.py
+++ b/tests/parser/syntax/utils/test_function_names.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import FunctionDeclarationException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    FunctionDeclarationException,
+)
 
 fail_list = [  # noqa: E122
     """

--- a/tests/parser/syntax/utils/test_variable_names.py
+++ b/tests/parser/syntax/utils/test_variable_names.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import VariableDeclarationException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
 
 fail_list = [  # noqa: E122
     """

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -1,5 +1,10 @@
-from decimal import Decimal
-from vyper.compiler import compile_code
+from decimal import (
+    Decimal,
+)
+
+from vyper.compiler import (
+    compile_code,
+)
 
 
 def test_builtin_constants(get_contract_with_gas_estimation):

--- a/tests/parser/types/numbers/test_custom_units.py
+++ b/tests/parser/types/numbers/test_custom_units.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_custom_units(get_contract_with_gas_estimation):

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 
 def test_decimal_test(get_contract_with_gas_estimation):

--- a/tests/parser/types/numbers/test_int128.py
+++ b/tests/parser/types/numbers/test_int128.py
@@ -1,8 +1,11 @@
-from vyper.exceptions import (
-    TypeMismatchException,
-    InvalidLiteralException
+from decimal import (
+    Decimal,
 )
-from decimal import Decimal
+
+from vyper.exceptions import (
+    InvalidLiteralException,
+    TypeMismatchException,
+)
 
 
 def test_exponents_with_nums(get_contract_with_gas_estimation):

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,6 +1,6 @@
 from vyper.exceptions import (
     ParserException,
-    TypeMismatchException
+    TypeMismatchException,
 )
 
 

--- a/tests/parser/types/test_node_types.py
+++ b/tests/parser/types/test_node_types.py
@@ -1,4 +1,6 @@
-from pytest import raises
+from pytest import (
+    raises,
+)
 
 from vyper.types import (
     BaseType,

--- a/tests/parser/types/test_variable_naming.py
+++ b/tests/parser/types/test_variable_naming.py
@@ -1,8 +1,14 @@
 import pytest
-from pytest import raises
+from pytest import (
+    raises,
+)
 
-from vyper import compiler
-from vyper.exceptions import FunctionDeclarationException
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    FunctionDeclarationException,
+)
 
 fail_list = [
     """

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,23 @@ extras=
     test
 whitelist_externals=make
 
+[isort]
+combine_as_imports = True
+force_sort_within_sections = True
+include_trailing_comma = True
+known_third_party = hypothesis,pytest,web3,eth_*,rlp
+known_first_party = vyper
+line_length = 21
+multi_line_output = 3
+use_parentheses = True
+
 [testenv:lint]
 basepython=python
 extras=lint
 commands=
     flake8 {toxinidir}/vyper {toxinidir}/tests {toxinidir}/scripts
     flake8 {toxinidir}/bin/vyper {toxinidir}/bin/vyper-lll
+    isort --recursive --check-only --diff {toxinidir}/vyper {toxinidir}/tests {toxinidir}/bin {toxinidir}/scripts
 
 [flake8]
 max-line-length= 100

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
-envlist=
+envlist =
     py{36}-core
     lint
 
-[testenv]
-usedevelop=True
-commands=
-    core: pytest {posargs:tests/}
-basepython =
-    py36: python3.6
-extras=
-    test
-whitelist_externals=make
+[flake8]
+max-line-length = 100
+per-file-ignores =
+    scripts/rlp_decoder.py:E501
+exclude =
+    venv*
+    .tox
+    docs
+    build
+    scripts/rlp_decoder.se.py
 
 [isort]
 combine_as_imports = True
@@ -23,22 +24,20 @@ line_length = 21
 multi_line_output = 3
 use_parentheses = True
 
+[testenv]
+usedevelop = True
+commands =
+    core: pytest {posargs:tests/}
+basepython =
+    py36: python3.6
+extras =
+    test
+whitelist_externals = make
+
 [testenv:lint]
-basepython=python
-extras=lint
-commands=
+basepython = python
+extras = lint
+commands =
     flake8 {toxinidir}/vyper {toxinidir}/tests {toxinidir}/scripts
     flake8 {toxinidir}/bin/vyper {toxinidir}/bin/vyper-lll
     isort --recursive --check-only --diff {toxinidir}/vyper {toxinidir}/tests {toxinidir}/bin {toxinidir}/scripts
-
-[flake8]
-max-line-length= 100
-ignore=
-per-file-ignores=
-    scripts/rlp_decoder.py:E501
-exclude=
-    venv*
-    .tox
-    docs
-    build
-    scripts/rlp_decoder.se.py

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -1,6 +1,11 @@
 import sys as _sys
+
 import pkg_resources as _pkg_resources
 
+from vyper.compiler import (  # noqa
+    compile_code,
+    compile_codes,
+)
 
 if (_sys.version_info.major, _sys.version_info.minor) < (3, 6):
     # Can't be tested, as our test harness is using python3.6.
@@ -11,5 +16,3 @@ try:
     __version__ = _pkg_resources.get_distribution('vyper').version
 except _pkg_resources.DistributionNotFound:
     __version__ = '0.0.0development'
-
-from vyper.compiler import compile_code, compile_codes  # noqa

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -1,8 +1,15 @@
 import functools
 
-from vyper.parser.parser import LLLnode
-from .opcodes import opcodes
-from vyper.utils import MemoryPositions
+from vyper.parser.parser import (
+    LLLnode,
+)
+from vyper.utils import (
+    MemoryPositions,
+)
+
+from .opcodes import (
+    opcodes,
+)
 
 
 def num_to_bytearray(x):

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -1,11 +1,21 @@
-from vyper.opcodes import opcodes
-from vyper.parser import parser
-from vyper import compile_lll
-from vyper import optimizer
-from collections import OrderedDict, deque
+from collections import (
+    OrderedDict,
+    deque,
+)
+
+from vyper import (
+    compile_lll,
+    optimizer,
+)
+from vyper.opcodes import (
+    opcodes,
+)
+from vyper.parser import (
+    parser,
+)
 from vyper.signatures.interface import (
-    extract_interface_str,
     extract_external_interface,
+    extract_interface_str,
 )
 
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -3,54 +3,51 @@ import ast
 from vyper.exceptions import (
     ConstancyViolationException,
     InvalidLiteralException,
+    ParserException,
     StructureException,
     TypeMismatchException,
-    ParserException,
 )
-from .signature import (
-    signature,
-    Optional,
+from vyper.parser.expr import (
+    Expr,
 )
 from vyper.parser.parser_utils import (
-    byte_array_to_num,
     LLLnode,
+    add_variable_offset,
+    byte_array_to_num,
     get_length,
     get_number_as_fraction,
     getpos,
     make_byte_array_copier,
     make_byte_slice_copier,
-    add_variable_offset,
-    unwrap_location
-)
-from vyper.parser.expr import (
-    Expr,
+    unwrap_location,
 )
 from vyper.types import (
     BaseType,
-    ByteArrayType,
     ByteArrayLike,
+    ByteArrayType,
+    ListType,
     StringType,
     TupleType,
-    ListType
-)
-from vyper.types import (
     are_units_compatible,
-    is_base_type,
     get_size_of_type,
+    is_base_type,
+)
+from vyper.types.convert import (
+    convert,
 )
 from vyper.utils import (
+    DECIMAL_DIVISOR,
+    RLP_DECODER_ADDRESS,
     MemoryPositions,
     SizeLimits,
-    DECIMAL_DIVISOR,
-    RLP_DECODER_ADDRESS
-)
-from vyper.utils import (
     bytes_to_int,
     fourbytes_to_int,
     sha3,
 )
-from vyper.types.convert import (
-    convert,
+
+from .signature import (
+    Optional,
+    signature,
 )
 
 

--- a/vyper/functions/signature.py
+++ b/vyper/functions/signature.py
@@ -1,27 +1,25 @@
 import ast
 import functools
 
-from vyper.parser.parser_utils import (
-    get_original_if_0_prefixed,
-)
 from vyper.exceptions import (
-    TypeMismatchException,
-    StructureException,
     InvalidLiteralException,
-)
-from vyper.types import (
-    BaseType,
-    ByteArrayType,
-    StringType
-)
-from vyper.types import (
-    is_base_type
+    StructureException,
+    TypeMismatchException,
 )
 from vyper.parser.expr import (
     Expr,
 )
+from vyper.parser.parser_utils import (
+    get_original_if_0_prefixed,
+)
+from vyper.types import (
+    BaseType,
+    ByteArrayType,
+    StringType,
+    is_base_type,
+)
 from vyper.utils import (
-    SizeLimits
+    SizeLimits,
 )
 
 

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -1,5 +1,9 @@
-from vyper.parser.parser_utils import LLLnode
-from vyper.utils import LOADED_LIMIT_MAP
+from vyper.parser.parser_utils import (
+    LLLnode,
+)
+from vyper.utils import (
+    LOADED_LIMIT_MAP,
+)
 
 
 def get_int_at(args, pos, signed=False):

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -1,20 +1,24 @@
 import ast
 import copy
 
-from vyper.parser.expr import Expr
-from vyper.parser.context import Context
 from vyper.exceptions import (
     StructureException,
     TypeMismatchException,
-    VariableDeclarationException
+    VariableDeclarationException,
+)
+from vyper.parser.context import (
+    Context,
+)
+from vyper.parser.expr import (
+    Expr,
 )
 from vyper.types.types import (
     BaseType,
-    ByteArrayType
+    ByteArrayType,
 )
 from vyper.utils import (
+    SizeLimits,
     is_instances,
-    SizeLimits
 )
 
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -1,20 +1,18 @@
 import contextlib
 import enum
 
-from vyper.utils import (
-    MemoryPositions,
-    check_valid_varname,
+from vyper.exceptions import (
+    VariableDeclarationException,
+)
+from vyper.signatures.function_signature import (
+    VariableRecord,
 )
 from vyper.types import (
     get_size_of_type,
 )
-
-from vyper.exceptions import (
-    VariableDeclarationException,
-)
-
-from vyper.signatures.function_signature import (
-    VariableRecord,
+from vyper.utils import (
+    MemoryPositions,
+    check_valid_varname,
 )
 
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -4,29 +4,24 @@ import warnings
 from vyper.exceptions import (
     InvalidLiteralException,
     NonPayableViolationException,
+    ParserException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
-    ParserException
 )
-from vyper.parser.lll_node import LLLnode
-from vyper.parser import self_call
-from vyper.parser import external_call
+from vyper.parser import (
+    external_call,
+    self_call,
+)
+from vyper.parser.lll_node import (
+    LLLnode,
+)
 from vyper.parser.parser_utils import (
+    add_variable_offset,
+    get_number_as_fraction,
+    get_original_if_0_prefixed,
     getpos,
     unwrap_location,
-    get_original_if_0_prefixed,
-    get_number_as_fraction,
-    add_variable_offset,
-)
-from vyper.utils import (
-    MemoryPositions,
-    SizeLimits,
-    bytes_to_int,
-    string_to_bytes,
-    DECIMAL_DIVISOR,
-    checksum_encode,
-    check_valid_varname
 )
 from vyper.types import (
     BaseType,
@@ -38,14 +33,19 @@ from vyper.types import (
     StringType,
     StructType,
     TupleType,
-)
-from vyper.types import (
-    is_base_type,
-)
-from vyper.types import (
     are_units_compatible,
+    combine_units,
+    is_base_type,
     is_numeric_type,
-    combine_units
+)
+from vyper.utils import (
+    DECIMAL_DIVISOR,
+    MemoryPositions,
+    SizeLimits,
+    bytes_to_int,
+    check_valid_varname,
+    checksum_encode,
+    string_to_bytes,
 )
 
 

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -1,22 +1,24 @@
 import ast
 
-from vyper.parser.lll_node import LLLnode
-from vyper.parser.parser_utils import (
-    getpos,
-    unwrap_location,
-    pack_arguments
-)
 from vyper.exceptions import (
     FunctionDeclarationException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
 )
+from vyper.parser.lll_node import (
+    LLLnode,
+)
+from vyper.parser.parser_utils import (
+    getpos,
+    pack_arguments,
+    unwrap_location,
+)
 from vyper.types import (
-    get_size_of_type,
     BaseType,
     ByteArrayLike,
-    TupleType
+    TupleType,
+    get_size_of_type,
 )
 
 

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -8,11 +8,9 @@ from vyper.exceptions import (
     StructureException,
     VariableDeclarationException,
 )
-from vyper.utils import (
-    check_valid_varname,
-    valid_global_keywords,
+from vyper.parser.constants import (
+    Constants,
 )
-from vyper.parser.constants import Constants
 from vyper.parser.parser_utils import (
     decorate_ast,
     getpos,
@@ -20,22 +18,25 @@ from vyper.parser.parser_utils import (
 )
 from vyper.signatures.function_signature import (
     ContractRecord,
-    VariableRecord
-)
-from vyper.types import (
-    parse_type,
-    ContractType,
-    ByteArrayLike,
-    ListType,
-    MappingType,
-    StructType,
-    BaseType,
+    VariableRecord,
 )
 from vyper.signatures.interface import (
     extract_sigs,
-    get_builtin_interfaces
+    get_builtin_interfaces,
 )
-
+from vyper.types import (
+    BaseType,
+    ByteArrayLike,
+    ContractType,
+    ListType,
+    MappingType,
+    StructType,
+    parse_type,
+)
+from vyper.utils import (
+    check_valid_varname,
+    valid_global_keywords,
+)
 
 NONRENTRANT_STORAGE_OFFSET = 0xffffff
 

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -1,16 +1,18 @@
 import os
 import re
 
+from vyper.opcodes import (
+    comb_opcodes,
+)
 from vyper.types import (
-    ceil32,
     BaseType,
     NodeType,
-    NullType
+    NullType,
+    ceil32,
 )
-from vyper.opcodes import (
-    comb_opcodes
+from vyper.utils import (
+    valid_lll_macros,
 )
-from vyper.utils import valid_lll_macros
 
 # Set default string representation for ints in LLL output.
 AS_HEX_DEFAULT = False

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -3,59 +3,67 @@ import copy
 import functools
 
 from vyper.exceptions import (
-    ParserException,
+    EventDeclarationException,
+    FunctionDeclarationException,
     InvalidLiteralException,
+    ParserException,
     StructureException,
     TypeMismatchException,
-    FunctionDeclarationException,
-    EventDeclarationException
 )
-from vyper.signatures.function_signature import (
-    FunctionSignature,
-    VariableRecord,
+from vyper.parser.context import (
+    Constancy,
+    Context,
 )
-from vyper.signatures.event_signature import (
-    EventSignature,
+from vyper.parser.expr import (
+    Expr,
 )
-from vyper.parser.stmt import Stmt
-from vyper.parser.expr import Expr
-from vyper.parser.context import Context, Constancy
-from vyper.parser.global_context import GlobalContext
-from vyper.parser.lll_node import LLLnode
-from vyper.parser.pre_parser import pre_parse
+from vyper.parser.global_context import (
+    GlobalContext,
+)
+from vyper.parser.lll_node import (
+    LLLnode,
+)
 from vyper.parser.parser_utils import (
-    make_setter,
     base_type_conversion,
     byte_array_to_num,
     decorate_ast,
     getpos,
     make_byte_array_copier,
+    make_setter,
     resolve_negative_literals,
     unwrap_location,
+)
+from vyper.parser.pre_parser import (
+    pre_parse,
+)
+from vyper.parser.stmt import (
+    Stmt,
+)
+from vyper.signatures.event_signature import (
+    EventSignature,
+)
+from vyper.signatures.function_signature import (
+    FunctionSignature,
+    VariableRecord,
+)
+from vyper.signatures.interface import (
+    check_valid_contract_interface,
 )
 from vyper.types import (
     BaseType,
     ByteArrayLike,
     ListType,
-)
-from vyper.types import (
+    ceil32,
     get_size_of_type,
     is_base_type,
-    ceil32,
 )
 from vyper.utils import (
-    MemoryPositions,
     LOADED_LIMIT_MAP,
-    string_to_bytes,
-)
-from vyper.utils import (
+    MemoryPositions,
     bytes_to_int,
     calc_mem_gas,
+    string_to_bytes,
 )
-from vyper.signatures.interface import (
-    check_valid_contract_interface,
-)
-
 
 if not hasattr(ast, 'AnnAssign'):
     raise Exception("Requires python 3.6 or higher for annotation support")

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -1,38 +1,36 @@
 import ast
 
-from vyper.utils import GAS_IDENTITY, GAS_IDENTITYWORD
-
 from vyper.exceptions import (
     InvalidLiteralException,
+    StructureException,
     TypeMismatchException,
-    StructureException
 )
 from vyper.parser.lll_node import (
     LLLnode,
 )
 from vyper.types import (
     BaseType,
-    ByteArrayType,
     ByteArrayLike,
+    ByteArrayType,
+    ListType,
+    MappingType,
     NullType,
     StringType,
     StructType,
-    MappingType,
-    TupleType,
     TupleLike,
-    ListType,
-)
-from vyper.types import (
-    is_base_type,
+    TupleType,
     are_units_compatible,
+    ceil32,
     get_size_of_type,
     has_dynamic_data,
-    ceil32
+    is_base_type,
 )
 from vyper.utils import (
-    SizeLimits,
+    DECIMAL_DIVISOR,
+    GAS_IDENTITY,
+    GAS_IDENTITYWORD,
     MemoryPositions,
-    DECIMAL_DIVISOR
+    SizeLimits,
 )
 
 

--- a/vyper/parser/pre_parser.py
+++ b/vyper/parser/pre_parser.py
@@ -4,16 +4,18 @@ from tokenize import (
     COMMENT,
     NAME,
     OP,
-
     TokenError,
     TokenInfo,
     tokenize,
     untokenize,
 )
+
+from vyper import (
+    __version__,
+)
 from vyper.exceptions import (
     StructureException,
 )
-from vyper import __version__
 
 
 def _parser_version_str(version_str):

--- a/vyper/parser/pre_parser.py
+++ b/vyper/parser/pre_parser.py
@@ -10,9 +10,6 @@ from tokenize import (
     untokenize,
 )
 
-from vyper import (
-    __version__,
-)
 from vyper.exceptions import (
     StructureException,
 )
@@ -27,6 +24,10 @@ def _parser_version_str(version_str):
 
 # Do a version check.
 def parse_version_pragma(version_str):
+    from vyper import (
+        __version__,
+    )
+
     version_arr = version_str.split('@version')
 
     file_version = version_arr[1].strip()

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -1,17 +1,17 @@
 import itertools
 
 from vyper.exceptions import (
-    ConstancyViolationException
+    ConstancyViolationException,
 )
 from vyper.parser.lll_node import (
-    LLLnode
+    LLLnode,
 )
 from vyper.parser.parser_utils import (
+    getpos,
     pack_arguments,
-    getpos
 )
 from vyper.signatures.function_signature import (
-    FunctionSignature
+    FunctionSignature,
 )
 from vyper.types import (
     BaseType,

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -3,29 +3,32 @@ import re
 
 from vyper.exceptions import (
     ConstancyViolationException,
+    EventDeclarationException,
+    InvalidLiteralException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
-    EventDeclarationException,
-    InvalidLiteralException
 )
 from vyper.functions import (
+    dispatch_table,
     stmt_dispatch_table,
-    dispatch_table
 )
 from vyper.parser import (
+    external_call,
     self_call,
-    external_call
+)
+from vyper.parser.expr import (
+    Expr,
 )
 from vyper.parser.parser_utils import (
-    base_type_conversion,
-    getpos,
     LLLnode,
+    base_type_conversion,
+    gen_tuple_return,
+    getpos,
     make_byte_array_copier,
+    make_return_stmt,
     make_setter,
     unwrap_location,
-    gen_tuple_return,
-    make_return_stmt,
 )
 from vyper.types import (
     BaseType,
@@ -33,24 +36,19 @@ from vyper.types import (
     ByteArrayType,
     ContractType,
     ListType,
+    NodeType,
     NullType,
     StructType,
     TupleType,
-)
-from vyper.types import (
     get_size_of_type,
     is_base_type,
     parse_type,
-    NodeType
 )
 from vyper.utils import (
     SizeLimits,
-    sha3,
+    bytes_to_int,
     fourbytes_to_int,
-    bytes_to_int
-)
-from vyper.parser.expr import (
-    Expr
+    sha3,
 )
 
 

--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -1,24 +1,26 @@
 import ast
 
-from vyper.types import (
-    get_size_of_type,
-    canonicalize_type,
-    print_unit,
-    unit_from_type,
-    delete_unit_if_empty,
-    ByteArrayType
-)
-from vyper.utils import (
-    sha3,
-    check_valid_varname,
-    bytes_to_int,
-    ceil32
-)
-from vyper.signatures.function_signature import VariableRecord
 from vyper.exceptions import (
+    EventDeclarationException,
     InvalidTypeException,
     VariableDeclarationException,
-    EventDeclarationException
+)
+from vyper.signatures.function_signature import (
+    VariableRecord,
+)
+from vyper.types import (
+    ByteArrayType,
+    canonicalize_type,
+    delete_unit_if_empty,
+    get_size_of_type,
+    print_unit,
+    unit_from_type,
+)
+from vyper.utils import (
+    bytes_to_int,
+    ceil32,
+    check_valid_varname,
+    sha3,
 )
 
 

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -1,31 +1,37 @@
 import ast
-from collections import Counter
+from collections import (
+    Counter,
+)
 
 from vyper.exceptions import (
+    FunctionDeclarationException,
     InvalidTypeException,
     StructureException,
-    FunctionDeclarationException
 )
-from vyper.types import ByteArrayLike
+from vyper.parser.lll_node import (
+    LLLnode,
+)
+from vyper.parser.parser_utils import (
+    getpos,
+)
 from vyper.types import (
+    ByteArrayLike,
+    TupleLike,
+    TupleType,
     canonicalize_type,
+    delete_unit_if_empty,
     get_size_of_type,
     parse_type,
     print_unit,
     unit_from_type,
-    delete_unit_if_empty,
-    TupleType,
-    TupleLike
 )
 from vyper.utils import (
-    fourbytes_to_int,
-    is_varname_valid,
     check_valid_varname,
+    fourbytes_to_int,
     function_whitelist,
+    is_varname_valid,
     sha3,
 )
-from vyper.parser.parser_utils import getpos
-from vyper.parser.lll_node import LLLnode
 
 
 # Function argument

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -1,19 +1,26 @@
 import ast
 import copy
-import os
-
 import importlib
+import os
 import pkgutil
-import vyper.interfaces
 
 from vyper.exceptions import (
     ParserException,
-    StructureException
+    StructureException,
 )
-from vyper.parser import parser
-from vyper.parser.constants import Constants
-from vyper.signatures.event_signature import EventSignature
-from vyper.signatures.function_signature import FunctionSignature
+import vyper.interfaces
+from vyper.parser import (
+    parser,
+)
+from vyper.parser.constants import (
+    Constants,
+)
+from vyper.signatures.event_signature import (
+    EventSignature,
+)
+from vyper.signatures.function_signature import (
+    FunctionSignature,
+)
 
 
 # Populate built-in interfaces.

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -1,32 +1,30 @@
 import ast
-import warnings
 import math
+import warnings
 
+from vyper.exceptions import (
+    InvalidLiteralException,
+    ParserException,
+    TypeMismatchException,
+)
 from vyper.functions.signature import (
-    signature
+    signature,
 )
 from vyper.parser.parser_utils import (
     LLLnode,
+    byte_array_to_num,
     getpos,
-    byte_array_to_num
-)
-from vyper.exceptions import (
-    InvalidLiteralException,
-    TypeMismatchException,
-    ParserException,
 )
 from vyper.types import (
     BaseType,
-    StringType,
     ByteArrayType,
-)
-from vyper.types import (
+    StringType,
     get_type,
 )
 from vyper.utils import (
     DECIMAL_DIVISOR,
     MemoryPositions,
-    SizeLimits
+    SizeLimits,
 )
 
 

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -1,10 +1,14 @@
 import abc
 import ast
+from collections import (
+    OrderedDict,
+)
 import copy
 import warnings
-from collections import OrderedDict
 
-from vyper.exceptions import InvalidTypeException
+from vyper.exceptions import (
+    InvalidTypeException,
+)
 from vyper.utils import (
     base_types,
     ceil32,

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -1,12 +1,16 @@
 import binascii
+from collections import (
+    OrderedDict,
+)
 import re
 
-from collections import OrderedDict
 from vyper.exceptions import (
     InvalidLiteralException,
-    VariableDeclarationException
+    VariableDeclarationException,
 )
-from vyper.opcodes import opcodes
+from vyper.opcodes import (
+    opcodes,
+)
 
 try:
     from Crypto.Hash import keccak


### PR DESCRIPTION
### What I did

Added automatic import sorting with `isort` to lint checks.

### How I did it

Added the `isort` package to lint requirements and modified `tox.ini` appropriately.

### How to verify it

Run tests.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://wildlife.ohiodnr.gov/portals/wildlife/Species%20and%20Habitats/Species%20Guide%20Index/Images/redfox2.jpg)
