### PR TITLE
Fix private underflow

### DIFF
--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -546,3 +546,18 @@ def call_arr() -> int128:
 
     c = get_contract(code)
     assert c.call_arr() == 42
+
+
+def test_private_zero_bytearray(get_contract):
+    private_test_code = """
+@private
+def inner(xs: bytes[256]):
+    pass
+@public
+def outer(xs: bytes[256] = "") -> bool:
+    self.inner(xs)
+    return True
+    """
+
+    c = get_contract(private_test_code)
+    assert c.outer()

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -118,12 +118,9 @@ def call_self_private(stmt_expr, context, sig):
             push_args += [
                 ['mstore', i_placeholder, arg_pos + total_arg_size],
                 ['label', start_label],
-                ['if', ['lt', ['mload', i_placeholder], static_pos], ['goto', end_label]],
-                [
-                    'if_unchecked',
-                    ['ne', ['mload', ['mload', i_placeholder]], 0],
-                    ['mload', ['mload', i_placeholder]],
-                ],
+                ['if', ['lt', ['mload', i_placeholder], static_pos],
+                    ['goto', end_label]],
+                ['mload', ['mload', i_placeholder]],
                 ['mstore', i_placeholder, ['sub', ['mload', i_placeholder], 32]],  # decrease i
                 ['goto', start_label],
                 ['label', end_label]

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -117,7 +117,16 @@ def call_self_private(stmt_expr, context, sig):
             start_label = ident + '_start'
             end_label = ident + '_end'
             i_placeholder = context.new_placeholder(BaseType('uint256'))
+if
             for idx, arg in enumerate(expr_args):
+                # Calculate copy start position.
+                # Given | static | dynamic | section in memory,
+                # copy backwards so the values are in order on the stack.
+                # We calculate i, the end of the whole encoded part
+                # (i.e. the starting index for copy)
+                # by taking ceil32(len<arg>) + offset<arg> + arg_pos
+                # for the last dynamic argument and arg_pos is the start
+                # the whole argument section.
                 if isinstance(arg.typ, ByteArrayLike):
                     xs = [['with', 'offset', ['mload', arg_pos + idx * 32],
                           ['with', 'len_pos', ['add', arg_pos, 'offset'],
@@ -127,7 +136,7 @@ def call_self_private(stmt_expr, context, sig):
                                       'len_pos',
                                       ['ceil32', 'len_value']]]]]]]
             # xs must be defined since needs_dyn_section implies at least one
-            # arg must be dynamic
+            # arg must be dynamic. this picks the last dynamic arg.
             push_args += xs
             push_args += [
                 ['label', start_label],

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -21,6 +21,7 @@ from vyper.types import (
     ceil32,
     get_size_of_type,
     get_static_size_of_type,
+    has_dynamic_data,
 )
 
 
@@ -109,8 +110,11 @@ def call_self_private(stmt_expr, context, sig):
                     for arg in expr_args])
         static_pos = arg_pos + static_arg_size
         total_arg_size = ceil32(inargsize - 4)
+        needs_dyn_section = any(
+                [has_dynamic_data(arg.typ)
+                    for arg in expr_args])
 
-        if static_arg_size != total_arg_size:  # requires dynamic section.
+        if needs_dyn_section:
             ident = 'push_args_%d_%d_%d' % (sig.method_id, stmt_expr.lineno, stmt_expr.col_offset)
             start_label = ident + '_start'
             end_label = ident + '_end'

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -117,28 +117,27 @@ def call_self_private(stmt_expr, context, sig):
             start_label = ident + '_start'
             end_label = ident + '_end'
             i_placeholder = context.new_placeholder(BaseType('uint256'))
-if
+
+            # Calculate copy start position.
+            # Given | static | dynamic | section in memory,
+            # copy backwards so the values are in order on the stack.
+            # We calculate i, the end of the whole encoded part
+            # (i.e. the starting index for copy)
+            # by taking ceil32(len<arg>) + offset<arg> + arg_pos
+            # for the last dynamic argument and arg_pos is the start
+            # the whole argument section.
             for idx, arg in enumerate(expr_args):
-                # Calculate copy start position.
-                # Given | static | dynamic | section in memory,
-                # copy backwards so the values are in order on the stack.
-                # We calculate i, the end of the whole encoded part
-                # (i.e. the starting index for copy)
-                # by taking ceil32(len<arg>) + offset<arg> + arg_pos
-                # for the last dynamic argument and arg_pos is the start
-                # the whole argument section.
                 if isinstance(arg.typ, ByteArrayLike):
-                    xs = [['with', 'offset', ['mload', arg_pos + idx * 32],
-                          ['with', 'len_pos', ['add', arg_pos, 'offset'],
-                          ['with', 'len_value', ['mload', 'len_pos'],
-                              ['mstore', i_placeholder,
-                                  ['add',
-                                      'len_pos',
-                                      ['ceil32', 'len_value']]]]]]]
-            # xs must be defined since needs_dyn_section implies at least one
-            # arg must be dynamic. this picks the last dynamic arg.
-            push_args += xs
+                    last_idx = idx
             push_args += [
+                ['with', 'offset', ['mload', arg_pos + last_idx * 32],
+                    ['with', 'len_pos', ['add', arg_pos, 'offset'],
+                        ['with', 'len_value', ['mload', 'len_pos'],
+                            ['mstore', i_placeholder,
+                                ['add', 'len_pos', ['ceil32', 'len_value']]]]]]
+            ]
+            push_args += [
+
                 ['label', start_label],
                 ['if', ['lt', ['mload', i_placeholder], static_pos],
                     ['goto', end_label]],

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -136,6 +136,8 @@ def call_self_private(stmt_expr, context, sig):
                             ['mstore', i_placeholder,
                                 ['add', 'len_pos', ['ceil32', 'len_value']]]]]]
             ]
+            # loop from end of dynamic section to start of dynamic section,
+            # pushing each element onto the stack.
             push_args += [
 
                 ['label', start_label],


### PR DESCRIPTION
### What I did
Fix #1463 

### How I did it
The dynamic section copier skipped null elements in case there was a difference between len(array) and maxlen(array) since elements past-the-end of memory are null. However, that could fail if the array length was nonzero but it had null elements. This fixes the dynamic section copier by explicitly using the length specified in the ABI encoding for byte arrays.

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://necaonline.com/wp-content/uploads/2018/08/1962-Godzilla6.jpg)
