### PR TITLE
Disallow conflicting method IDs

### DIFF
--- a/tests/signatures/test_method_id_conflicts.py
+++ b/tests/signatures/test_method_id_conflicts.py
@@ -1,0 +1,60 @@
+import pytest
+
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
+
+FAILING_CONTRACTS = [
+    """
+@public
+@constant
+def gsf():
+    pass
+
+@public
+@constant
+def tgeo():
+    pass
+    """,
+    """
+@public
+@constant
+def withdraw(a: uint256):
+    pass
+
+@public
+@constant
+def OwnerTransferV7b711143(a: uint256):
+    pass
+    """,
+    """
+@public
+@constant
+def withdraw(a: uint256):
+    pass
+
+@public
+@constant
+def gsf():
+    pass
+
+@public
+@constant
+def tgeo():
+    pass
+
+@public
+@constant
+def OwnerTransferV7b711143(a: uint256):
+    pass
+    """,
+]
+
+
+@pytest.mark.parametrize('failing_contract_code', FAILING_CONTRACTS)
+def test_method_id_conflicts(failing_contract_code):
+    with pytest.raises(StructureException):
+        compiler.compile_code(failing_contract_code)


### PR DESCRIPTION
### What was wrong?

It's possible to compile a vyper contract that contains conflicting methods.  That is, if a contract has two or more methods that produce the same internal routing ID (used for method selection during contract execution), it will still compile and create a contract with a security vulnerability.

### How did I fix it?

Added a check for duplicate method IDs in the contract interface.

### How to verify it?

Run the tests.

### Description for the changelog

* Fixed a bug that allowed contracts with conflicting methods (methods that produce the same internal routing ID) to compile without error.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pwpark.com/wp-content/uploads/2018/07/red-panda-1024x826.jpg)
