### PR TITLE
Wrap pushing and popping of locals into a loop.

### DIFF
--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -88,7 +88,7 @@ def call_self_private(stmt_expr, context, sig):
         mem_from, mem_to = var_slots[0][0], var_slots[-1][0] + var_slots[-1][1] * 32
 
         i_placeholder = context.new_placeholder(BaseType('uint256'))
-        local_save_ident = "%d_%d" % (stmt_expr.lineno, stmt_expr.col_offset)
+        local_save_ident = "_%d_%d" % (stmt_expr.lineno, stmt_expr.col_offset)
         push_loop_label = 'save_locals_start' + local_save_ident
         pop_loop_label = 'restore_locals_start' + local_save_ident
 

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -111,7 +111,7 @@ def call_self_private(stmt_expr, context, sig):
             ]
         else:
             push_local_vars = [['mload', pos] for pos in range(mem_from, mem_to, 32)]
-            pop_local_vars = [['mstore', pos, 'pass'] for pos in range(mem_to - 32, mem_from - 32, -32)]
+            pop_local_vars = [['mstore', pos, 'pass'] for pos in range(mem_to-32, mem_from-32, -32)]
 
     # Push Arguments
     if expr_args:

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -86,11 +86,28 @@ def call_self_private(stmt_expr, context, sig):
         var_slots = [(v.pos, v.size) for name, v in context.vars.items()]
         var_slots.sort(key=lambda x: x[0])
         mem_from, mem_to = var_slots[0][0], var_slots[-1][0] + var_slots[-1][1] * 32
+
+        i_placeholder = context.new_placeholder(BaseType('uint256'))
+        local_save_ident = "%d_%d" % (stmt_expr.lineno, stmt_expr.col_offset)
+        push_loop_label = 'save_locals_start' + local_save_ident
+        pop_loop_label = 'restore_locals_start' + local_save_ident
+
         push_local_vars = [
-            ['mload', pos] for pos in range(mem_from, mem_to, 32)
+                ['mstore', i_placeholder, mem_from],
+                ['label', push_loop_label],
+                ['mload', ['mload', i_placeholder]],
+                ['mstore', i_placeholder, ['add', ['mload', i_placeholder], 32]],
+                ['if', ['lt', ['mload', i_placeholder], mem_to],
+                    ['goto', push_loop_label]]
         ]
+
         pop_local_vars = [
-            ['mstore', pos, 'pass'] for pos in reversed(range(mem_from, mem_to, 32))
+            ['mstore', i_placeholder, mem_to - 32],
+            ['label', pop_loop_label],
+            ['mstore', ['mload', i_placeholder], 'pass'],
+            ['mstore', i_placeholder, ['sub', ['mload', i_placeholder], 32]],
+            ['if', ['ge', ['mload', i_placeholder], mem_from],
+                   ['goto', pop_loop_label]]
         ]
 
     # Push Arguments


### PR DESCRIPTION
### What I did
Reduced contract code size due to excessive pushing/popping of locals.
### How I did it
Changed `push_local_vars` and `pop_local_vars` in `self_call.py` to LLL code that implements a loop equal in semantics.

All the tests pass.
### How to verify it
Compile the following contract.
```python
struct Animal:
    Name: uint256
    Exists: int128

COLLECTION_SIZE: constant(uint256) = 1000

contractOwner: address
daddy: address
collection: map(address, Animal)

count: int128

@private
@constant
def isZookeeper(sender: address) -> bool:
    return sender == self.contractOwner or sender == self.daddy

@public
def addToCollection(animals: address[COLLECTION_SIZE]):
    assert self.isZookeeper(msg.sender)

    for animal in animals:
        if animal == ZERO_ADDRESS: break

        if self.collection[animal].Exists == 0:
            self.count += 1
            self.collection[animal].Exists = self.count

@public
def __init__(myDaddy: address):
    self.daddy = myDaddy
```
In the generated LLL code, there will no longer large portions of `mload` and `mstore` calls when saving/restoring locals.

Old code size (bytes): 55340
New code size (bytes): 39510

### Cute Animal Picture

![VERY NICE, GREAT SUCCESS!](https://eserioblog.files.wordpress.com/2014/02/borat.jpg)
