### PR TITLE
Documentation - Fixed docker command to include ethereum/vyper when calling docker run

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -195,8 +195,8 @@ To run the compiler use the `docker run` command:
 Alternatively you can log into the docker image and execute vyper on the prompt.
 ::
 
-    docker run -v $(pwd):/code/ -it --entrypoint /bin/bash vyper
-    root@d35252d1fb1b:/code# ethereum/vyper <contract_file.vy>
+    docker run -v $(pwd):/code/ -it --entrypoint /bin/bash ethereum/vyper
+    root@d35252d1fb1b:/code# vyper <contract_file.vy>
 
 The normal paramaters are also supported, for example:
 ::

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -190,18 +190,18 @@ Vyper can be downloaded as docker image from dockerhub:
 To run the compiler use the `docker run` command:
 ::
 
-    docker run -v $(pwd):/code vyper /code/<contract_file.vy>
+    docker run -v $(pwd):/code ethereum/vyper /code/<contract_file.vy>
 
 Alternatively you can log into the docker image and execute vyper on the prompt.
 ::
 
     docker run -v $(pwd):/code/ -it --entrypoint /bin/bash vyper
-    root@d35252d1fb1b:/code# vyper <contract_file.vy>
+    root@d35252d1fb1b:/code# ethereum/vyper <contract_file.vy>
 
 The normal paramaters are also supported, for example:
 ::
 
-    docker run -v $(pwd):/code vyper -f abi /code/<contract_file.vy>
+    docker run -v $(pwd):/code ethereum/vyper -f abi /code/<contract_file.vy>
     [{'name': 'test1', 'outputs': [], 'inputs': [{'type': 'uint256', 'name': 'a'}, {'type': 'bytes', 'name': 'b'}], 'constant': False, 'payable': False, 'type': 'function', 'gas': 441}, {'name': 'test2', 'outputs': [], 'inputs': [{'type': 'uint256', 'name': 'a'}], 'constant': False, 'payable': False, 'type': 'function', 'gas': 316}]
 
 


### PR DESCRIPTION
Relavent to issue #1374 

### What I did
Updated _installing-vyper.rst_ 

### How I did it
Modified doc file to include `ethereum/vyper`

### How to verify it

### Description for the changelog
Documentation page for `Installing Vyper` now includes the correct `docker run` commands

### Cute Animal  #Picture

![image](https://user-images.githubusercontent.com/18735263/55403502-e4254000-554d-11e9-9f1d-e52d554b7b51.png)
