### PR TITLE
Add 'indexed' keyword to ERC20 interface

### DIFF
--- a/vyper/interfaces/ERC20.py
+++ b/vyper/interfaces/ERC20.py
@@ -1,7 +1,7 @@
 interface_code = """
 # Events
-Transfer: event({_from: address, _to: address, _value: uint256})
-Approval: event({_owner: address, _spender: address, _value: uint256})
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
 
 # Functions
 @constant


### PR DESCRIPTION
### What I did
Added the 'indexed' keyword, so vyper/interfaces/ERC20.py would comply with ERC20 specification.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.awesomelycute.com/gallery/2015/05/cute-baby-penguin-5.jpg)

This PR fixes https://github.com/ethereum/vyper/issues/1502 
