### PR TITLE
Allow external calls which return struct

### DIFF
--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -17,7 +17,7 @@ from vyper.parser.parser_utils import (
 from vyper.types import (
     BaseType,
     ByteArrayLike,
-    TupleType,
+    TupleLike,
     get_size_of_type,
 )
 
@@ -97,7 +97,7 @@ def get_external_contract_call_output(sig, context):
         returner = [0, output_placeholder]
     elif isinstance(sig.output_type, ByteArrayLike):
         returner = [0, output_placeholder + 32]
-    elif isinstance(sig.output_type, TupleType):
+    elif isinstance(sig.output_type, TupleLike):
         returner = [0, output_placeholder]
     else:
         raise TypeMismatchException("Invalid output type: %s" % sig.output_type)


### PR DESCRIPTION
Doesn't guarantee that dynamic pack/unpacking will work, just allows it
in the simple case.

### What I did
Fix #1392 

### How I did it
Relax the case analysis in `get_external_contract_call_output`

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.everythingmixed.com/wp-content/uploads/cutest-animals-24.jpg)
