### PR TITLE
Added new commands to make.cmd: dev-deps, lint, docs, clean

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -1,12 +1,19 @@
 @echo off
 if "%1"=="init" goto :init
 if "%1"=="test" goto :test
+if "%1"=="dev-deps" goto :dev-deps
+if "%1"=="lint" goto :lint
+if "%1"=="docs" goto :docs
+if "%1"=="clean" goto :clean
+if "%1"=="clean-build" goto :clean-build
+if "%1"=="clean-pyc" goto :clean-pyc
+if "%1"=="clean-test" goto :clean-test
 rem Default
 if "%1"=="" goto :init
 
 :error
 echo Unknown parameters: %*
-echo Expected: init test 
+echo Expected: init test lint clean clean-pyc clean-build clean-test docs
 rem echo Expect: test lint clean clean-pyc clean-build clean-test docs docker-build
 goto :end
 
@@ -18,6 +25,43 @@ goto :end
 python setup.py test
 goto :end
 
-rem TODO: clean, etc (for recursive delete, use robocopy to move to temp dir, then delete temp dir)
+:dev-deps
+python -m pip install .[test,lint]
+goto :end
+
+:lint
+tox -e lint
+goto :end
+
+:docs
+CALL docs\make clean
+CALL docs\make html
+START docs\_build\html\index.html
+goto :end
+
+:clean
+CALL :clean-build
+CALL :clean-pyc
+CALL :clean-test
+goto :end
+
+:clean-build
+if exist build RMDIR /Q /S build
+if exist dist RMDIR /Q /S dist
+for /d %%x in (*.egg-info) do if exist "%%x" RMDIR /Q /S "%%x"
+goto :end
+
+
+:clean-pyc
+for /r %%x in (*.pyc) do del %%x
+for /r %%x in (*.pyo) do del %%x
+for /r %%x in (*~) do del %%x
+for /r /d %%x in (__pycache__) do if exist "%%x" RMDIR "%%x"
+goto :end
+
+
+:clean-test
+for /r /d %%x in (htmlcov) do if exist "%%x" RMDIR /Q /S "%%x"
+goto :end
 
 :end


### PR DESCRIPTION
### What I did
Updated the make.cmd file for windows dev environments (There was also a TODO). It is modeled exactly like the MAKEFILE with one exception:
MAKEFILE runs `sphinx-apidoc -o docs/ -d 2 vyper/`, which I could not figure out why it is needed. Please let me know if this needs to be added to make.cmd as well or if it can even be removed from the MAKEFILE. It seems to produce unnecessary .rst files which are included nowhere.

Added the following commands: make 
- dev-deps: install test and lint dependencies
- lint: run lint
- docs: clean compile and open docs
- clean: Run all three clean commands
- clean-build / clean-pyc / clean-test: delete unnecessary files and folders

### How I did it
Modify the make.cmd file 

### How to verify it
make [lint clean clean-pyc clean-build clean-test docs] on a windows machine

### Description for the changelog
Extended make.cmd functionality

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i2-prod.mirror.co.uk/incoming/article5259970.ece/ALTERNATES/s1200/TEASER-Red-panda-playing-in-snow.jpg)
