### PR TITLE
Fix static array frame for private functions

### DIFF
--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -530,3 +530,19 @@ def start():
     assert c.test() is False
     c.start(transact={})
     assert c.test() is True
+
+
+def test_private_array_param(get_contract):
+    code = """
+@private
+def change_arr(arr: int128[2]):
+    pass
+@public
+def call_arr() -> int128:
+    a: int128[2] # test with zeroed arg
+    self.change_arr(a)
+    return 42
+    """
+
+    c = get_contract(code)
+    assert c.call_arr() == 42

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -510,6 +510,23 @@ def get_size_of_type(typ):
         raise Exception("Can not get size of type, Unexpected type: %r" % repr(typ))
 
 
+# amount of space a type takes in the static section of its ABI encoding
+def get_static_size_of_type(typ):
+    if isinstance(typ, BaseType):
+        return 1
+    elif isinstance(typ, ByteArrayLike):
+        return 1
+    elif isinstance(typ, ListType):
+        return get_size_of_type(typ.subtype) * typ.count
+    elif isinstance(typ, MappingType):
+        raise Exception("Maps are not supported for function arguments or outputs.")
+    elif isinstance(typ, TupleLike):
+        return sum([get_size_of_type(v) for v in typ.tuple_members()])
+    else:
+        raise Exception("Can not get size of type, Unexpected type: %r" % repr(typ))
+
+
+# could be rewritten as get_static_size_of_type == get_size_of_type?
 def has_dynamic_data(typ):
     if isinstance(typ, BaseType):
         return False


### PR DESCRIPTION
### What I did
Fix https://github.com/ethereum/vyper/issues/1418.

### How I did it
The dynamic push_args segment was inappropriately used for backing up static arrays onto the stack. However, it happened to back up the elements correctly when the array elements were nonzero. This removes dynamic push_args and fixes the length count for the static push_args segment.

### How to verify it
Check the new test which passes a zeroed out static array to a private function.

### Description for the changelog
Fix static array packing for private functions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://i3.mirror.co.uk/incoming/article823894.ece/alternates/s2197/Tyrannosaurus%20Rex)