### PR TITLE
Add env var passthrough for coveralls

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ use_parentheses = True
 [testenv]
 usedevelop = True
 passenv =
+    COVERALLS_REPO_TOKEN
     CIRCLECI
     CIRCLE_*
     CI_PULL_REQUEST


### PR DESCRIPTION
### What I did

Add an env var passthrough in the tox config for coveralls.