### PR TITLE
Fix compilable constant, nonreentrant functions

### DIFF
--- a/tests/signatures/test_invalid_function_decorators.py
+++ b/tests/signatures/test_invalid_function_decorators.py
@@ -1,0 +1,24 @@
+import pytest
+
+from vyper import (
+    compiler,
+)
+from vyper.exceptions import (
+    StructureException,
+)
+
+FAILING_CONTRACTS = [
+    """
+@public
+@constant
+@nonreentrant('lock')
+def nonreentrant_foo() -> uint256:
+    return 1
+    """,
+]
+
+
+@pytest.mark.parametrize('failing_contract_code', FAILING_CONTRACTS)
+def test_invalid_function_decorators(failing_contract_code):
+    with pytest.raises(StructureException):
+        compiler.compile_code(failing_contract_code)

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -96,7 +96,7 @@ def parse_external_contracts(external_contracts, global_ctx):
             sig = FunctionSignature.from_definition(
                 _def,
                 contract_def=True,
-                constant=constant,
+                constant_override=constant,
                 custom_structs=global_ctx._structs,
                 constants=global_ctx._constants
             )

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -157,7 +157,7 @@ class FunctionSignature:
                         custom_structs=None,
                         contract_def=False,
                         constants=None,
-                        constant=False):
+                        constant_override=False):
         if not custom_structs:
             custom_structs = {}
 
@@ -219,7 +219,7 @@ class FunctionSignature:
             else:
                 mem_pos += get_size_of_type(parsed_type) * 32
 
-        const, payable, private, public, nonreentrant_key = constant, False, False, False, ''
+        const, payable, private, public, nonreentrant_key = constant_override, False, False, False, ''
 
         # Update function properties from decorators
         for dec in code.decorator_list:

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -219,8 +219,9 @@ class FunctionSignature:
             else:
                 mem_pos += get_size_of_type(parsed_type) * 32
 
-        # Apply decorators
-        const, payable, private, public, nonreentrant_key = False, False, False, False, ''
+        const, payable, private, public, nonreentrant_key = constant, False, False, False, ''
+
+        # Update function properties from decorators
         for dec in code.decorator_list:
             if isinstance(dec, ast.Name) and dec.id == "constant":
                 const = True
@@ -258,10 +259,9 @@ class FunctionSignature:
                 "Function visibility must be declared (@public or @private)",
                 code,
             )
-        if constant and nonreentrant_key:
+        if const and nonreentrant_key:
             raise StructureException("@nonreentrant makes no sense on a @constant function.", code)
-        if constant:
-            const = True
+
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:
         # def foo(): ...

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -219,7 +219,11 @@ class FunctionSignature:
             else:
                 mem_pos += get_size_of_type(parsed_type) * 32
 
-        const, payable, private, public, nonreentrant_key = constant_override, False, False, False, ''
+        const = constant_override
+        payable = False
+        private = False
+        public = False
+        nonreentrant_key = ''
 
         # Update function properties from decorators
         for dec in code.decorator_list:


### PR DESCRIPTION
### What was wrong?

Fixes #1544.  Constant, non-reentrant functions such as the following were compilable in certain cases:
```python
@public
@constant
@nonreentrant('lock')
def nonreentrant_foo() -> uint256:
    return 1
```

### How I fixed it

Added a failing test for the above contract.  Modified the handling of certain values in the `FunctionSignature.from_definition` method.

### How to verify it

Run the tests.

### Description for the changelog

- Fixed a bug that allowed a function to be decorated with both `@constant` and `@nonreentrant(...)`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.nhptv.org/wild/images/americanbadgerfws.jpg)
