### PR TITLE
Update the makefile install rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test dev-deps lint clean clean-pyc clean-build clean-test docs docker-build
 
 init:
-	python setup.py install
+	pip install .
 
 dev-deps:
 	pip install .[test,lint]


### PR DESCRIPTION
`setup.py install` no longer does the right thing.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://toije35938.i.lithium.com/t5/image/serverpage/image-id/1663i87DC785D4C51B258/image-size/large?v=1.0&amp;px=999)
