### PR TITLE
Inject git version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ docs/modules.rst
 .mypy_cache
 .hypothesis
 
+# vyper version
+

--- a/bin/vyper
+++ b/bin/vyper
@@ -56,7 +56,7 @@ parser.add_argument(
 parser.add_argument(
     '--version',
     action='version',
-    version='{0}\nGIT:{1}'.format(vyper.__version__, vyper.__commit__),
+    version='{0}+commit.{1}'.format(vyper.__version__, vyper.__commit__),
 )
 parser.add_argument(
     '--show-gas-estimates',

--- a/bin/vyper
+++ b/bin/vyper
@@ -56,7 +56,7 @@ parser.add_argument(
 parser.add_argument(
     '--version',
     action='version',
-    version='{0}'.format(vyper.__version__),
+    version='{0}\nGIT:{1}'.format(vyper.__version__, vyper.__commit__),
 )
 parser.add_argument(
     '--show-gas-estimates',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
-
+import subprocess, os, tempfile
 
 test_deps = [
     'pytest>=3.6',
@@ -27,6 +27,14 @@ extras = {
     'test': test_deps,
     'lint': lint_deps,
 }
+
+commithash = subprocess.check_output("git rev-parse HEAD".split())
+commithash = commithash.decode('utf-8').strip()
+
+
+hashfile = os.path.relpath('./vyper/git_version.txt')
+with open(hashfile, 'w') as f :
+    f.write(commithash)
 
 
 setup(
@@ -62,5 +70,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
-    ]
+    ],
+    package_data={
+        '': ['vyper/git_version.txt']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ extras = {
 commithash = subprocess.check_output("git rev-parse HEAD".split())
 commithash = commithash.decode('utf-8').strip()
 
-hash_file_rel_path = os.path.join('vyper', 'git_version.txt')
+if not os.path.exists('build'):
+    os.mkdir('build')
+hash_file_rel_path = os.path.join('build', 'vyper_git_version.txt')
 hashfile = os.path.relpath(hash_file_rel_path)
 with open(hashfile, 'w') as f :
     f.write(commithash)
@@ -71,7 +73,5 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
     ],
-    package_data={
-        '': [hash_file_rel_path]
-    }
+    data_files=[('', [hash_file_rel_path])]
 )

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ extras = {
 commithash = subprocess.check_output("git rev-parse HEAD".split())
 commithash = commithash.decode('utf-8').strip()
 
-
-hashfile = os.path.relpath('./vyper/git_version.txt')
+hash_file_rel_path = os.path.join('vyper', 'git_version.txt')
+hashfile = os.path.relpath(hash_file_rel_path)
 with open(hashfile, 'w') as f :
     f.write(commithash)
 
@@ -72,6 +72,6 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     package_data={
-        '': ['vyper/git_version.txt']
+        '': [hash_file_rel_path]
     }
 )

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -18,6 +18,7 @@ except _pkg_resources.DistributionNotFound:
     __version__ = '0.0.0development'
 
 try:
-    __commit__ = _pkg_resources.resource_string('vyper', 'git_version.txt').decode('utf-8')
+    __commit__ = _pkg_resources.resource_string('vyper', 'vyper_git_version.txt').decode('utf-8')
+    __commit__ = __commit__[:7]
 except FileNotFoundError:
-    __commit__ = '+commit.unknown'
+    __commit__ = 'unknown'

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -16,3 +16,8 @@ try:
     __version__ = _pkg_resources.get_distribution('vyper').version
 except _pkg_resources.DistributionNotFound:
     __version__ = '0.0.0development'
+
+try:
+    __commit__ = _pkg_resources.resource_string('vyper', 'git_version.txt').decode('utf-8')
+except FileNotFoundError:
+    __commit__ = '+commit.unknown'


### PR DESCRIPTION
### What I did
Revisited Charles' original PR #1220 , and all seems to work well if one uses `package_data=` instead of `data_files=`.

### How I did it

### How to verify it

### Description for the changelog
Git commit hash shown as part of version output.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2015/09/cute-bunnies-20__605.jpg)
