### PR TITLE
Add constancy protection to range expressions

### DIFF
--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -84,6 +84,62 @@ def a (x:int128):
 @public
 def b():
     self.a(10)
+    """,
+    # test constancy in range expressions
+    """
+glob: int128
+@public
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@public
+def bar():
+    for i in range(self.foo(), self.foo() + 1):
+        pass
+    """,
+    """
+glob: int128
+@public
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@public
+def bar():
+    for i in range(self.foo()):
+        pass
+    """,
+    """
+glob: int128
+@public
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@public
+def bar():
+    for i in [1,2,3,4,self.foo()]:
+        pass
+    """,
+    """
+glob: int128
+@public
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@public
+def bar():
+    for i in range(self.foo(), 7):
+        pass
+    """,
+    """
+glob: int128
+@public
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@public
+def bar():
+    for i in range(3, self.foo()):
+        pass
     """
 ]
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -50,6 +50,8 @@ class Context:
         self.constancy = constancy
         # Whether body is currently in an assert statement
         self.in_assertion = False
+        # Whether we are currently parsing a range expression
+        self.in_range_expr = False
         # Is the function payable?
         self.is_payable = is_payable
         # Number of placeholders generated (used to generate random names)
@@ -79,7 +81,9 @@ class Context:
         self.global_ctx = global_ctx
 
     def is_constant(self):
-        return self.constancy is Constancy.Constant or self.in_assertion
+        return self.constancy is Constancy.Constant or \
+                self.in_assertion or \
+                self.in_range_expr
 
     #
     # Context Managers
@@ -103,6 +107,13 @@ class Context:
         self.in_assertion = True
         yield
         self.in_assertion = prev_value
+
+    @contextlib.contextmanager
+    def range_scope(self):
+        prev_value = self.in_range_expr
+        self.in_range_expr = True
+        yield
+        self.in_range_expr = prev_value
 
     @contextlib.contextmanager
     def make_blockscope(self, blockscope_id):
@@ -161,6 +172,8 @@ class Context:
     def pp_constancy(self):
         if self.in_assertion:
             return 'an assertion'
+        elif self.in_range_expr:
+            return 'a range expression'
         elif self.constancy == Constancy.Constant:
             return 'a constant function'
         raise ValueError('Compiler error: unknown constancy in pp_constancy: %r' % self.constancy)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -604,7 +604,7 @@ class Stmt(object):
         return False
 
     def parse_for_list(self):
-        with self.context.range_scope() :
+        with self.context.range_scope():
             iter_list_node = Expr(self.stmt.iter, self.context).lll_node
         if not isinstance(iter_list_node.typ.subtype, BaseType):  # Sanity check on list subtype.
             raise StructureException('For loops allowed only on basetype lists.', self.stmt.iter)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -481,7 +481,10 @@ class Stmt(object):
             return LLLnode.from_list(['assert', test_expr], typ=None, pos=getpos(self.stmt))
 
     def _check_valid_range_constant(self, arg_ast_node, raise_exception=True):
-        arg_expr = Expr.parse_value_expr(arg_ast_node, self.context)
+        with self.context.range_scope():
+            # TODO should catch if raise_exception == False?
+            arg_expr = Expr.parse_value_expr(arg_ast_node, self.context)
+
         is_integer_literal = (
             isinstance(arg_expr.typ, BaseType) and arg_expr.typ.is_literal
         ) and arg_expr.typ.typ in {'uint256', 'int128'}
@@ -601,7 +604,8 @@ class Stmt(object):
         return False
 
     def parse_for_list(self):
-        iter_list_node = Expr(self.stmt.iter, self.context).lll_node
+        with self.context.range_scope() :
+            iter_list_node = Expr(self.stmt.iter, self.context).lll_node
         if not isinstance(iter_list_node.typ.subtype, BaseType):  # Sanity check on list subtype.
             raise StructureException('For loops allowed only on basetype lists.', self.stmt.iter)
         iter_var_type = (


### PR DESCRIPTION
### What I did
Fix #1397 

### How I did it
Add another type of block (range_scope) which can set constancy.

### How to verify it
See tests added in https://github.com/ethereum/vyper/pull/1424/commits/d299235a6023f6ea5ac72396266c866a90dc88ac

### Description for the changelog
Add constancy protection to range expressions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/4dXxojR818w/hqdefault.jpg)
