### PR TITLE
Add support for ListType in external contract call

### DIFF
--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -16,8 +16,8 @@ from vyper.parser.parser_utils import (
 from vyper.types import (
     BaseType,
     ByteArrayLike,
-    TupleLike,
     ListType,
+    TupleLike,
     get_size_of_type,
 )
 

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -17,6 +17,7 @@ from vyper.types import (
     BaseType,
     ByteArrayLike,
     TupleLike,
+    ListType,
     get_size_of_type,
 )
 
@@ -99,6 +100,8 @@ def get_external_contract_call_output(sig, context):
     elif isinstance(sig.output_type, ByteArrayLike):
         returner = [0, output_placeholder + 32]
     elif isinstance(sig.output_type, TupleLike):
+        returner = [0, output_placeholder]
+    elif isinstance(sig.output_type, ListType):
         returner = [0, output_placeholder]
     else:
         raise TypeMismatchException("Invalid output type: %s" % sig.output_type)


### PR DESCRIPTION



### What I did
Imported ListType from types and added case for get_external_contract_call_output

### How I did it

### How to verify it
I don't know the codebase well enough to make sure this makes sense. Just submitting this PR in case it really is this simple. Someone more knowledgeable should make any necessary security checks.

### Description for the changelog
Added support for fixed-length arrays as output from external contract call

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://m.media-amazon.com/images/I/81IK1cktrkL._SR500,500_.jpg)
