### PR TITLE
Remove redundant 'seq' in initializer code

### DIFF
--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -31,5 +31,5 @@ def __init__():
     """
     parser_utils.LLLnode.repr_show_gas = True
     out = parse_to_lll(code)
-    assert '35303' in str(out)[:28]
+    assert '35273' in str(out)[:28]
     parser_utils.LLLnode.repr_show_gas = False

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -224,7 +224,7 @@ def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None):
         external_contracts = parse_external_contracts(external_contracts, global_ctx)
     # If there is an init func...
     if initfunc:
-        o.append(['seq', initializer_lll])
+        o.append(initializer_lll)
         o.append(parse_func(
             initfunc[0],
             {**{'self': sigs}, **external_contracts},


### PR DESCRIPTION
### What I did

Call me crazy, but I think Vyper has been inserting an unnecessary `seq` construct into all initializer code.

**Update**: @jacqueswww has pointed out that this extra `seq` is optimized away.

### How I did it

Took it out.  Fixed one broken test.

### How to verify it

Run tests.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.buzzle.com/media/images-en/photos/mammals/foxes/1200-80559683-fox-in-woods.jpg)
