### PR TITLE
Update/fix coverage reporting config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+
 workflows:
   version: 2
   test:

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: circle-ci
+parallel: true

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from setuptools import setup, find_packages
 test_deps = [
     'pytest>=3.6',
     'pytest-cov==2.4.0',
+    'coverage==4.0.3',
+    'python-coveralls==2.9.1',
     'pytest-xdist==1.18.1',
     'py-evm==0.2.0a39',
     'eth-tester==0.1.0b37',
@@ -13,7 +15,6 @@ test_deps = [
     'tox>=3.7,<4',
 ]
 lint_deps = [
-    'coveralls>=1.6,<2',
     'flake8>=3.7,<4',
     'flake8-bugbear==18.8.0',
     'isort>=4.2.15,<5',

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,11 @@ use_parentheses = True
 
 [testenv]
 usedevelop = True
+passenv =
+    COVERALLS_REPO_TOKEN
 commands =
     core: pytest {posargs:tests/}
+    py36-core: ./upload_coverage.sh
 basepython =
     py36: python3.6
     py37: python3.7

--- a/upload_coverage.sh
+++ b/upload_coverage.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -z "${COVERALLS_REPO_TOKEN}" ]]; then
+  printf 'COVERALLS_REPO_TOKEN env var not set\n'
+else
+  coveralls
+fi


### PR DESCRIPTION
### What I did

Updated config for coverage reporting to coveralls.

### How I did it

Added appropriate requirements to test extras.  Updated `tox.ini` to run coverage upload wrapper script.  Added appropriate env var to circle CI project environment (this isn't reflected in PR changes).

### How to verify it

Trigger a circle CI build.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.wildlifeaid.org.uk/wp-content/uploads/2016/03/FP9_July09.jpg)