### PR TITLE
Add `make dev-deps` to installation docs

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -129,6 +129,7 @@ install and test commands:
     git clone https://github.com/ethereum/vyper.git
     cd vyper
     make
+    make dev-deps
     make test
 
 Additionally, you may try to compile an example contract by running:
@@ -159,6 +160,7 @@ If any unexpected errors or exceptions are encountered, please feel free create 
     ::
 
         make
+        make dev-deps
         make test
 
     If you get the error `ld: library not found for -lyaml` in the output of `make`, make sure `libyaml` is installed using `brew info libyaml`. If it is installed, add its location to the compile flags as well:


### PR DESCRIPTION
@jacqueswww Not sure if we want to add this here or not (feel free to close if not) but may save a bit of headache for people who are getting the tests running for the first time (or first time in a while like me 😓😅)

### What I did

Added a couple lines to docs.

### How I did it

N/A

### How to verify it

N/A

### Description for the changelog

Added `make dev-deps` to docs.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/60113049-367d9380-972e-11e9-8a06-c802f9c2f77e.png)
