### PR TITLE
Fix/typo in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/modules.rst
 
 # IDEs
 .idea/
+.vscode/
 
 .tox
 .mypy_cache

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 * **Inline assembly:** Adding inline assembly would make it no longer possible to search for a variable name in order to find all instances where that variable is read or modified.
 * **Function overloading** - This can cause lots of confusion on which function is called at any given time. Thus it's easier to write missleading code (``foo("hello")`` logs "hello" but ``foo("hello", "world")`` steals you funds).
   Another problem with function overloading is that it makes the code much harder to search through as you have to keep track on which call refers to which function.
-* **Operator overloading:** Operator overloading makes writing misleading code possible. For example "+" could be overloaded so that it executes commands the are not visible at first glance, such as sending funds the
+* **Operator overloading:** Operator overloading makes writing misleading code possible. For example "+" could be overloaded so that it executes commands that are not visible at first glance, such as sending funds the
   user did not want to send.
 * **Recursive calling:** Recursive calling makes it impossible to set an upper bound on gas limits, opening the door for gas limit attacks.
 * **Infinite-length loops:** Similar to recursive calling, infinite-length loops make it impossible to set an upper bound on gas limits, opening the door for gas limit attacks.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Following the principles and goals, Vyper **does not** provide the following fea
 * **Inline assembly:** Adding inline assembly would make it no longer possible to search for a variable name in order to find all instances where that variable is read or modified.
 * **Function overloading** - This can cause lots of confusion on which function is called at any given time. Thus it's easier to write missleading code (``foo("hello")`` logs "hello" but ``foo("hello", "world")`` steals you funds).
   Another problem with function overloading is that it makes the code much harder to search through as you have to keep track on which call refers to which function.
-* **Operator overloading:** Operator overloading makes writing misleading code possible. For example "+" could be overloaded so that it executes commands that are not visible at first glance, such as sending funds the
+* **Operator overloading:** Operator overloading makes writing misleading code possible. For example "+" could be overloaded so that it executes commands that are not visible at a first glance, such as sending funds the
   user did not want to send.
 * **Recursive calling:** Recursive calling makes it impossible to set an upper bound on gas limits, opening the door for gas limit attacks.
 * **Infinite-length loops:** Similar to recursive calling, infinite-length loops make it impossible to set an upper bound on gas limits, opening the door for gas limit attacks.


### PR DESCRIPTION
### What I did
Fixed a typo and made the statement grammatically correct.
Updated .gitignore file to ignore files from .vscode when using Visual Studio code editor.

### How I did it
Forked the repo, created a new branch from master, read the documentation, concluded what should be added to fix the typo, made the changes, verified the statement is grammatically correct using Grammarly.

### How to verify it
Use Grammarly a chrome extension to verify the statement is grammatically correct.

### Description for the changelog
**Older Statement**
```
Operator overloading makes writing misleading code possible. For example "+" could be overloaded so the it executes commands that are not visible at first glance, such as sending funds the user did not want to send.
```
**New Statement**

```
Operator overloading makes writing misleading code possible. For example "+" could be overloaded so that it executes commands that are not visible at a first glance, such as sending funds the user did not want to send.
```

### Cute Animal Picture
![vyperFirstPR](https://user-images.githubusercontent.com/32358081/57058271-801ca580-6ccc-11e9-89fc-99c51272f9df.jpg)
