### PR TITLE
Add calldata located variables.

### DIFF
--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -318,9 +318,10 @@ def test(a: bytes32) -> (bytes32, uint256, int128):
     b: uint256 = 1
     c: int128 = 1
     d: int128 = 123
-    a, b, c = self._test(a)
+    f: bytes32
+    f, b, c = self._test(a)
     assert d == 123
-    return a, b, c
+    return f, b, c
 
 @public
 def test2(a: bytes32) -> (bytes32, uint256, int128):

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -9,6 +9,7 @@ from vyper import (
 from vyper.exceptions import (
     TypeMismatchException,
     VariableDeclarationException,
+    ConstancyViolationException,
 )
 
 fail_list = [
@@ -69,6 +70,21 @@ def test():
     c: bytes[1]
     a, b, c = self.out_literals()
     """,
+    ("""
+@private
+def _test(a: bytes32) -> (bytes32, uint256, int128):
+    b: uint256 = 1000
+    return a, b, -1200
+
+@public
+def test(a: bytes32) -> (bytes32, uint256, int128):
+    b: uint256 = 1
+    c: int128 = 1
+    d: int128 = 123
+    a, b, c = self._test(a)
+    assert d == 123
+    return a, b, c
+    """, ConstancyViolationException)
 ]
 
 

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -7,9 +7,9 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
+    ConstancyViolationException,
     TypeMismatchException,
     VariableDeclarationException,
-    ConstancyViolationException,
 )
 
 fail_list = [

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -210,7 +210,7 @@ def test(some_dynamic_var: uint256) -> uint256:
     """
 
     lll = compile_code(code, ['ir'])['ir']
-    assert search_for_sublist(lll, ['add', ['mload', [320]], [4096]])
+    assert search_for_sublist(lll, ['add', ['calldataload', [4]], [4096]])
 
 
 def test_constant_lists(get_contract):

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -148,11 +148,11 @@ class Context:
             var_size = 32 * get_size_of_type(typ)
             var_pos, _ = self.memory_allocator.increase_memory(var_size)
             self.vars[name] = VariableRecord(
-                name,
-                var_pos,
-                typ,
-                True,
-                self.blockscopes.copy(),
+                name=name,
+                pos=var_pos,
+                typ=typ,
+                mutable=True,
+                blockscopes=self.blockscopes.copy(),
             )
             return var_pos
 

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -142,6 +142,10 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
                     "Log list type '%s' does not match provided, expected '%s'" % (provided, typ)
                 )
 
+        # NOTE: Below code could be refactored into iterators/getter functions for each type of
+        #       repetitive loop. But seeing how each one is a unique for loop, and in which way
+        #       the sub value makes the difference in each type of list clearer.
+
         # List from storage
         if isinstance(arg, ast.Attribute) and arg.value.id == 'self':
             stor_list = context.globals[arg.attr]

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -172,7 +172,11 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
             check_list_type_match(context.vars[arg.id].typ.subtype)
             mem_offset = 0
             for _ in range(0, size):
-                arg2 = LLLnode.from_list(pos + mem_offset, typ=typ, location='memory')
+                arg2 = LLLnode.from_list(
+                    pos + mem_offset,
+                    typ=typ,
+                    location=context.vars[arg.id].location
+                )
                 holder, maxlen = pack_args_by_32(
                     holder,
                     maxlen,

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -262,7 +262,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             return LLLnode.from_list(
                 var.pos,
                 typ=var.typ,
-                location='memory',
+                location=var.location,
                 pos=getpos(self.expr),
                 annotation=self.expr.id,
                 mutable=var.mutable,
@@ -1112,7 +1112,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
     def parse_value_expr(cls, expr, context):
         return unwrap_location(cls(expr, context).lll_node)
 
-    # Parse an expression that represents an address in memory or storage
+    # Parse an expression that represents an address in memory/calldata or storage.
     @classmethod
     def parse_variable_location(cls, expr, context):
         o = cls(expr, context).lll_node

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -262,7 +262,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             return LLLnode.from_list(
                 var.pos,
                 typ=var.typ,
-                location=var.location,
+                location=var.location,  # either 'memory' or 'calldata' storage is handled above.
                 pos=getpos(self.expr),
                 annotation=self.expr.id,
                 mutable=var.mutable,

--- a/vyper/parser/function_definitions/parse_public_function.py
+++ b/vyper/parser/function_definitions/parse_public_function.py
@@ -104,7 +104,7 @@ def parse_public_function(code: ast.FunctionDef,
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)
 
     # Allocate variable space.
-    context.memory_allocator.increase_memory(sig.max_copy_size)
+    # context.memory_allocator.increase_memory(sig.max_copy_size)
 
     clampers = []
 
@@ -114,11 +114,12 @@ def parse_public_function(code: ast.FunctionDef,
         copier = ['pass']
     elif sig.name == '__init__':
         copier = ['codecopy', MemoryPositions.RESERVED_MEMORY, '~codelen', sig.base_copy_size]
-    else:
-        copier = get_public_arg_copier(
-            total_size=sig.base_copy_size,
-            memory_dest=MemoryPositions.RESERVED_MEMORY
-        )
+        context.memory_allocator.increase_memory(sig.max_copy_size)
+    # else:
+    #     copier = get_public_arg_copier(
+    #         total_size=sig.base_copy_size,
+    #         memory_dest=MemoryPositions.RESERVED_MEMORY
+    #     )
     clampers.append(copier)
 
     # Add asserts for payable and internal
@@ -126,6 +127,7 @@ def parse_public_function(code: ast.FunctionDef,
         clampers.append(['assert', ['iszero', 'callvalue']])
 
     # Fill variable positions
+    default_args_start_pos = len(sig.base_args)
     for i, arg in enumerate(sig.args):
         if i < len(sig.base_args):
             clampers.append(make_arg_clamper(
@@ -138,12 +140,29 @@ def parse_public_function(code: ast.FunctionDef,
             mem_pos, _ = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
-            context.vars[arg.name] = VariableRecord(
-                arg.name,
-                MemoryPositions.RESERVED_MEMORY + arg.pos,
-                arg.typ,
-                False,
-            )
+            if sig.name == '__init__':
+                context.vars[arg.name] = VariableRecord(
+                    arg.name,
+                    MemoryPositions.RESERVED_MEMORY + arg.pos,
+                    arg.typ,
+                    False,
+                )
+            elif i >= default_args_start_pos:  # default args need to be allocated in memory.
+                default_arg_pos, _ = context.memory_allocator.increase_memory(32)
+                context.vars[arg.name] = VariableRecord(
+                    name=arg.name,
+                    pos=default_arg_pos,
+                    typ=arg.typ,
+                    mutable=False,
+                )
+            else:
+                context.vars[arg.name] = VariableRecord(
+                    name=arg.name,
+                    pos=4 + arg.pos,
+                    typ=arg.typ,
+                    mutable=False,
+                    location='calldata'
+                )
 
     # Create "clampers" (input well-formedness checkers)
     # Return function body

--- a/vyper/parser/function_definitions/parse_public_function.py
+++ b/vyper/parser/function_definitions/parse_public_function.py
@@ -103,9 +103,6 @@ def parse_public_function(code: ast.FunctionDef,
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)
 
-    # Allocate variable space.
-    # context.memory_allocator.increase_memory(sig.max_copy_size)
-
     clampers = []
 
     # Generate copiers

--- a/vyper/parser/function_definitions/parse_public_function.py
+++ b/vyper/parser/function_definitions/parse_public_function.py
@@ -115,11 +115,6 @@ def parse_public_function(code: ast.FunctionDef,
     elif sig.name == '__init__':
         copier = ['codecopy', MemoryPositions.RESERVED_MEMORY, '~codelen', sig.base_copy_size]
         context.memory_allocator.increase_memory(sig.max_copy_size)
-    # else:
-    #     copier = get_public_arg_copier(
-    #         total_size=sig.base_copy_size,
-    #         memory_dest=MemoryPositions.RESERVED_MEMORY
-    #     )
     clampers.append(copier)
 
     # Add asserts for payable and internal

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -186,7 +186,7 @@ class LLLnode:
                         "be zerovalent: %r"
                     ) % self.args[3])
                 self.valency = 0
-                if self.args[1].value == 'mload' or self.args[1].value == 'sload':
+                if self.args[1].value in ('calldataload', 'mload') or self.args[1].value == 'sload':
                     rounds = self.args[2].value
                 else:
                     rounds = abs(self.args[2].value - self.args[1].value)

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -82,8 +82,11 @@ def call_self_private(stmt_expr, context, sig):
     push_args = []
 
     # Push local variables.
-    if context.vars:
-        var_slots = [(v.pos, v.size) for name, v in context.vars.items()]
+    var_slots = [
+        (v.pos, v.size) for name, v in context.vars.items()
+        if v.location == 'memory'
+    ]
+    if var_slots:
         var_slots.sort(key=lambda x: x[0])
         mem_from, mem_to = var_slots[0][0], var_slots[-1][0] + var_slots[-1][1] * 32
         push_local_vars = [

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -41,11 +41,13 @@ from vyper.utils import (
 
 # Function argument
 class VariableRecord:
-    def __init__(self, name, pos, typ, mutable, blockscopes=None, defined_at=None):
+    def __init__(self, name, pos, typ, mutable, *,
+                 location='memory', blockscopes=None, defined_at=None):
         self.name = name
         self.pos = pos
         self.typ = typ
         self.mutable = mutable
+        self.location = location
         self.blockscopes = [] if blockscopes is None else blockscopes
         self.defined_at = defined_at  # source code location variable record was defined.
 


### PR DESCRIPTION
### What I did

Fixes #1381.
This is an optimisation I am glad I finally got to make! Basically we were copying variables to memory unnecessarily, by using the calldata directly one not only gets better speed - but also ensures on the EVM level the variables are read-only (yes we had a test that actually was altering a parameter in a tuple assign).
This changes affects these these function parameter types.
- Arrays
- All Base Types
Note: Turned out ByteArrays were too difficult optimise, especially when they tend to have to be packed, which one would have to just allocate them again. Also one looses out not being able to always re-use the identity / mem copy contract.

Taking some files from the examples directory:
Blind Auction -> 73 % less bytecode (!!!)
ERC20 -> 4.9 % less bytecode
ERC720 -> 6.3% less bytecode

Additionally we save runtime costs because we skip 'n full N of mstore (memory growth) on each call.
Also private calls tend to be much cheaper on average, because the in-memory context is smaller.

### How I did it

Used a lot of coffee :coffee: 

### How to verify it
Check commits, play with your own contracts.

### Description for the changelog
Bytecode & Runtime optimisation for function parameters.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images-na.ssl-images-amazon.com/images/I/71lrW7iN5uL._SY500_.jpg)
