### PR TITLE
Remove sha3 alias

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -146,11 +146,11 @@ Returns the length of a given list of bytes.
 
 Takes 2 or more bytes arrays of type ``bytes32`` or ``bytes`` and combines them into one.
 
-**sha3/ keccak256**
+**keccak256**
 --------------------
 ::
 
-  def sha3(a) -> b:
+  def keccak256(a) -> b:
     """
     :param a: value to hash
     :type a: either str_literal, bytes, bytes32
@@ -158,9 +158,7 @@ Takes 2 or more bytes arrays of type ``bytes32`` or ``bytes`` and combines them 
     :output b: bytes32
     """
 
-Returns ``keccak256`` (Ethereum's sha3) hash of input.
-Note that it can be called either by using ``sha3`` or ``keccak256``.
-
+Returns ``keccak256`` hash of input.
 
 **sha256**
 --------------------

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -50,7 +50,7 @@ Operator              Description
 ``x != y``            Inequality
 ====================  ===================
 
-The operators ``or`` and ``and`` do not apply short-circuiting rules, i.e. both 
+The operators ``or`` and ``and`` do not apply short-circuiting rules, i.e. both
 `x` and `y` will always be evaluated.
 
 .. index:: ! int128, ! int, ! integer
@@ -320,7 +320,7 @@ Operators
 ====================================  ============================================================
 Keyword                               Description
 ====================================  ============================================================
-``sha3(x)``                           Return the sha3 hash as bytes32.
+``keccak256(x)``                      Return the keccak256 hash as bytes32.
 ``concat(x, ...)``                    Concatenate multiple inputs.
 ``slice(x, start=_start, len=_len)``  Return a slice of ``_len`` starting at ``_start``.
 ====================================  ============================================================
@@ -361,13 +361,13 @@ Operators
 Keyword                               Description
 ====================================  ============================================================
 ``len(x)``                            Return the length as an integer.
-``sha3(x)``                           Return the sha3 hash as bytes32.
+``keccak256(x)``                      Return the keccak256 hash as bytes32.
 ``concat(x, ...)``                    Concatenate multiple inputs.
 ``slice(x, start=_start, len=_len)``  Return a slice of ``_len`` starting at ``_start``.
 ====================================  ============================================================
 
 Where ``x`` is a byte array or string while ``_start`` and ``_len`` are integers.
-The ``len``, ``sha3``, ``concat``, ``slice`` operators can be used with ``string`` and ``bytes`` types.
+The ``len``, ``keccak256``, ``concat``, ``slice`` operators can be used with ``string`` and ``bytes`` types.
 
 .. index:: !reference
 
@@ -516,7 +516,7 @@ Initial Values
 **************
 
 In Vyper, there is no ``null`` option like most programming languages have. Thus, every variable type has a default value. In order to check if a variable is empty, you will need to compare it to its type's default value.
-If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.  
+If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.
 
 Here you can find a list of all types and default values:
 

--- a/examples/auctions/blind_auction.vy
+++ b/examples/auctions/blind_auction.vy
@@ -43,7 +43,7 @@ def __init__(_beneficiary: address, _biddingTime: timedelta, _revealTime: timede
 
 # Place a blinded bid with:
 #
-# _blindedBid = sha3(concat(
+# _blindedBid = keccak256(concat(
 #       convert(value, bytes32),
 #       convert(fake, bytes32),
 #       secret)
@@ -117,7 +117,7 @@ def reveal(_numBids: int128, _values: wei_value[128], _fakes: bool[128], _secret
         value: wei_value = _values[i]
         fake: bool = _fakes[i]
         secret: bytes32 = _secrets[i]
-        blindedBid: bytes32 = sha3(concat(
+        blindedBid: bytes32 = keccak256(concat(
             convert(value, bytes32),
             convert(fake, bytes32),
             secret

--- a/examples/wallet/wallet.vy
+++ b/examples/wallet/wallet.vy
@@ -35,11 +35,11 @@ def approve(_seq: int128, to: address, value: wei_value, data: bytes[4096], sigd
     # 2) The address the transaction is going to be sent to (can be a contract or a user).
     # 3) The value in wei that will be sent with this transaction.
     # 4) The data to be sent with this transaction (usually data is used to deploy contracts or to call functions on contracts, but you can put whatever you want in it).
-    # Takes the sha3 (keccak256) hash of the combination
-    h: bytes32 = sha3(concat(convert(_seq, bytes32), convert(to, bytes32), convert(value, bytes32), data))
+    # Takes the keccak256 hash of the combination
+    h: bytes32 = keccak256(concat(convert(_seq, bytes32), convert(to, bytes32), convert(value, bytes32), data))
     # Then we combine the Ethereum Signed message with our previous hash
     # Owners will have to sign the below message
-    h2: bytes32 = sha3(concat(b"\x19Ethereum Signed Message:\n32", h))
+    h2: bytes32 = keccak256(concat(b"\x19Ethereum Signed Message:\n32", h))
     # Verifies that the caller of approve has entered the correct transaction number
     assert self.seq == _seq
     # # Iterates through all the owners and verifies that there signatures,

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -108,7 +108,7 @@ def foo():
     """
 @public
 def foo():
-    a: bytes32 = sha3("ѓtest")
+    a: bytes32 = keccak256("ѓtest")
     """,
     """
 @public

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -70,7 +70,7 @@ def foo():
     """
 @public
 def foo():
-    x: bytes32 = sha3("moose", 3)
+    x: bytes32 = keccak256("moose", 3)
     """,
     """
 @public

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -36,7 +36,7 @@ def returnten() -> int128:
 
 @public
 def _hashy(x: bytes32) -> bytes32:
-    return sha3(x)
+    return keccak256(x)
 
 @public
 def return_hash_of_rzpadded_cow() -> bytes32:
@@ -54,7 +54,7 @@ def test_selfcall_code_3(get_contract_with_gas_estimation, keccak):
     selfcall_code_3 = """
 @public
 def _hashy2(x: bytes[100]) -> bytes32:
-    return sha3(x)
+    return keccak256(x)
 
 @public
 def return_hash_of_cow_x_30() -> bytes32:

--- a/tests/parser/functions/test_keccak256.py
+++ b/tests/parser/functions/test_keccak256.py
@@ -2,15 +2,15 @@ def test_hash_code(get_contract_with_gas_estimation, keccak):
     hash_code = """
 @public
 def foo(inp: bytes[100]) -> bytes32:
-    return sha3(inp)
+    return keccak256(inp)
 
 @public
 def foob() -> bytes32:
-    return sha3(b"inp")
+    return keccak256(b"inp")
 
 @public
 def bar() -> bytes32:
-    return sha3("inp")
+    return keccak256("inp")
     """
 
     c = get_contract_with_gas_estimation(hash_code)
@@ -25,7 +25,7 @@ def test_hash_code2(get_contract_with_gas_estimation):
     hash_code2 = """
 @public
 def foo(inp: bytes[100]) -> bool:
-    return sha3(inp) == sha3("badminton")
+    return keccak256(inp) == keccak256("badminton")
     """
     c = get_contract_with_gas_estimation(hash_code2)
     assert c.foo(b"badminto") is False
@@ -42,20 +42,20 @@ def set_test(inp: bytes[100]):
 
 @public
 def tryy(inp: bytes[100]) -> bool:
-    return sha3(inp) == sha3(self.test)
+    return keccak256(inp) == keccak256(self.test)
 
 @public
 def tryy_str(inp: string[100]) -> bool:
-    return sha3(inp) == sha3(self.test)
+    return keccak256(inp) == keccak256(self.test)
 
 @public
 def trymem(inp: bytes[100]) -> bool:
     x: bytes[100] = self.test
-    return sha3(inp) == sha3(x)
+    return keccak256(inp) == keccak256(x)
 
 @public
 def try32(inp: bytes32) -> bool:
-    return sha3(inp) == sha3(self.test)
+    return keccak256(inp) == keccak256(self.test)
 
     """
     c = get_contract_with_gas_estimation(hash_code3)
@@ -80,4 +80,4 @@ def try32(inp: bytes32) -> bool:
     assert c.try32(b"\x35" * 32) is False
     assert c.tryy(b"\x35" * 33) is True
 
-    print("Passed SHA3 hash test")
+    print("Passed KECCAK256 hash test")

--- a/tests/parser/integration/test_basics.py
+++ b/tests/parser/integration/test_basics.py
@@ -25,7 +25,7 @@ def test_selfcall_code_3(get_contract_with_gas_estimation, keccak):
     selfcall_code_3 = """
 @public
 def _hashy2(x: bytes[100]) -> bytes32:
-    return sha3(x)
+    return keccak256(x)
 
 @public
 def return_hash_of_cow_x_30() -> bytes32:

--- a/tests/parser/syntax/test_keccak256.py
+++ b/tests/parser/syntax/test_keccak256.py
@@ -7,8 +7,8 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    TypeMismatchException,
     StructureException,
+    TypeMismatchException,
 )
 
 type_fail_list = [

--- a/tests/parser/syntax/test_keccak256.py
+++ b/tests/parser/syntax/test_keccak256.py
@@ -40,9 +40,9 @@ def foo():
 ]
 
 
-@pytest.mark.parametrize('bad_code', type_fail_list)
+@pytest.mark.parametrize('bad_code', structure_fail_list)
 def test_block_structure_fail(bad_code):
-    with raises(TypeMismatchException):
+    with raises(StructureException):
         compiler.compile_code(bad_code)
 
 

--- a/tests/parser/syntax/test_keccak256.py
+++ b/tests/parser/syntax/test_keccak256.py
@@ -8,7 +8,7 @@ from vyper import (
 )
 from vyper.exceptions import (
     TypeMismatchException,
-    SyntaxException,
+    StructureException,
 )
 
 type_fail_list = [
@@ -19,10 +19,12 @@ def foo():
     """
 ]
 
+
 @pytest.mark.parametrize('bad_code', type_fail_list)
 def test_block_type_fail(bad_code):
     with raises(TypeMismatchException):
         compiler.compile_code(bad_code)
+
 
 structure_fail_list = [
     """
@@ -36,6 +38,7 @@ def foo():
     x: bytes32 = sha3(0x1234567890123456789012345678901234567890123456789012345678901234)
     """
 ]
+
 
 @pytest.mark.parametrize('bad_code', type_fail_list)
 def test_block_structure_fail(bad_code):
@@ -55,6 +58,7 @@ def foo():
     x: bytes32 = keccak256(0x1234567890123456789012345678901234567890123456789012345678901234)
     """
 ]
+
 
 @pytest.mark.parametrize('good_code', valid_list)
 def test_block_success(good_code):

--- a/tests/parser/syntax/test_keccak256.py
+++ b/tests/parser/syntax/test_keccak256.py
@@ -8,24 +8,23 @@ from vyper import (
 )
 from vyper.exceptions import (
     TypeMismatchException,
+    SyntaxException,
 )
 
-fail_list = [
+type_fail_list = [
     """
 @public
 def foo():
-    x: bytes32 = sha3(3)
+    x: bytes32 = keccak256(3)
     """
 ]
 
-
-@pytest.mark.parametrize('bad_code', fail_list)
-def test_block_fail(bad_code):
+@pytest.mark.parametrize('bad_code', type_fail_list)
+def test_block_type_fail(bad_code):
     with raises(TypeMismatchException):
         compiler.compile_code(bad_code)
 
-
-valid_list = [
+structure_fail_list = [
     """
 @public
 def foo():
@@ -38,6 +37,24 @@ def foo():
     """
 ]
 
+@pytest.mark.parametrize('bad_code', type_fail_list)
+def test_block_structure_fail(bad_code):
+    with raises(TypeMismatchException):
+        compiler.compile_code(bad_code)
+
+
+valid_list = [
+    """
+@public
+def foo():
+    x: bytes32 = keccak256("moose")
+    """,
+    """
+@public
+def foo():
+    x: bytes32 = keccak256(0x1234567890123456789012345678901234567890123456789012345678901234)
+    """
+]
 
 @pytest.mark.parametrize('good_code', valid_list)
 def test_block_success(good_code):

--- a/tests/parser/syntax/test_unbalanced_return.py
+++ b/tests/parser/syntax/test_unbalanced_return.py
@@ -108,10 +108,10 @@ def test() -> int128:
         if False:
             return 0
         else:
-            x = sha3(x)
+            x = keccak256(x)
             return 1
     else:
-        x = sha3(x)
+        x = keccak256(x)
         return 1
     return 1
     """

--- a/tests/parser/types/test_variable_naming.py
+++ b/tests/parser/types/test_variable_naming.py
@@ -20,6 +20,11 @@ def foo(max: int128) -> int128:
 @public
 def foo(len: int128, sha3: int128) -> int128:
     return len+sha3
+    """,
+    """
+@public
+def foo(len: int128, keccak256: int128) -> int128:
+    return len+keccak256
     """
 ]
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -305,6 +305,7 @@ def concat(expr, context):
         annotation='concat',
     )
 
+
 @signature(('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))
 def _sha3(expr, args, kwargs, context):
     raise StructureException("sha3 function has been deprecated in favor of keccak256")

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -46,7 +46,7 @@ from vyper.utils import (
     SizeLimits,
     bytes_to_int,
     fourbytes_to_int,
-    sha3,
+    keccak256,
 )
 
 from .signatures import (
@@ -305,14 +305,18 @@ def concat(expr, context):
         annotation='concat',
     )
 
-
 @signature(('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))
 def _sha3(expr, args, kwargs, context):
+    raise StructureException("sha3 function has been deprecated in favor of keccak256")
+
+
+@signature(('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))
+def _keccak256(expr, args, kwargs, context):
     sub = args[0]
     # Can hash literals
     if isinstance(sub, bytes):
         return LLLnode.from_list(
-            bytes_to_int(sha3(sub)),
+            bytes_to_int(keccak256(sub)),
             typ=BaseType('bytes32'),
             pos=getpos(expr)
         )
@@ -456,7 +460,7 @@ def sha256(expr, args, kwargs, context):
 def method_id(expr, args, kwargs, context):
     if b' ' in args[0]:
         raise TypeMismatchException('Invalid function signature no spaces allowed.')
-    method_id = fourbytes_to_int(sha3(args[0])[:4])
+    method_id = fourbytes_to_int(keccak256(args[0])[:4])
     if args[1] == 'bytes32':
         return LLLnode(method_id, typ=BaseType('bytes32'), pos=getpos(expr))
     elif args[1] == 'bytes[4]':
@@ -1305,7 +1309,7 @@ dispatch_table = {
     'sha3': _sha3,
     'sha256': sha256,
     'method_id': method_id,
-    'keccak256': _sha3,
+    'keccak256': _keccak256,
     'ecrecover': ecrecover,
     'ecadd': ecadd,
     'ecmul': ecmul,

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -55,7 +55,7 @@ from vyper.utils import (
     SizeLimits,
     bytes_to_int,
     fourbytes_to_int,
-    sha3,
+    keccak256,
 )
 
 
@@ -466,7 +466,7 @@ class Stmt(object):
         arg_placeholder = self.context.new_placeholder(BaseType(32))
         reason_str_type = ByteArrayType(len(reason_str))
         placeholder_bytes = Expr(msg, self.context).lll_node
-        method_id = fourbytes_to_int(sha3(b"Error(string)")[:4])
+        method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
         assert_reason = [
                 'seq',
                 ['mstore', sig_placeholder, method_id],

--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -19,7 +19,7 @@ from vyper.utils import (
     ceil32,
     check_valid_varname,
     iterable_cast,
-    sha3,
+    keccak256,
 )
 
 
@@ -105,7 +105,7 @@ class EventSignature:
                 else:
                     pos += get_size_of_type(parsed_type) * 32
         sig = name + '(' + ','.join([canonicalize_type(arg.typ, indexed_list[pos]) for pos, arg in enumerate(args)]) + ')'  # noqa F812
-        event_id = bytes_to_int(sha3(bytes(sig, 'utf-8')))
+        event_id = bytes_to_int(keccak256(bytes(sig, 'utf-8')))
         return cls(name, args, indexed_list, event_id, sig)
 
     @iterable_cast(dict)

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -35,7 +35,7 @@ from vyper.utils import (
     function_whitelist,
     is_varname_valid,
     iterable_cast,
-    sha3,
+    keccak256,
 )
 
 
@@ -289,7 +289,7 @@ class FunctionSignature:
         sig = cls.get_full_sig(name, code.args.args, sigs, custom_units, custom_structs, constants)
 
         # Take the first 4 bytes of the hash of the sig to get the method ID
-        method_id = fourbytes_to_int(sha3(bytes(sig, 'utf-8'))[:4])
+        method_id = fourbytes_to_int(keccak256(bytes(sig, 'utf-8'))[:4])
         return cls(
             name,
             args,

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -15,10 +15,10 @@ from vyper.opcodes import (
 
 try:
     from Crypto.Hash import keccak
-    sha3 = lambda x: keccak.new(digest_bits=256, data=x).digest()  # noqa: E731
+    keccak256 = lambda x: keccak.new(digest_bits=256, data=x).digest()  # noqa: E731
 except ImportError:
     import sha3 as _sha3
-    sha3 = lambda x: _sha3.sha3_256(x).digest()  # noqa: E731
+    keccak256 = lambda x: _sha3.sha3_256(x).digest()  # noqa: E731
 
 
 # Converts four bytes to an integer
@@ -56,7 +56,7 @@ def bytes_to_int(bytez):
 def checksum_encode(addr):  # Expects an input of the form 0x<40 hex chars>
     assert addr[:2] == '0x' and len(addr) == 42
     o = ''
-    v = bytes_to_int(sha3(addr[2:].lower().encode('utf-8')))
+    v = bytes_to_int(keccak256(addr[2:].lower().encode('utf-8')))
     for i, c in enumerate(addr[2:]):
         if c in '0123456789':
             o += c


### PR DESCRIPTION
### What I did

Implemented #1328 

### How I did it

Replaced instances of `sha3` in docs, tests, examples, and language implementation with `keccak256`. 

Added thrown exception when `sha3` is used instead of `keccak256` + added tests for this.

Did _not_ make any changes to the LLL/opcodes. 

### How to verify it

Run the tests:

`make test`

### Description for the changelog

Remove sha3 alias

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/60232556-2e227700-985a-11e9-810c-2f06cb0c3dae.png)
