### PR TITLE
Flexible imports relative to paths given at the CLI

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -82,6 +82,18 @@ def exc_handler(contract_name, exception):
     raise exception
 
 
+def import_file_paths(dirs, importpath):
+    """ Get the possible import paths for an interface import """
+    extensions = ('.vy', '.json')
+    valid_paths = list()
+    for d in dirs:
+        for ext in extensions:
+            resolved_path = os.path.join(d, os.path.normpath(importpath.replace('.', '/'))) + ext
+            if os.path.isfile(resolved_path):
+                valid_paths.append(resolved_path)
+    return valid_paths
+
+
 if __name__ == '__main__':
     if args.show_gas_estimates:
         parser_utils.LLLnode.repr_show_gas = True
@@ -114,18 +126,17 @@ if __name__ == '__main__':
             formats.append(translate_map.get(f, f))
 
         interface_codes = {}
+        import_paths = set()
 
-        for code in codes.values():
+        for code_path, code in codes.items():
             interface_codes.update(extract_file_interface_imports(code))
+            dir_path = os.path.dirname(code_path)
+            if dir_path:
+                import_paths.add(dir_path)
 
         if interface_codes:
             for interface_name, interface_path in interface_codes.items():
-                file_path = os.path.join(os.path.normpath(interface_path.replace('.', '/')))
-                extensions = ('.vy', '.json')
-                valid_paths = [
-                    file_path + ex
-                    for ex in extensions if os.path.exists(file_path + ex)
-                ]
+                valid_paths = import_file_paths(import_paths, interface_path)
                 if not valid_paths:
                     raise Exception('Imported interface "{}{.vy,.json}" does not exist.'.format(
                         interface_path,


### PR DESCRIPTION
### What I did

Adjusted the `vyper` CLI script to be more flexible when importing interfaces. The intention being that the current working directory is less important than the location of the given paths of the files making the import.

### How I did it

CLI script searches all relevant dirs given instead of just different extensions.

This uses all directories provided at the CLI as search paths and not just the specific file that does the importing.  I did this mostly to keep this PR simple, but can refactor to be specific to the importing file.  Thoughts?

### How to verify it

Run the `vyper` CLI script away from the directory containing the contract(s).  I didn't see any CLI unit tests so I did not add any for this.  But I can if requested.

### Description for the changelog

Interface imports are now relative to file paths instead of current directory

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/rHFqCDL.jpg)
