### PR TITLE
Rewrite ne (!=) with xor

### DIFF
--- a/tests/compiler/LLL/test_optimize_lll.py
+++ b/tests/compiler/LLL/test_optimize_lll.py
@@ -1,0 +1,28 @@
+import pytest
+
+from vyper import (
+    compile_lll,
+    optimizer,
+)
+from vyper.parser.parser import (
+    LLLnode,
+)
+from vyper.parser.s_expressions import (
+    parse_s_exp,
+)
+
+optimize_list = [
+    (['ne',1,0], ['ne',1,0]), # noop
+    (['if', ['ne',1,0], 'pass'], ['if', ['xor',1,0], 'pass']),
+    (['assert', ['ne', 1,0]], ['assert', ['xor',1,0]]),
+    (['assert_reason', ['ne',1,0], 0,0], ['assert_reason', ['xor',1,0], 0,0]),
+    (['mstore', 0, ['ne',1,0]], ['mstore',0,['ne',1,0]]), # noop
+]
+
+@pytest.mark.parametrize('lll', optimize_list)
+def test_lll_compile_fail(lll):
+    optimized = optimizer.optimize(LLLnode.from_list(lll[0]))
+    optimized.repr_show_gas = True
+    hand_optimized = LLLnode.from_list(lll[1])
+    hand_optimized.repr_show_gas = True
+    assert optimized == hand_optimized

--- a/tests/compiler/LLL/test_optimize_lll.py
+++ b/tests/compiler/LLL/test_optimize_lll.py
@@ -1,23 +1,20 @@
 import pytest
 
 from vyper import (
-    compile_lll,
     optimizer,
 )
 from vyper.parser.parser import (
     LLLnode,
 )
-from vyper.parser.s_expressions import (
-    parse_s_exp,
-)
 
 optimize_list = [
-    (['ne',1,0], ['ne',1,0]), # noop
-    (['if', ['ne',1,0], 'pass'], ['if', ['xor',1,0], 'pass']),
-    (['assert', ['ne', 1,0]], ['assert', ['xor',1,0]]),
-    (['assert_reason', ['ne',1,0], 0,0], ['assert_reason', ['xor',1,0], 0,0]),
-    (['mstore', 0, ['ne',1,0]], ['mstore',0,['ne',1,0]]), # noop
+    (['ne', 1, 0], ['ne', 1, 0]),  # noop
+    (['if', ['ne', 1, 0], 'pass'], ['if', ['xor', 1, 0], 'pass']),
+    (['assert', ['ne', 1, 0]], ['assert', ['xor', 1, 0]]),
+    (['assert_reason', ['ne', 1, 0], 0, 0], ['assert_reason', ['xor', 1, 0], 0, 0]),
+    (['mstore', 0, ['ne', 1, 0]], ['mstore', 0, ['ne', 1, 0]]),  # noop
 ]
+
 
 @pytest.mark.parametrize('lll', optimize_list)
 def test_lll_compile_fail(lll):

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -390,10 +390,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
     # != operator
     elif code.value == 'ne':
         return compile_to_assembly(LLLnode.from_list(
-            [
-                'iszero',
-                ['eq', code.args[0], code.args[1]],
-            ]
+            ['xor', code.args[0], code.args[1]],
         ), withargs, existing_labels, break_dest, height)
     # e.g. 95 -> 96, 96 -> 96, 97 -> 128
     elif code.value == "ceil32":

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -390,7 +390,10 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
     # != operator
     elif code.value == 'ne':
         return compile_to_assembly(LLLnode.from_list(
-            ['xor', code.args[0], code.args[1]],
+            [
+                'iszero',
+                ['eq', code.args[0], code.args[1]],
+            ]
         ), withargs, existing_labels, break_dest, height)
     # e.g. 95 -> 96, 96 -> 96, 97 -> 128
     elif code.value == "ceil32":

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -223,16 +223,13 @@ def optimize(node: LLLnode) -> LLLnode:
     # [ne, x, y] has the same truthyness as [xor, x, y]
     # rewrite 'ne' as 'xor' in places where truthy is accepted.
     elif has_cond_arg(node) and argz[0].value == 'ne':
-        argz[0].value = 'xor'
-        return LLLnode(
-            node.value,
-            argz,
-            node.typ,
-            node.location,
-            node.pos,
-            node.annotation,
-            add_gas_estimate=node.add_gas_estimate,
-            valency=node.valency,
+        argz[0] = LLLnode.from_list(['xor'] + argz[0].args)
+        return LLLnode.from_list([node.value] + argz,
+            typ=node.typ,
+            location=node.location,
+            pos=node.pos,
+            annotation=node.annotation,
+            # let from_list handle valency and gas_estimate
         )
     elif _is_with_without_set(node, argz):
         # TODO: This block is currently unreachable due to

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -224,13 +224,14 @@ def optimize(node: LLLnode) -> LLLnode:
     # rewrite 'ne' as 'xor' in places where truthy is accepted.
     elif has_cond_arg(node) and argz[0].value == 'ne':
         argz[0] = LLLnode.from_list(['xor'] + argz[0].args)
-        return LLLnode.from_list([node.value] + argz,
-            typ=node.typ,
-            location=node.location,
-            pos=node.pos,
-            annotation=node.annotation,
-            # let from_list handle valency and gas_estimate
-        )
+        return LLLnode.from_list(
+                [node.value] + argz,
+                typ=node.typ,
+                location=node.location,
+                pos=node.pos,
+                annotation=node.annotation,
+                # let from_list handle valency and gas_estimate
+                )
     elif _is_with_without_set(node, argz):
         # TODO: This block is currently unreachable due to
         # `_is_with_without_set` unconditionally returning `False` this appears

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -237,7 +237,7 @@ class LLLnode:
     def to_list(self):
         return [self.value] + [a.to_list() for a in self.args]
 
-    def __eq__(self, other) :
+    def __eq__(self, other):
         return self.value == other.value and \
                 self.args == other.args and \
                 self.typ == other.typ and \

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -237,6 +237,17 @@ class LLLnode:
     def to_list(self):
         return [self.value] + [a.to_list() for a in self.args]
 
+    def __eq__(self, other) :
+        return self.value == other.value and \
+                self.args == other.args and \
+                self.typ == other.typ and \
+                self.location == other.location and \
+                self.pos == other.pos and \
+                self.annotation == other.annotation and \
+                self.mutable == other.mutable and \
+                self.add_gas_estimate == other.add_gas_estimate and \
+                self.valency == other.valency
+
     @property
     def repr_value(self):
         if isinstance(self.value, int) and self.as_hex:


### PR DESCRIPTION
Saves 3 gas / one word of bytecode per usage

### What I did
Rewrite ne with xor (https://github.com/ethereum/vyper/issues/1386) in jumpi statements

### How I did it
Add an optimizer case

### How to verify it
```
$ vyper -f ir /dev/stdin <<EOF
> @public
> def foo():
>   assert 1 != 2
> 
> @public
> def bar() -> bool:
>   return 1 != 2
> EOF
[seq,
  [return,
    0,
    [lll,
      [seq,
        [mstore, 28, [calldataload, 0]],
        [mstore, 32, 1461501637330902918203684832716283019655932542976],
        [mstore, 64, 170141183460469231731687303715884105727],
        [mstore, 96, -170141183460469231731687303715884105728],
        [mstore, 128, 1701411834604692317316873037158841057270000000000],
        [mstore, 160, -1701411834604692317316873037158841057280000000000],
        # Line 1
        [if,
          [eq, [mload, 0], '3264763256' <foo()>],
          [seq,
            [assert, [iszero, callvalue]],
            # Line 3
            [assert, [xor, 1, 2]],
            # Line 1
            stop]],
        # Line 5
        [if,
          [eq, [mload, 0], '4273672062' <bar()>],
          [seq,
            [assert, [iszero, callvalue]],
            # Line 7
            [mstore, 0, [ne, 1, 2]],
            [return, 0, 32],
            # Line 5
            stop]],
        /* Default function */ [revert, 0, 0]],
      0]]]
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://tailandfur.com/wp-content/uploads/2013/08/Cute-Baby-Animal-Picture-3600005.jpg)
