### PR TITLE
PC debugger output

### DIFF
--- a/tests/compiler/LLL/test_compile_lll.py
+++ b/tests/compiler/LLL/test_compile_lll.py
@@ -6,6 +6,8 @@ from vyper.parser.parser import (
 from vyper.parser.s_expressions import (
     parse_s_exp,
 )
+from vyper import compile_lll
+
 
 fail_list = [
     [-2**255 - 3],
@@ -74,3 +76,14 @@ def test_lll_from_s_expression(get_contract_from_lll):
     lll = LLLnode.from_list(s_expressions[0])
     c = get_contract_from_lll(lll, abi=abi)
     assert c.test(-123456) == -123456
+
+
+def test_pc_debugger():
+    debugger_lll = [
+        'seq_unchecked',
+        ['mstore', 0, 32],
+        ['pc_debugger']
+    ]
+    lll_nodes = LLLnode.from_list(debugger_lll)
+    _, line_number_map = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll_nodes))
+    assert line_number_map['pc_breakpoints'][0] == 5

--- a/tests/compiler/LLL/test_compile_lll.py
+++ b/tests/compiler/LLL/test_compile_lll.py
@@ -1,13 +1,14 @@
 import pytest
 
+from vyper import (
+    compile_lll,
+)
 from vyper.parser.parser import (
     LLLnode,
 )
 from vyper.parser.s_expressions import (
     parse_s_exp,
 )
-from vyper import compile_lll
-
 
 fail_list = [
     [-2**255 - 3],

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -11,8 +11,6 @@ from .opcodes import (
     opcodes,
 )
 
-
-
 PUSH_OFFSET = 0x5f
 DUP_OFFSET = 0x7f
 SWAP_OFFSET = 0x8f


### PR DESCRIPTION
### What I did
For help in developing and checking bytecode output, inserting `pc_debugger` is super useful.

- Also added to vyper-debug to consume the breakpoint.
- Has no effect on the bytecode.

### How I did it
Add secondary debug LLL macro.

### How to verify it
Check the test.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.npr.org/assets/img/2013/01/10/ap815548341194-2-6dd20497afa68a4fe729e909ac50e67c0e67cda9-s800-c85.jpg)
