### PR TITLE
Allow array index to be uint256

### DIFF
--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -88,6 +88,10 @@ class SyntaxException(ParserException):
     pass
 
 
+class ArrayIndexException(ParserException):
+    pass
+
+
 class CompilerPanic(Exception):
 
     def __init__(self, message):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -346,9 +346,11 @@ def add_variable_offset(parent, key, pos):
                         'Index is %r but array size is %r' % (key.value, typ.count),
                         pos)
             sub = k
-        elif is_base_type(key.typ, 'int128'):
-            sub = ['clamplt', ['clampge', k, 0], typ.count]
         else:
+            # this works, even for int128. for int128, since two's-complement
+            # is used, if the index is negative, (unsigned) LT will interpret
+            # it as a very large number, larger than any practical value for
+            # an array index, and the clamp will throw an error.
             sub = ['uclamplt', k, typ.count]
 
         if location == 'storage':

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -334,7 +334,7 @@ def add_variable_offset(parent, key, pos):
 
         subtype = typ.subtype
         sub = [
-            'uclamplt', base_type_conversion(key, key.typ, BaseType('int128'), pos=pos), typ.count
+            'uclamplt', base_type_conversion(key, key.typ, BaseType('uint256'), pos=pos), typ.count
         ]
 
         if location == 'storage':


### PR DESCRIPTION
### What I did
Fix #1478 and #1483 

TODO:
- [x] tests

### How I did it
This goes back to commit 444870548f1008b9c6b42723ae8fdcb367acbf97.
Before that, the type of the index was inferred. After that, it changed
to be the default numeric type in the language, `num` (now `int128`).

Array index types should generally be uint256.

### How to verify it
Check IR of following:
```python
xs: uint256[10]
# runtime bounds check
@public
def signed_bounds_check(ix: int128) -> uint256: 
  return self.xs[ix]

# allow uint256 index
@public
def uint256_index(ix: uint256) -> uint256: 
  return self.xs[ix]
```
Check this throws compile-time exception:
```python
xs: uint256[10]
# compile-time failure
@public
def compile_time_bounds_check() -> uint256: 
  return self.xs[10]
```

### Description for the changelog
- Allow array index to be uint256 or int128
- Fix runtime bounds checks for signed indices
- Convert runtime bounds checks into compile-time check for literal
  indices.

### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://www.newdinosaurs.com/wp-content/uploads/2016/01/28_stegosaurus_karen_carr.jpg)
