### PR TITLE
Changed nonrentant to nonreentrant as per PR #1416

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -52,12 +52,12 @@ Decorator                    Description
 `@private`                   Can only be called within current contract.
 `@constant`                  Does not alter contract state.
 `@payable`                   The contract is open to receive Ether.
-`@nonrentant(<unique_key>)`  Function can only be called once,
+`@nonreentrant(<unique_key>)`  Function can only be called once,
                              both externally and internally. Used to
                              prevent reentrancy attacks.
 ===========================  ===========================================
 
-The visibility decorators `@public` or `@private` are mandatory on function declarations, whilst the other decorators(@constant, @payable, @nonrentant) are optional.
+The visibility decorators `@public` or `@private` are mandatory on function declarations, whilst the other decorators(@constant, @payable, @nonreentrant) are optional.
 
 Default function
 ----------------


### PR DESCRIPTION
### What I did
Changed **nonrentant** to **nonreentrant** as per PR #1416 

### How I did it
Replaced the words after discussion with  @fubuloubu in PR #1416 

### Description for the changelog
It implies changes in the codebase of **nonrentant** to **nonreentrant**

### Cute Animal Picture
![PR3](https://user-images.githubusercontent.com/32358081/57328685-b1afc980-712f-11e9-9edc-e958b6efedaa.jpg)


