### PR TITLE
Updated installing-vyper.rst with option to install Vyper by using a bash script

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -61,6 +61,14 @@ Run the following commands to install:
 
        sudo apt-get install python3-dev
 
+Using a BASH script
+^^^^^^^^^^^^^^^^^^^
+Vyper can be installed using a bash script.
+::
+
+    https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
+
+
 Arch
 -----
 Using your aur helper of choice (`yay` here).
@@ -160,25 +168,6 @@ If any unexpected errors or exceptions are encountered, please feel free create 
 
     You can then run `make` and `make test` again.
 
-*****
-BASH
-*****
-
-Vyper can be installed using a bash script.
-::
-
-    wget https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
-
-Changes file permission (make it executable).
-::
-
-        chmod 775 install_vyper_ubuntu.sh
-
-Executes the script.
-::
-
-    ./install_vyper_ubuntu.sh
-
 
 ***
 PIP
@@ -249,9 +238,6 @@ Vyper is published in the snap store. In any of the `supported Linux distros <ht
 ::
 
     sudo snap install vyper --edge --devmode
-
-::
-
 
 To install the latest beta version use:
 

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -160,6 +160,26 @@ If any unexpected errors or exceptions are encountered, please feel free create 
 
     You can then run `make` and `make test` again.
 
+*****
+BASH
+*****
+
+Vyper can be installed using a bash script.
+::
+
+    wget https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
+
+Changes file permission (make it executable).
+::
+
+        chmod 775 install_vyper_ubuntu.sh
+
+Executes the script.
+::
+
+    ./install_vyper_ubuntu.sh
+
+
 ***
 PIP
 ***

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -69,6 +69,7 @@ Vyper can be installed using a bash script.
     https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
 
 
+*Reminder*: Please read and understand the commands in any bash script before executing, especially with `sudo`.
 Arch
 -----
 Using your aur helper of choice (`yay` here).


### PR DESCRIPTION
### What I did
Created a bash script to install vyper on ubuntu systems.
Added those changes in the installing-vyper.rst

### How I did it
After following the **Installing Vyper** Section on **Read the Docs**, I thought about creating a bash script for installation purpose.
The script can be found at:
[Bash script to install vyper on Ubuntu](https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh)

### How to verify it

> wget https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
> chmod 775 install_vyper_ubuntu.sh
> ./install_vyper_ubuntu.sh

### Description for the changelog
Added bash script to install vyper in installing-vyper.rst

### Cute Animal Picture
![PR4](https://user-images.githubusercontent.com/32358081/57330208-0274f180-7133-11e9-9401-305cfdcb0c10.jpeg)


