### PR TITLE
Fixes/updates in vyper.utils

### DIFF
--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -75,6 +75,16 @@ x: int128
 def foo():
     x = 5
     """,
+    """
+@public
+def foo():
+    msg: bool = True
+    """,
+    """
+@public
+def foo():
+    struct: bool = True
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_ann_assign.py
+++ b/tests/parser/syntax/test_ann_assign.py
@@ -65,8 +65,8 @@ struct S:
     b: decimal
 @public
 def foo() -> int128:
-    struct: S = S({a: 1.2, b: 1})
-    return struct.a
+    s: S = S({a: 1.2, b: 1})
+    return s.a
     """, TypeMismatchException),
     ("""
 struct S:
@@ -74,8 +74,8 @@ struct S:
     b: decimal
 @public
 def foo() -> int128:
-    struct: S = S({b: 1.2, c: 1, d: 33, e: 55})
-    return struct.a
+    s: S = S({b: 1.2, c: 1, d: 33, e: 55})
+    return s.a
     """, TypeMismatchException)
 ]
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1272,3 +1272,9 @@ stmt_dispatch_table = {
     'raw_log': raw_log,
     'create_forwarder_to': create_forwarder_to,
 }
+
+built_in_functions = [
+    x for x in stmt_dispatch_table.keys()
+] + [
+    x for x in dispatch_table.keys()
+]

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -165,10 +165,11 @@ reserved_words = {
     # control flow
     'if', 'for', 'while', 'until', 'pass',
     'def',
-    # EVM operations
+    # EVM operations and transaction properties
     'push', 'dup', 'swap', 'send', 'call',
     'selfdestruct', 'assert', 'stop', 'throw',
     'raise', 'init', '_init_', '___init___', '____init____',
+    'msg',
     # boolean literals
     'true', 'false',
     # more control flow and special operations
@@ -180,8 +181,8 @@ reserved_words = {
     # denominations
     'ether', 'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada', 'babbage',
     'gwei', 'kwei', 'mwei', 'twei', 'pwei',
-    # contract keyword
-    'contract',
+    # contract keywords
+    'contract', 'struct',
     # units
     'units',
     # sentinal constant values

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -208,14 +208,19 @@ valid_lll_macros = {
 # Same conditions apply for function names and events
 def is_varname_valid(varname, custom_units, custom_structs, constants):
     from vyper.functions import dispatch_table, stmt_dispatch_table
+
     built_in_functions = [
         x for x in stmt_dispatch_table.keys()
     ] + [
         x for x in dispatch_table.keys()
     ]
+
+    varname_lower = varname.lower()
+    varname_upper = varname.upper()
+
     if custom_units is None:
         custom_units = set()
-    if varname.lower() in {cu.lower() for cu in custom_units}:
+    if varname_lower in {cu.lower() for cu in custom_units}:
         return False, "%s is a unit name." % varname
 
     # struct names are case sensitive.
@@ -223,18 +228,19 @@ def is_varname_valid(varname, custom_units, custom_structs, constants):
         return False, "Duplicate name: %s, previously defined as a struct." % varname
     if varname in constants:
         return False, "Duplicate name: %s, previously defined as a constant." % varname
-    if varname.lower() in base_types:
+    if varname_lower in base_types:
         return False, "%s name is a base type." % varname
-    if varname.lower() in valid_units:
+    if varname_lower in valid_units:
         return False, "%s is a built in unit type." % varname
-    if varname.lower() in reserved_words:
+    if varname_lower in reserved_words:
         return False, "%s is a a reserved keyword." % varname
-    if varname.upper() in opcodes:
+    if varname_upper in opcodes:
         return False, "%s is a reserved keyword (EVM opcode)." % varname
-    if varname.lower() in built_in_functions:
+    if varname_lower in built_in_functions:
         return False, "%s is a built in function." % varname
     if not re.match('^[_a-zA-Z][a-zA-Z0-9_]*$', varname):
         return False, "%s contains invalid character(s)." % varname
+
     return True, ""
 
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -207,13 +207,7 @@ valid_lll_macros = {
 # Is a variable or member variable name valid?
 # Same conditions apply for function names and events
 def is_varname_valid(varname, custom_units, custom_structs, constants):
-    from vyper.functions import dispatch_table, stmt_dispatch_table
-
-    built_in_functions = [
-        x for x in stmt_dispatch_table.keys()
-    ] + [
-        x for x in dispatch_table.keys()
-    ]
+    from vyper.functions import built_in_functions
 
     varname_lower = varname.lower()
     varname_upper = varname.upper()


### PR DESCRIPTION
### What I did

Fixed problem mentioned in issue #1364 .  Updated reserved words list and did some other miscellaneous cleanup.

### How to verify it

Run the tests.

### Description for the changelog

* The keywords `struct` and `msg` were incorrectly being allowed as variable names.  Those keywords are now properly treated as reserved words.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/736x/c4/d2/72/c4d272f0d907df0b04fc37e522f3653f.jpg)
