### PR TITLE
Allow equality checks between string types

### DIFF
--- a/tests/parser/syntax/test_string.py
+++ b/tests/parser/syntax/test_string.py
@@ -3,9 +3,6 @@ import pytest
 from vyper import (
     compiler,
 )
-from vyper.exceptions import (
-    TypeMismatchException,
-)
 
 valid_list = [
     """
@@ -24,16 +21,7 @@ def foo() -> bool:
     x: string[15] = "¡très bien!"
     y: string[15] = "test"
     return x != y
-    """
-]
-
-
-@pytest.mark.parametrize('good_code', valid_list)
-def test_string_success(good_code):
-    assert compiler.compile_code(good_code) is not None
-
-
-fail_list = [
+    """,
     """
 @public
 def foo() -> bool:
@@ -44,8 +32,6 @@ def foo() -> bool:
 ]
 
 
-@pytest.mark.parametrize('bad_code', fail_list)
-def test_string_fail(bad_code):
-
-    with pytest.raises(TypeMismatchException):
-        compiler.compile_code(bad_code)
+@pytest.mark.parametrize('good_code', valid_list)
+def test_string_success(good_code):
+    assert compiler.compile_code(good_code) is not None

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,8 +1,3 @@
-from vyper.exceptions import (
-    ParserException,
-    TypeMismatchException,
-)
-
 
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
     test_bytes = """
@@ -205,31 +200,23 @@ def testsome_storage(y: bytes[1]) -> bool:
     assert not c.testsome_storage(b'x')
 
 
-def test_bytes_comparison_fail_size_mismatch(assert_compile_failed,
-                                             get_contract_with_gas_estimation):
+def test_bytes_comparison(get_contract_with_gas_estimation):
     code = """
 @public
-def get(a: bytes[1]) -> bool:
+def get_mismatch(a: bytes[1]) -> bool:
     b: bytes[2] = 'ab'
     return a == b
-    """
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(code),
-        TypeMismatchException
-    )
 
-
-def test_bytes_comparison_fail_too_large(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
 @public
-def get(a: bytes[100]) -> bool:
+def get_large(a: bytes[100]) -> bool:
     b: bytes[100] = 'ab'
     return a == b
     """
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(code),
-        ParserException
-    )
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.get_mismatch(b'\x00') is False
+    assert c.get_large(b'\x00') is False
+    assert c.get_large(b'ab') is True
 
 
 def test_bytes32_literals(get_contract):

--- a/tests/parser/types/test_string.py
+++ b/tests/parser/types/test_string.py
@@ -159,3 +159,61 @@ def test(a: uint256, b: string[50] = "foo") -> bytes[100]:
 
     assert c.test(12345)[-3:] == b"foo"
     assert c.test(12345, "bar")[-3:] == b"bar"
+
+
+def test_string_equality(get_contract_with_gas_estimation):
+    code = """
+@public
+def equal_true() -> bool:
+    foo: string[100] = "foobar"
+    bar: string[100] = "foobar"
+    return foo == bar
+
+@public
+def equal_false() -> bool:
+    foo: string[100] = "foobar"
+    bar: string[100] = "barfoo"
+    return foo == bar
+
+@public
+def not_equal_true() -> bool:
+    foo: string[100] = "foobar"
+    bar: string[100] = "barfoo"
+    return foo != bar
+
+@public
+def not_equal_false() -> bool:
+    foo: string[100] = "foobar"
+    bar: string[100] = "foobar"
+    return foo != bar
+
+@public
+def literal_equal_true() -> bool:
+    return "The quick brown fox jumps over the lazy dog" == \
+    "The quick brown fox jumps over the lazy dog"
+
+@public
+def literal_equal_false() -> bool:
+    return "The quick brown dog jumps over the lazy fox" == \
+    "The quick brown fox jumps over the lazy dog"
+
+@public
+def literal_not_equal_true() -> bool:
+    return "The quick fox jumps over the dog" != \
+    "The quick brown fox jumps over the lazy dog"
+
+@public
+def literal_not_equal_false() -> bool:
+    return "The quick brown fox jumps over the lazy dog" != \
+    "The quick brown fox jumps over the lazy dog"
+    """
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.equal_true() is True
+    assert c.equal_false() is False
+    assert c.not_equal_true() is True
+    assert c.not_equal_false() is False
+    assert c.literal_equal_true() is True
+    assert c.literal_equal_false() is False
+    assert c.literal_not_equal_true() is True
+    assert c.literal_not_equal_false() is False

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -11,6 +11,9 @@ from vyper.exceptions import (
 from vyper.parser.expr import (
     Expr,
 )
+from vyper.parser.keccak256_helper import (
+    keccak256_helper,
+)
 from vyper.parser.parser_utils import (
     LLLnode,
     add_variable_offset,
@@ -313,55 +316,7 @@ def _sha3(expr, args, kwargs, context):
 
 @signature(('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))
 def _keccak256(expr, args, kwargs, context):
-    sub = args[0]
-    # Can hash literals
-    if isinstance(sub, bytes):
-        return LLLnode.from_list(
-            bytes_to_int(keccak256(sub)),
-            typ=BaseType('bytes32'),
-            pos=getpos(expr)
-        )
-    # Can hash bytes32 objects
-    if is_base_type(sub.typ, 'bytes32'):
-        return LLLnode.from_list(
-            [
-                'seq',
-                ['mstore', MemoryPositions.FREE_VAR_SPACE, sub],
-                ['sha3', MemoryPositions.FREE_VAR_SPACE, 32]
-            ],
-            typ=BaseType('bytes32'),
-            pos=getpos(expr),
-        )
-    # Copy the data to an in-memory array
-    if sub.location == "memory":
-        # If we are hashing a value in memory, no need to copy it, just hash in-place
-        return LLLnode.from_list(
-            ['with', '_sub', sub, ['sha3', ['add', '_sub', 32], ['mload', '_sub']]],
-            typ=BaseType('bytes32'),
-            pos=getpos(expr),
-        )
-    elif sub.location == "storage":
-        lengetter = LLLnode.from_list(['sload', ['sha3_32', '_sub']], typ=BaseType('int128'))
-    else:
-        # This should never happen, but just left here for future compiler-writers.
-        raise Exception("Unsupported location: %s" % sub.location)  # pragma: no test
-    placeholder = context.new_placeholder(sub.typ)
-    placeholder_node = LLLnode.from_list(placeholder, typ=sub.typ, location='memory')
-    copier = make_byte_array_copier(
-        placeholder_node,
-        LLLnode.from_list('_sub', typ=sub.typ, location=sub.location),
-    )
-    return LLLnode.from_list(
-        [
-            'with', '_sub', sub, [
-                'seq',
-                copier,
-                ['sha3', ['add', placeholder, 32], lengetter]
-            ],
-        ],
-        typ=BaseType('bytes32'),
-        pos=getpos(expr)
-    )
+    return keccak256_helper(expr, args, kwargs, context)
 
 
 def _make_sha256_call(inp_start, inp_len, out_start, out_len):

--- a/vyper/parser/keccak256_helper.py
+++ b/vyper/parser/keccak256_helper.py
@@ -1,0 +1,69 @@
+
+from vyper.parser.lll_node import (
+    LLLnode,
+)
+from vyper.parser.parser_utils import (
+    getpos,
+    make_byte_array_copier,
+)
+from vyper.types import (
+    BaseType,
+    is_base_type,
+)
+from vyper.utils import (
+    MemoryPositions,
+    bytes_to_int,
+    keccak256,
+)
+
+
+def keccak256_helper(expr, args, kwargs, context):
+    sub = args[0]
+    # Can hash literals
+    if isinstance(sub, bytes):
+        return LLLnode.from_list(
+            bytes_to_int(keccak256(sub)),
+            typ=BaseType('bytes32'),
+            pos=getpos(expr)
+        )
+    # Can hash bytes32 objects
+    if is_base_type(sub.typ, 'bytes32'):
+        return LLLnode.from_list(
+            [
+                'seq',
+                ['mstore', MemoryPositions.FREE_VAR_SPACE, sub],
+                ['sha3', MemoryPositions.FREE_VAR_SPACE, 32]
+            ],
+            typ=BaseType('bytes32'),
+            pos=getpos(expr),
+        )
+    # Copy the data to an in-memory array
+    if sub.location == "memory":
+        # If we are hashing a value in memory, no need to copy it, just hash in-place
+        return LLLnode.from_list(
+            ['with', '_sub', sub, ['sha3', ['add', '_sub', 32], ['mload', '_sub']]],
+            typ=BaseType('bytes32'),
+            pos=getpos(expr),
+        )
+    elif sub.location == "storage":
+        lengetter = LLLnode.from_list(['sload', ['sha3_32', '_sub']], typ=BaseType('int128'))
+    else:
+        # This should never happen, but just left here for future compiler-writers.
+        raise Exception("Unsupported location: %s" % sub.location)  # pragma: no test
+    placeholder = context.new_placeholder(sub.typ)
+    placeholder_node = LLLnode.from_list(placeholder, typ=sub.typ, location='memory')
+    copier = make_byte_array_copier(
+        placeholder_node,
+        LLLnode.from_list('_sub', typ=sub.typ, location=sub.location),
+    )
+    return LLLnode.from_list(
+        [
+            'with', '_sub', sub, [
+                'seq',
+                copier,
+                ['sha3', ['add', placeholder, 32], lengetter]
+            ],
+        ],
+        typ=BaseType('bytes32'),
+        pos=getpos(expr)
+    )


### PR DESCRIPTION
### What I did

Implemented VIP #1355, allowing equality checks between string types.

### How I did it

Check strings with length > 32 or unequal lengths by comparing `keccak256` hash of each.

### How to verify it

Run the tests: `make test`. More specifically: `pytest -k test_string` and `pytest -k test_bytes`

### Description for the changelog

Allow equality checks between string types

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8602661/60323057-3c49c380-993e-11e9-9283-36979bb1a634.png)
