### PR TITLE
Added current state of type conversions support to docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -49,12 +49,14 @@ Rounds a decimal up to the nearest integer.
     :param a: value to convert
     :type a: either bool, decimal, int128, uint256 or bytes32
     :param b: the destination type to convert to
-    :type b: type of either decimal, int128, uint256 or bytes32
+    :type b: type of either bool, decimal, int128, uint256 or bytes32
 
     :output c: either decimal, int128, uint256 or bytes32
     """
 
-Converts a variable/ literal from one type to another.
+Converts a variable / literal from one type to another.
+
+For more details on available type conversions, see :ref:`type_conversions`.
 
 **clear**
 -------------------------

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -50,7 +50,7 @@ Operator              Description
 ``x != y``            Inequality
 ====================  ===================
 
-The operators ``or`` and ``and`` do not apply short-circuiting rules, i.e. both 
+The operators ``or`` and ``and`` do not apply short-circuiting rules, i.e. both
 `x` and `y` will always be evaluated.
 
 .. index:: ! int128, ! int, ! integer
@@ -516,7 +516,7 @@ Initial Values
 **************
 
 In Vyper, there is no ``null`` option like most programming languages have. Thus, every variable type has a default value. In order to check if a variable is empty, you will need to compare it to its type's default value.
-If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.  
+If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.
 
 Here you can find a list of all types and default values:
 
@@ -543,5 +543,159 @@ Here you can find a list of all types and default values:
 
 .. note::
     In reference types all the type's members are set to their initial values.
+
+
+.. _type_conversions:
+
+**************
+Type Conversions
+**************
+
+All type conversions in Vyper must be made explicitly using the built-in ``convert(a, b)`` function. Currently, the following type conversions are supported:
+
+.. list-table:: Basic Type Conversions
+   :header-rows: 1
+
+   * - Destination Type (b)
+     - Input Type (a.type)
+     - Allowed Inputs Values (a)
+     - Additional Notes
+   * - ``bool``
+     - ``bool``
+     - `—`
+     - Do not allow converting to/from the same type
+   * - ``bool``
+     - ``decimal``
+     - ``MINNUM...MAXNUM``
+     - Has the effective conversion logic of: ``return (a != 0.0)``
+   * - ``bool``
+     - ``int128``
+     - ``MINNUM...MAXNUM``
+     - Has the effective conversion logic of: ``return (a != 0)``
+   * - ``bool``
+     - ``uint256``
+     - ``0...MAX_UINT256``
+     - Has the effective conversion logic of: ``return (a != 0)``
+   * - ``bool``
+     - ``bytes32``
+     - ``(0x00 * 32)...(0xFF * 32)``
+     - Has the effective conversion logic of: ``return (a != 0x00)``
+   * - ``bool``
+     - ``bytes``
+     - ``(0x00 * 1)...(0xFF * 32)``
+     - Has the effective conversion logic of: ``return (a != 0x00)``
+   * -
+     -
+     -
+     -
+   * - ``decimal``
+     - ``bool``
+     - ``True / False``
+     - Result will be ``0.0`` or ``1.0``
+   * - ``decimal``
+     - ``decimal``
+     - —
+     - Do not allow converting to/from the same type
+   * - ``decimal``
+     - ``int128``
+     - ``MINNUM...MAXNUM``
+     -
+   * - ``decimal``
+     - ``uint256``
+     - ``0...MAXDECIMAL``
+     -
+   * - ``decimal``
+     - ``bytes32``
+     - ``(0x00 * 32)...(0xFF * 32)``
+     -
+   * - ``decimal``
+     - ``bytes``
+     - ``(0x00 * 1)...(0xFF * 32)``
+     -
+   * -
+     -
+     -
+     -
+   * - ``int128``
+     - ``bool``
+     - ``True / False``
+     - Result will be ``0`` or ``1``
+   * - ``int128``
+     - ``decimal``
+     - ``MINNUM...MAXNUM``
+     - Only allow input within ``int128`` supported range, truncates the decimal value
+   * - ``int128``
+     - ``int128``
+     - —
+     - Do not allow converting to/from the same type
+   * - ``int128``
+     - ``uint256``
+     - ``0...MAXNUM``
+     -
+   * - ``int128``
+     - ``bytes32``
+     - ``(0x00 * 32)...(0xFF * 32)``
+     -
+   * - ``int128``
+     - ``bytes``
+     - ``(0x00 * 1)...(0xFF * 32)``
+     -
+   * -
+     -
+     -
+     -
+   * - ``uint256``
+     - ``bool``
+     - ``True / False``
+     - Result will be ``0`` or ``1``
+   * - ``uint256``
+     - ``decimal``
+     - ``0...MAXDECIMAL``
+     - Truncates the ``decimal`` value
+   * - ``uint256``
+     - ``int128``
+     - ``0...MAXNUM``
+     -
+   * - ``uint256``
+     - ``uint256``
+     - —
+     - Do not allow converting to/from the same type
+   * - ``uint256``
+     - ``bytes32``
+     - ``(0x00 * 32)...(0xFF * 32)``
+     -
+   * - ``uint256``
+     - ``bytes``
+     - ``(0x00 * 1)...(0xFF * 32)``
+     -
+   * -
+     -
+     -
+     -
+   * - ``bytes32``
+     - ``bool``
+     - ``True / False``
+     - Result will be either ``(0x00 * 32)`` or ``(0x00 * 31 + 0x01)``
+   * - ``bytes32``
+     - ``decimal``
+     - ``MINDECIMAL...MAXDECIMAL``
+     -
+   * - ``bytes32``
+     - ``int128``
+     - ``MINNUM...MAXNUM``
+     -
+   * - ``bytes32``
+     - ``uint256``
+     - ``0...MAX_UINT256``
+     -
+   * - ``bytes32``
+     - ``bytes32``
+     - —
+     - Do not allow converting to/from the same type
+   * - ``bytes32``
+     - ``bytes``
+     - ``(0x00 * 1)...(0xFF * 32)``
+     - Left-pad input ``bytes`` to size of ``32``
+
 
 .. index:: !conversion

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -679,7 +679,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
    * - ``bytes32``
      - ``decimal``
      - ``MINDECIMAL...MAXDECIMAL``
-     -
+     - Has the effective behavior of multiplying the ``decimal`` value by the decimal divisor ``10000000000`` and then converting that signed *integer* value to a ``bytes32`` byte array
    * - ``bytes32``
      - ``int128``
      - ``MINNUM...MAXNUM``


### PR DESCRIPTION
### What I did

This PR is mostly pulling content from #1093 into the docs.

The main outstanding blocks of work to do towards that VIP at this point (at least that are currently on my radar) are:

1. adding full support for conversions to-from `bytes` type
2. adding full support for conversions to-from `address` type

These are both outlined already in the table in #1093, and are something I'll be making commits toward. 

However, I figured given that a lot is implemented at this point, it would be worth adding a table that defines the current state of things somewhere in the docs, as otherwise the current specification is a bit buried in Github.

### How I did it

^^

### How to verify it

`make docs`

### Description for the changelog

Added current state of type conversions support to docs.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/60162137-25786500-97b6-11e9-86b1-08dc7fa007f3.png)
