### PR TITLE
Add Disclosure for #1418

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,7 @@ we will add an entry to this table for posterity and reference by others.
 
 | VVE | Description | Introduced | Fixed | Report Link |
 | --- | ----------- | ---------- | ----- | ----------- |
+| VVE-2019-0001 | Stack Exhaustion via Private Calls w/ Arrays | v0.1.0-beta.4 | v0.1.0-beta.10 | https://github.com/ethereum/vyper/issues/1418#issuecomment-496509570 |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
### What I did
Add an entry to the VVE table for #1418 disclosure. It was determined that no known wide-scale usage of Vyper would be affected.
