### PR TITLE
Upgrade to mypy 0.701

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ lint_deps = [
     'flake8>=3.7,<4',
     'flake8-bugbear==18.8.0',
     'isort>=4.2.15,<5',
-    'mypy==0.670',
+    'mypy==0.701',
 ]
 
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -2,6 +2,7 @@ import ast
 import functools
 from typing import (
     List,
+    cast,
 )
 
 from vyper.exceptions import (
@@ -91,7 +92,8 @@ def parse_to_ast(source_code: str) -> List[ast.stmt]:
     if '\x00' in reformatted_code:
         raise ParserException('No null bytes (\\x00) allowed in the source code.')
 
-    parsed_ast = ast.parse(reformatted_code)
+    # The return type depends on the parse mode which is why we need to cast here
+    parsed_ast = cast(ast.Module, ast.parse(reformatted_code))
     annotate_and_optimize_ast(parsed_ast, reformatted_code, class_types)
 
     return parsed_ast.body


### PR DESCRIPTION
This is my first PR in this repo so please be gentle. I was looking for a simple task to fire up my brain after vacation :)

### What I did

- Upgraded to mypy 0.701 [which comes with lots of improvements](https://mypy-lang.blogspot.com/2019/04/mypy-0700-released-up-to-4x-faster.html)

### How I did it

- Changed version in `setup.py`
- added a cast for a failing check that was previously uncaught. The `cast` is needed because the return type of `ast.parse` depends on the `mode` which defaults to `exec` and returns an `ast.Module` in that case.

### How to verify it

run `tox -e lint`

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.lifewithdogs.tv/wp-content/uploads/2016/10/dog-tired.jpg)
