### PR TITLE
Type annotations for early stage compiler functions

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -22,6 +22,9 @@ from vyper.parser import (
 from vyper.signatures.interface import (
     extract_file_interface_imports,
 )
+from vyper.typing import (
+    ContractName,
+)
 
 warnings.simplefilter('always')
 
@@ -100,7 +103,7 @@ def uniq(seq: Iterable[T]) -> List[T]:
     return result
 
 
-def exc_handler(contract_name, exception):
+def exc_handler(contract_name: ContractName, exception: Exception) -> None:
     print('Error compiling: ', contract_name)
     raise exception
 

--- a/bin/vyper
+++ b/bin/vyper
@@ -8,6 +8,10 @@ import os
 import sys
 from typing import (
     Dict,
+    Iterable,
+    List,
+    Set,
+    TypeVar,
 )
 import warnings
 
@@ -76,9 +80,24 @@ elif not args.debug:
     sys.tracebacklimit = 0
 
 
-def uniq(seq):
-    exists = set()
-    return [x for x in seq if not (x in exists or exists.add(x))]
+T = TypeVar('T')
+
+
+def uniq(seq: Iterable[T]) -> List[T]:
+    """
+    Returns unique items in ``seq`` in order.
+    """
+    seen: Set[T] = set()
+    result = []
+
+    for x in seq:
+        if x in seen:
+            continue
+
+        seen.add(x)
+        result.append(x)
+
+    return result
 
 
 def exc_handler(contract_name, exception):

--- a/bin/vyper
+++ b/bin/vyper
@@ -158,7 +158,6 @@ if __name__ == '__main__':
         out = vyper.compile_codes(
             codes,
             ['bytecode', 'bytecode_runtime', 'abi', 'source_map', 'method_identifiers'],
-            output_type='dict',
             exc_handler=exc_handler,
             interface_codes=get_interface_codes(codes)
         )
@@ -177,13 +176,12 @@ if __name__ == '__main__':
         for f in orig_args:
             formats.append(translate_map.get(f, f))
 
-        out_list = vyper.compile_codes(
+        out_list = list(vyper.compile_codes(
             codes,
             formats,
-            output_type='list',
             exc_handler=exc_handler,
             interface_codes=get_interface_codes(codes)
-        )
+        ).values())
 
         for out in out_list:
             for f in orig_args:

--- a/bin/vyper
+++ b/bin/vyper
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 from typing import (
-    Dict,
+    Any,
     Iterable,
     List,
     Set,
@@ -23,6 +23,7 @@ from vyper.signatures.interface import (
     extract_file_interface_imports,
 )
 from vyper.typing import (
+    ContractCodes,
     ContractName,
 )
 
@@ -108,7 +109,7 @@ def exc_handler(contract_name: ContractName, exception: Exception) -> None:
     raise exception
 
 
-def get_interface_codes(codes):
+def get_interface_codes(codes: ContractCodes) -> Any:
     interface_codes = {}
 
     for code in codes.values():
@@ -147,7 +148,7 @@ if __name__ == '__main__':
     if args.show_gas_estimates:
         parser_utils.LLLnode.repr_show_gas = True
 
-    codes: Dict[str, str] = OrderedDict()
+    codes: ContractCodes = OrderedDict()
     for file_name in args.input_files:
         with open(file_name) as fh:
             codes[file_name] = fh.read()

--- a/bin/vyper
+++ b/bin/vyper
@@ -111,6 +111,7 @@ def exc_handler(contract_name: ContractName, exception: Exception) -> None:
 
 def get_interface_codes(codes: ContractCodes) -> Any:
     interface_codes = {}
+    interfaces = {}
 
     for code in codes.values():
         interface_codes.update(extract_file_interface_imports(code))
@@ -132,16 +133,17 @@ def get_interface_codes(codes: ContractCodes) -> Any:
             with open(valid_path) as fh:
                 code = fh.read()
                 if valid_path.endswith('.json'):
-                    interface_codes[interface_name] = {
+                    interfaces[interface_name] = {
                         'type': 'json',
                         'code': json.loads(code.encode())
                     }
                 else:
-                    interface_codes[interface_name] = {
+                    interfaces[interface_name] = {
                         'type': 'vyper',
                         'code': code
                     }
-    return interface_codes
+
+    return interfaces
 
 
 if __name__ == '__main__':

--- a/bin/vyper
+++ b/bin/vyper
@@ -9,7 +9,7 @@ import sys
 from typing import (
     Any,
     Iterable,
-    List,
+    Iterator,
     Set,
     TypeVar,
 )
@@ -87,21 +87,18 @@ elif not args.debug:
 T = TypeVar('T')
 
 
-def uniq(seq: Iterable[T]) -> List[T]:
+def uniq(seq: Iterable[T]) -> Iterator[T]:
     """
-    Returns unique items in ``seq`` in order.
+    Yield unique items in ``seq`` in order.
     """
     seen: Set[T] = set()
-    result = []
 
     for x in seq:
         if x in seen:
             continue
 
         seen.add(x)
-        result.append(x)
-
-    return result
+        yield x
 
 
 def exc_handler(contract_name: ContractName, exception: Exception) -> None:
@@ -173,7 +170,7 @@ if __name__ == '__main__':
             'ast': 'ast_dict'
         }
         formats = []
-        orig_args = uniq(args.format.split(','))
+        orig_args = tuple(uniq(args.format.split(',')))
 
         for f in orig_args:
             formats.append(translate_map.get(f, f))

--- a/bin/vyper-serve
+++ b/bin/vyper-serve
@@ -92,7 +92,6 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             out_dict = vyper.compile_codes(
                 {'': code},
                 vyper.compiler.output_formats_map.keys(),
-                output_type='dict',
             )['']
             out_dict['ir'] = str(out_dict['ir'])
         except ParserException as e:

--- a/tests/compiler/test_bytecode_runtime.py
+++ b/tests/compiler/test_bytecode_runtime.py
@@ -8,7 +8,7 @@ def a() -> bool:
     return True
     """
 
-    out = vyper.compile_codes({'': code}, ['bytecode_runtime', 'bytecode'])[0]
+    out = vyper.compile_code(code, ['bytecode_runtime', 'bytecode'])
 
     assert len(out['bytecode']) > len(out['bytecode_runtime'])
     assert out['bytecode_runtime'][2:] in out['bytecode'][2:]

--- a/tests/compiler/test_opcodes.py
+++ b/tests/compiler/test_opcodes.py
@@ -8,7 +8,7 @@ def a() -> bool:
     return True
     """
 
-    out = vyper.compile_codes({'': code}, ['opcodes_runtime', 'opcodes'])[0]
+    out = vyper.compile_code(code, ['opcodes_runtime', 'opcodes'])
 
     assert len(out['opcodes']) > len(out['opcodes_runtime'])
     assert out['opcodes_runtime'] in out['opcodes']

--- a/tests/parser/functions/test_abi.py
+++ b/tests/parser/functions/test_abi.py
@@ -1,5 +1,5 @@
 from vyper.compiler import (
-    compile_codes,
+    compile_code,
     mk_full_signature,
 )
 
@@ -56,11 +56,10 @@ def foo(x: uint256) -> bytes[100]:
     return b"hello"
     """
 
-    out = compile_codes(
-        codes={'t.vy': code},
+    out = compile_code(
+        code,
         output_formats=['method_identifiers'],
-        output_type='list'
-    )[0]
+    )
 
     assert out['method_identifiers'] == {
         'foo(uint256)': '0x2fbebd38',

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -60,7 +60,7 @@ contract One:
     def test(_owner: address): modifying
     """
 
-    out = compile_codes({'one.vy': code}, ['external_interface'])[0]
+    out = compile_codes({'one.vy': code}, ['external_interface'])['one.vy']
     out = out['external_interface']
 
     assert interface.strip() == out.strip()
@@ -79,7 +79,7 @@ def test() -> bool:
     """
 
     assert_compile_failed(
-        lambda: compile_codes({'one.vy': code}),
+        lambda: compile_code(code),
         StructureException
     )
 
@@ -121,7 +121,7 @@ def bar() -> uint256:
     return 2
     """
 
-    assert compile_codes({'one.vy': code}, interface_codes=interface_codes)[0]
+    assert compile_code(code, interface_codes=interface_codes)
 
     not_implemented_code = """
 import a as FooBarInterface
@@ -135,7 +135,7 @@ def foo() -> uint256:
     """
 
     assert_compile_failed(
-        lambda: compile_codes({'one.vy': not_implemented_code}, interface_codes=interface_codes)[0],
+        lambda: compile_code(not_implemented_code, interface_codes=interface_codes),
         StructureException
     )
 

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -225,7 +225,7 @@ def compile_codes(codes,
     for contract_name, code in codes.items():
         for output_format in output_formats:
             if output_format not in output_formats_map:
-                raise Exception('Unsupported format type %s.' % output_format)
+                raise ValueError(f'Unsupported format type {repr(output_format)}')
 
             try:
                 out.setdefault(contract_name, {})
@@ -245,7 +245,7 @@ def compile_codes(codes,
     elif output_type == 'dict':
         return out
     else:
-        raise Exception('Unknown output_type')
+        raise ValueError(f'Unsupported output type {repr(output_type)}')
 
 
 def compile_code(code, output_formats=None, interface_codes=None):

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -215,7 +215,6 @@ output_formats_map = {
 
 def compile_codes(codes,
                   output_formats=None,
-                  output_type='list',
                   exc_handler=None,
                   interface_codes=None):
     if output_formats is None:
@@ -240,14 +239,17 @@ def compile_codes(codes,
                 else:
                     raise exc
 
-    if output_type == 'list':
-        return [v for v in out.values()]
-    elif output_type == 'dict':
-        return out
-    else:
-        raise ValueError(f'Unsupported output type {repr(output_type)}')
+    return out
+
+
+UNKNOWN_CONTRACT_NAME = '<unknown>'
 
 
 def compile_code(code, output_formats=None, interface_codes=None):
-    codes = {'': code}
-    return compile_codes(codes, output_formats, 'list', interface_codes=interface_codes)[0]
+    codes = {UNKNOWN_CONTRACT_NAME: code}
+
+    return compile_codes(
+        codes,
+        output_formats,
+        interface_codes=interface_codes,
+    )[UNKNOWN_CONTRACT_NAME]

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -212,7 +212,7 @@ def extract_file_interface_imports(code: SourceCode) -> InterfaceImports:
                     )
                 if a_name.asname in imports_dict:
                     raise StructureException(
-                        'Interface with Alias {} already exists'.format(a_name.asname),
+                        'Interface with alias {} already exists'.format(a_name.asname),
                         item,
                     )
                 imports_dict[a_name.asname] = a_name.name

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -24,6 +24,10 @@ from vyper.signatures.event_signature import (
 from vyper.signatures.function_signature import (
     FunctionSignature,
 )
+from vyper.typing import (
+    SourceCode,
+    InterfaceImports,
+)
 
 
 # Populate built-in interfaces.
@@ -194,12 +198,13 @@ def extract_external_interface(code, contract_name, interface_codes=None):
     return out
 
 
-def extract_file_interface_imports(code):
+def extract_file_interface_imports(code: SourceCode) -> InterfaceImports:
     ast_tree = parser.parse_to_ast(code)
-    imports_dict = {}
+
+    imports_dict: InterfaceImports = {}
     for item in ast_tree:
         if isinstance(item, ast.Import):
-            for a_name in item.names:
+            for a_name in item.names:  # type: ignore
                 if not a_name.asname:
                     raise StructureException(
                         'Interface statement requires an accompanying `as` statement.',
@@ -211,8 +216,8 @@ def extract_file_interface_imports(code):
                         item,
                     )
                 imports_dict[a_name.asname] = a_name.name
-    return imports_dict
 
+    return imports_dict
 
 def check_valid_contract_interface(global_ctx, contract_sigs):
 

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -25,8 +25,8 @@ from vyper.signatures.function_signature import (
     FunctionSignature,
 )
 from vyper.typing import (
-    SourceCode,
     InterfaceImports,
+    SourceCode,
 )
 
 
@@ -219,8 +219,8 @@ def extract_file_interface_imports(code: SourceCode) -> InterfaceImports:
 
     return imports_dict
 
-def check_valid_contract_interface(global_ctx, contract_sigs):
 
+def check_valid_contract_interface(global_ctx, contract_sigs):
     if global_ctx._interface:
         funcs_left = global_ctx._interface.copy()
 

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -6,3 +6,11 @@ from typing import (
 # Parser types
 ClassTypes = Dict[str, str]
 ParserPosition = Tuple[int, int]
+
+# Compiler
+SourceCode = str
+
+# Interfaces
+InterfaceAsName = str
+InterfaceImportPath = str
+InterfaceImports = Dict[InterfaceAsName, InterfaceImportPath]

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -3,7 +3,7 @@ from typing import (
     Tuple,
 )
 
-# Parser types
+# Parser
 ClassTypes = Dict[str, str]
 ParserPosition = Tuple[int, int]
 

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -10,6 +10,7 @@ ParserPosition = Tuple[int, int]
 # Compiler
 ContractName = str
 SourceCode = str
+ContractCodes = Dict[ContractName, SourceCode]
 
 # Interfaces
 InterfaceAsName = str

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -8,6 +8,7 @@ ClassTypes = Dict[str, str]
 ParserPosition = Tuple[int, int]
 
 # Compiler
+ContractName = str
 SourceCode = str
 
 # Interfaces


### PR DESCRIPTION
### What I did

Added type annotations for a number of functions encountered during the first stages of invoking the `vyper` binary.  Also did some refactors to facilitate type checking and annotation.

### How to verify it

Run the tests.  Reviewers might also find it helpful to look at each commit individually instead of the entire branch diff.

### Description for the changelog

- The API of `vyper.compile_codes` has been simplified to always return an `OrderedDict` mapping vyper code file names to their respective compilation results.  This means that this function no longer accepts an `output_type` keyword argument.  Users wishing to duplicate the functionality of passing `output_type='list'` should convert the results of this function to a list like so: `list(compile_codes(...).values())`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://assets.worldwildlife.org/photos/3124/images/carousel_small/SCR_202639.jpg)
