### PR TITLE
Typo in comment ✍

### DIFF
--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -59,7 +59,7 @@ def transfer(_to : address, _value : uint256) -> bool:
     @param _to The address to transfer to.
     @param _value The amount to be transferred.
     """
-    # NOTE: vyper does not allow unterflows
+    # NOTE: vyper does not allow underflows
     #       so the following subtraction would revert on insufficient balance
     self.balanceOf[msg.sender] -= _value
     self.balanceOf[_to] += _value
@@ -77,7 +77,7 @@ def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
      @param _to address The address which you want to transfer to
      @param _value uint256 the amount of tokens to be transferred
     """
-    # NOTE: vyper does not allow unterflows
+    # NOTE: vyper does not allow underflows
     #       so the following subtraction would revert on insufficient balance
     self.balanceOf[_from] -= _value
     self.balanceOf[_to] += _value


### PR DESCRIPTION
### What I did
I replaced `unter` to `under`

### How I did it
By hand.

### How to verify it
By your eyes.

### Description for the changelog
Trivial typo in comment fixed.

### Cute Animal Picture


![Put a link to a cute animal picture inside the parenthesis-->](https://animalfair.com/wp-content/uploads/2013/02/baby-hedgehog-cute-201210-294x220.jpeg)
