### PR TITLE
Add instructions for Windows users.

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -97,6 +97,16 @@ Also, ensure the following libraries are installed using `brew`:
 ::
 
     brew install gmp leveldb
+	
+Windows
+--------
+
+Windows users can first `install Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and then follow the instructions for Ubuntu, or `install Docker for Windows <https://docs.docker.com/docker-for-windows/install/>`_ and then follow the instructions for Docker.
+
+.. note::
+    - Windows Subsystem for Linux is only available for Windows 10.
+    - Windows versions that are < 10 and Windows 10 Home should install the slightly outdated `Docker Toolbox <https://docs.docker.com/toolbox/toolbox_install_windows/>`_, as explained in the link.
+   
 
 Creating a virtual environment
 ==============================


### PR DESCRIPTION
The 'installing vyper' page included instructions for Ubuntu and MacOS only.
Since Windows is a very popular OS, explaining what are the possibilities for Windows users is important.
This PR fixes https://github.com/ethereum/vyper/issues/1531

### What I did
Added the 2 options for windows: docker and linux subsytem for windows.

### How I did it
Simply edited docs/installing-vyper.rst

### How to verify it
Observe docs/installing-vyper.rst

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://picpulp.com/wp-content/uploads/2013/03/Cute_Animals_HD_Wallpaper_56__1920x1200_7927.jpg?x11708)
