### PR TITLE
Fix path missing exception.

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -127,9 +127,9 @@ if __name__ == '__main__':
                     for ex in extensions if os.path.exists(file_path + ex)
                 ]
                 if not valid_paths:
-                    raise Exception('Imported interface "{}{.vy,.json}" does not exist.'.format(
-                        interface_path,
-                    ))
+                    raise Exception(
+                        f'Imported interface "{interface_path}{{.vy,.json}}" does not exist.'
+                    )
 
                 valid_path = valid_paths[0]
                 with open(valid_path) as fh:


### PR DESCRIPTION
### What I did
Fix #1394.

### How I did it
```bash
$ vim myContract.vy  # Contents of #1394
$ vyper myContract.vy 
Exception: Imported interface "foobar{.vy,.json}" does not exist.
$ vim foobar.json  # Just put `{}` inside
$ vyper myContract.vy 
0x6100...
```

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/474x/10/09/be/1009bea2c89b53a408e2da6eb6dd082c--bun-bun-adorable-animals.jpg)
