### PR TITLE
Added `bytes32` as target type for `decimal` conversion

### DIFF
--- a/tests/parser/functions/test_convert_to_bytes32.py
+++ b/tests/parser/functions/test_convert_to_bytes32.py
@@ -163,24 +163,24 @@ def xookar() -> bytes32:
 
     hooVal = c.hoo()
     hoonarVal = c.hoonar()
-    _hoo = ((-2**127) * 10000000000).to_bytes(32, byteorder="big", signed=True)
+    _hoo = ((-2**127) * decimal_divisor).to_bytes(32, byteorder="big", signed=True)
     assert hooVal == _hoo
     assert hoonarVal == _hoo
 
     gooVal = c.goo()
     goomarVal = c.goomar()
-    _goo = ((2**127 - 1) * 10000000000).to_bytes(32, byteorder="big", signed=True)
+    _goo = ((2**127 - 1) * decimal_divisor).to_bytes(32, byteorder="big", signed=True)
     assert gooVal == _goo
     assert goomarVal == _goo
 
     zooVal = c.zoo()
     zoojarVal = c.zoojar()
-    _zoo = (5 * 10000000000).to_bytes(32, byteorder="big", signed=True)
+    _zoo = (5 * decimal_divisor).to_bytes(32, byteorder="big", signed=True)
     assert zooVal == _zoo
     assert zoojarVal == _zoo
 
     xooVal = c.xoo()
     xookarVal = c.xookar()
-    _xoo = (-5 * 10000000000).to_bytes(32, byteorder="big", signed=True)
+    _xoo = (-5 * decimal_divisor).to_bytes(32, byteorder="big", signed=True)
     assert xooVal == _xoo
     assert xookarVal == _xoo

--- a/tests/parser/functions/test_convert_to_bytes32.py
+++ b/tests/parser/functions/test_convert_to_bytes32.py
@@ -80,3 +80,64 @@ def testConvertBytes32(flag: bool) -> bytes32:
     trueBytes = c.testConvertBytes32(True)
     assert trueBytes[31:32] == b'\x01'
     assert len(trueBytes) == 32
+
+
+def test_convert_from_decimal(get_contract_with_gas_estimation):
+    code = """
+bar: decimal
+nar: decimal
+mar: decimal
+
+@public
+def foo() -> bytes32:
+    return convert(0.0, bytes32)
+
+@public
+def foobar() -> bytes32:
+    self.bar = 0.0
+    return convert(self.bar, bytes32)
+
+@public
+def hoo() -> bytes32:
+    return convert(MIN_DECIMAL, bytes32)
+
+@public
+def hoonar() -> bytes32:
+    self.nar = MIN_DECIMAL
+    return convert(self.nar, bytes32)
+
+@public
+def goo() -> bytes32:
+    return convert(MAX_DECIMAL, bytes32)
+
+@public
+def goomar() -> bytes32:
+    self.mar = MAX_DECIMAL
+    return convert(self.mar, bytes32)
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    fooVal = c.foo()
+    foobarVal = c.foobar()
+    assert fooVal == (b"\x00" * 32)
+    assert len(fooVal) == 32
+    assert foobarVal == (b"\x00" * 32)
+    assert len(foobarVal) == 32
+    assert fooVal == foobarVal
+
+    hooVal = c.hoo()
+    hoonarVal = c.hoonar()
+    assert hooVal[0:11] == (b"\xff" * 11)
+    assert len(hooVal) == 32
+    assert hoonarVal[0:11] == (b"\xff" * 11)
+    assert len(hoonarVal) == 32
+    assert hooVal == hoonarVal
+
+    gooVal = c.goo()
+    goomarVal = c.goomar()
+    assert gooVal[0:11] == (b"\x00" * 11)
+    assert len(gooVal) == 32
+    assert goomarVal[0:11] == (b"\x00" * 11)
+    assert len(goomarVal) == 32
+    assert gooVal == goomarVal

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -303,7 +303,7 @@ def to_decimal(expr, args, kwargs, context):
             raise InvalidLiteralException("Invalid input for decimal: %r" % in_arg, expr)
 
 
-@signature(('int128', 'uint256', 'address', 'bytes', 'bool'), '*')
+@signature(('int128', 'uint256', 'address', 'bytes', 'bool', 'decimal'), '*')
 def to_bytes32(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _len = get_type(in_arg)


### PR DESCRIPTION
### What I did

Added support for conversion _to_ `bytes32` _from_ `decimal`. Minor part of #1093

### How I did it

Minor change to `convert.py`.

### How to verify it

Run the tests:

`make test`

Or more specifically:

`pytest -k test_convert_to_bytes32`

### Description for the changelog

Added support for conversion _to_ `bytes32` _from_ `decimal`.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/60157915-0de8ae80-97ad-11e9-8a21-3f8a95f462cf.png)
