### PR TITLE
Add better source error printouts and VyperNode.__repr__

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -19,6 +19,9 @@ import vyper
 from vyper.parser import (
     parser_utils,
 )
+from vyper.settings import (
+    VYPER_TRACEBACK_LIMIT,
+)
 from vyper.signatures.interface import (
     extract_file_interface_imports,
 )
@@ -69,18 +72,21 @@ parser.add_argument(
     default='bytecode', dest='format',
 )
 parser.add_argument(
-    '--debug',
-    help='Add compiler debugging output',
-    action='store_true',
+    '--traceback-limit',
+    help='Set the traceback limit for error messages reported by the compiler',
+    type=int,
 )
 
 args = parser.parse_args()
 
-tb_limit = os.environ.get('VYPER_TRACEBACK_LIMIT')
-if tb_limit:
-    sys.tracebacklimit = int(tb_limit)
-elif not args.debug:
-    # sys.traceback limit defaults to 1000
+if args.traceback_limit is not None:
+    sys.tracebacklimit = args.traceback_limit
+elif VYPER_TRACEBACK_LIMIT is not None:
+    sys.tracebacklimit = VYPER_TRACEBACK_LIMIT
+else:
+    # Python usually defaults sys.tracebacklimit to 1000.  We use a default
+    # setting of zero so error printouts only include information about where
+    # an error occurred in a Vyper source file.
     sys.tracebacklimit = 0
 
 

--- a/bin/vyper-serve
+++ b/bin/vyper-serve
@@ -128,7 +128,7 @@ def runserver(host='', port=8000):
 
 if __name__ == '__main__':
     if ':' in args.bind_address:
-        lll_node.APPLY_COLOR = False
+        lll_node.VYPER_COLOR_OUTPUT = False
         runserver(*args.bind_address.split(':'))
     else:
         print('Provide bind address in "{address}:{port}" format')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -240,3 +240,15 @@ def test_annotate_source_code_marks_positions_in_source_code():
         if not self.lineno:
             self.lineno = lineno
 """[1:-1]
+
+
+@pytest.mark.parametrize(
+    'bad_lineno',
+    (-100, -1, 0, 45, 1000),
+)
+def test_annotate_source_code_raises_value_errors(bad_lineno):
+    with pytest.raises(
+        ValueError,
+        match='Line number is out of range',
+    ):
+        annotate_source_code(TEST_SOURCE_CODE, bad_lineno)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ from vyper.utils import (
     indent,
 )
 
-
 TEST_TEXT = """
 test
 lines

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.utils import (
+    annotate_source_code,
     indent,
 )
 
@@ -46,3 +47,164 @@ def test_indent_raises_value_errors():
         match='Unrecognized indentation characters value',
     ):
         indent(TEST_TEXT, indent_chars=None, level=1)  # type: ignore
+
+
+TEST_SOURCE_CODE = r"""
+# Attempts to display the line and column of violating code.
+class ParserException(Exception):
+    def __init__(self, message='Error Message not found.', item=None):
+        self.message = message
+        self.lineno = None
+        self.col_offset = None
+
+        if isinstance(item, tuple):  # is a position.
+            self.lineno, self.col_offset = item
+        elif item and hasattr(item, 'lineno'):
+            self.set_err_pos(item.lineno, item.col_offset)
+            if hasattr(item, 'source_code'):
+                self.source_code = item.source_code.splitlines()
+
+    def set_err_pos(self, lineno, col_offset):
+        if not self.lineno:
+            self.lineno = lineno
+
+            if not self.col_offset:
+                self.col_offset = col_offset
+
+    def __str__(self):
+        output = self.message
+
+        if self.lineno and hasattr(self, 'source_code'):
+
+            output = 'line %d: %s\n%s' % (
+                self.lineno,
+                output,
+                self.source_code[self.lineno - 1]
+            )
+
+            if self.col_offset:
+                col = '-' * self.col_offset + '^'
+                output += '\n' + col
+
+        elif self.lineno is not None and self.col_offset is not None:
+            output = 'line %d:%d %s' % (
+                self.lineno,
+                self.col_offset,
+                output
+            )
+
+        return output
+"""[1:-1]
+
+
+def test_annotate_source_code_marks_positions_in_source_code():
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        22,
+        col_offset=16,
+        context_lines=0,
+        line_numbers=False,
+    )
+    assert annotation == r"""
+    def __str__(self):
+----------------^
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        22,
+        col_offset=15,
+        context_lines=1,
+        line_numbers=False,
+    )
+    assert annotation == r"""
+
+    def __str__(self):
+---------------^
+        output = self.message
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        22,
+        col_offset=20,
+        context_lines=2,
+        line_numbers=False,
+    )
+    assert annotation == r"""
+                self.col_offset = col_offset
+
+    def __str__(self):
+--------------------^
+        output = self.message
+
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        1,
+        col_offset=5,
+        context_lines=3,
+        line_numbers=True,
+    )
+    assert annotation == r"""
+---> 1 # Attempts to display the line and column of violating code.
+------------^
+     2 class ParserException(Exception):
+     3     def __init__(self, message='Error Message not found.', item=None):
+     4         self.message = message
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        44,
+        col_offset=8,
+        context_lines=8,
+        line_numbers=True,
+    )
+    assert annotation == r"""
+     36
+     37         elif self.lineno is not None and self.col_offset is not None:
+     38             output = 'line %d:%d %s' % (
+     39                 self.lineno,
+     40                 self.col_offset,
+     41                 output
+     42             )
+     43
+---> 44         return output
+----------------^
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        15,
+        col_offset=8,
+        context_lines=11,
+        line_numbers=True,
+    )
+    assert annotation == r"""
+      4         self.message = message
+      5         self.lineno = None
+      6         self.col_offset = None
+      7
+      8         if isinstance(item, tuple):  # is a position.
+      9             self.lineno, self.col_offset = item
+     10         elif item and hasattr(item, 'lineno'):
+     11             self.set_err_pos(item.lineno, item.col_offset)
+     12             if hasattr(item, 'source_code'):
+     13                 self.source_code = item.source_code.splitlines()
+     14
+---> 15     def set_err_pos(self, lineno, col_offset):
+----------------^
+     16         if not self.lineno:
+     17             self.lineno = lineno
+     18
+     19             if not self.col_offset:
+     20                 self.col_offset = col_offset
+     21
+     22     def __str__(self):
+     23         output = self.message
+     24
+     25         if self.lineno and hasattr(self, 'source_code'):
+     26
+"""[1:-1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,3 +208,35 @@ def test_annotate_source_code_marks_positions_in_source_code():
      25         if self.lineno and hasattr(self, 'source_code'):
      26
 """[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        15,
+        col_offset=None,
+        context_lines=3,
+        line_numbers=True,
+    )
+    assert annotation == r"""
+     12             if hasattr(item, 'source_code'):
+     13                 self.source_code = item.source_code.splitlines()
+     14
+---> 15     def set_err_pos(self, lineno, col_offset):
+     16         if not self.lineno:
+     17             self.lineno = lineno
+     18
+"""[1:-1]
+
+    annotation = annotate_source_code(
+        TEST_SOURCE_CODE,
+        15,
+        col_offset=None,
+        context_lines=2,
+        line_numbers=False,
+    )
+    assert annotation == r"""
+                self.source_code = item.source_code.splitlines()
+
+    def set_err_pos(self, lineno, col_offset):
+        if not self.lineno:
+            self.lineno = lineno
+"""[1:-1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+import pytest
+
+from vyper.utils import (
+    indent,
+)
+
+
+TEST_TEXT = """
+test
+lines
+to
+indent
+"""[1:-1]
+
+
+def test_indent_indents_text():
+    assert indent(TEST_TEXT, indent_chars='-', level=1) == """
+-test
+-lines
+-to
+-indent
+"""[1:-1]
+    assert indent(TEST_TEXT, indent_chars=' ', level=4) == """
+    test
+    lines
+    to
+    indent
+"""[1:-1]
+    assert indent(TEST_TEXT, indent_chars=[' ', '*', '-', '='], level=4) == """
+    test
+****lines
+----to
+====indent
+"""[1:-1]
+
+
+def test_indent_raises_value_errors():
+    with pytest.raises(
+        ValueError,
+        match='Must provide indentation chars for each line',
+    ):
+        indent(TEST_TEXT, indent_chars=[' '], level=1)
+
+    with pytest.raises(
+        ValueError,
+        match='Unrecognized indentation characters value',
+    ):
+        indent(TEST_TEXT, indent_chars=None, level=1)  # type: ignore

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -6,6 +6,13 @@ import typing
 from vyper.exceptions import (
     CompilerPanic,
 )
+from vyper.settings import (
+    VYPER_ERROR_CONTEXT_LINES,
+    VYPER_ERROR_LINE_NUMBERS,
+)
+from vyper.utils import (
+    annotate_source_code,
+)
 
 BASE_NODE_ATTRIBUTES = ('node_id', 'source_code', 'col_offset', 'lineno')
 
@@ -42,6 +49,20 @@ class VyperNode:
             return True
         else:
             return False
+
+    def __repr__(self):
+        cls = type(self)
+        class_repr = f'{cls.__module__}.{cls.__qualname__}'
+
+        source_annotation = annotate_source_code(
+            self.source_code,
+            self.lineno,
+            self.col_offset,
+            context_lines=VYPER_ERROR_CONTEXT_LINES,
+            line_numbers=VYPER_ERROR_LINE_NUMBERS,
+        )
+
+        return f'{class_repr}:\n{source_annotation}'
 
 
 class Module(VyperNode):

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -1,7 +1,7 @@
-import os
-
-VYPER_ERROR_CONTEXT_LINES = int(os.environ.get('VYPER_ERROR_CONTEXT_LINES', '1'))
-VYPER_ERROR_LINE_NUMBERS = os.environ.get('VYPER_ERROR_LINE_NUMBERS', '1') == '1'
+from vyper.settings import (
+    VYPER_ERROR_CONTEXT_LINES,
+    VYPER_ERROR_LINE_NUMBERS,
+)
 
 
 # Attempts to display the line and column of violating code.

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from vyper.exceptions import (
@@ -13,17 +12,17 @@ from vyper.types import (
     NullType,
     ceil32,
 )
+from vyper.settings import (
+    VYPER_COLOR_OUTPUT,
+)
 from vyper.utils import (
     valid_lll_macros,
 )
 
 # Set default string representation for ints in LLL output.
 AS_HEX_DEFAULT = False
-# Terminal color types
-APPLY_COLOR = os.environ.get('VYPER_COLOR_OUTPUT', '0') == '1'
 
-
-if APPLY_COLOR:
+if VYPER_COLOR_OUTPUT:
     OKBLUE = '\033[94m'
     OKMAGENTA = '\033[35m'
     OKLIGHTMAGENTA = '\033[95m'

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -6,14 +6,14 @@ from vyper.exceptions import (
 from vyper.opcodes import (
     comb_opcodes,
 )
+from vyper.settings import (
+    VYPER_COLOR_OUTPUT,
+)
 from vyper.types import (
     BaseType,
     NodeType,
     NullType,
     ceil32,
-)
-from vyper.settings import (
-    VYPER_COLOR_OUTPUT,
 )
 from vyper.utils import (
     valid_lll_macros,

--- a/vyper/settings.py
+++ b/vyper/settings.py
@@ -1,5 +1,16 @@
 import os
+from typing import (
+    Optional,
+)
 
 VYPER_COLOR_OUTPUT = os.environ.get('VYPER_COLOR_OUTPUT', '0') == '1'
 VYPER_ERROR_CONTEXT_LINES = int(os.environ.get('VYPER_ERROR_CONTEXT_LINES', '1'))
 VYPER_ERROR_LINE_NUMBERS = os.environ.get('VYPER_ERROR_LINE_NUMBERS', '1') == '1'
+
+VYPER_TRACEBACK_LIMIT: Optional[int]
+
+_tb_limit_str = os.environ.get('VYPER_TRACEBACK_LIMIT')
+if _tb_limit_str is not None:
+    VYPER_TRACEBACK_LIMIT = int(_tb_limit_str)
+else:
+    VYPER_TRACEBACK_LIMIT = None

--- a/vyper/settings.py
+++ b/vyper/settings.py
@@ -1,0 +1,5 @@
+import os
+
+VYPER_COLOR_OUTPUT = os.environ.get('VYPER_COLOR_OUTPUT', '0') == '1'
+VYPER_ERROR_CONTEXT_LINES = int(os.environ.get('VYPER_ERROR_CONTEXT_LINES', '1'))
+VYPER_ERROR_LINE_NUMBERS = os.environ.get('VYPER_ERROR_LINE_NUMBERS', '1') == '1'

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -366,8 +366,8 @@ def annotate_source_code(
 
         location_repr = indent(location_repr, indent_chars=justified_reprs)
 
-    # Do a bit of cleanup to ensure there are no unneeded trailing blank lines
-    # or whitespace chars
+    # Ensure no trailing whitespace and trailing blank lines are only included
+    # if they are part of the source code
     if col_offset is None:
         # Number of lines doesn't include column marker line
         num_lines = end_offset - start_offset

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -366,4 +366,15 @@ def annotate_source_code(
 
         location_repr = indent(location_repr, indent_chars=justified_reprs)
 
-    return location_repr
+    # Do a bit of cleanup to ensure there are no unneeded trailing blank lines
+    # or whitespace chars
+    if col_offset is None:
+        # Number of lines doesn't include column marker line
+        num_lines = end_offset - start_offset
+    else:
+        num_lines = end_offset - start_offset + 1
+
+    cleanup_lines = [l.rstrip() for l in location_repr.splitlines()]
+    cleanup_lines += [''] * (num_lines - len(cleanup_lines))
+
+    return '\n'.join(cleanup_lines)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,6 +4,10 @@ from collections import (
 )
 import functools
 import re
+from typing import (
+    List,
+    Union,
+)
 
 from vyper.exceptions import (
     InvalidLiteralException,
@@ -268,3 +272,98 @@ def iterable_cast(cast_type):
             return cast_type(func(*args, **kwargs))
         return f
     return yf
+
+
+def indent(text: str, indent_chars: Union[str, List[str]] = ' ', level: int = 1) -> str:
+    """
+    Indent lines of text in the string ``text`` using the indentation
+    character(s) given in ``indent_chars`` ``level`` times.
+
+    :param text: A string containing the lines of text to be indented.
+    :param level: The number of times to indent lines in ``text``.
+    :param indent_chars: The characters to use for indentation.  If a string,
+        uses repetitions of that string for indentation.  If a list of strings,
+        uses repetitions of each string to indent each line.
+
+    :return: The indented text.
+    """
+    text_lines = text.splitlines(keepends=True)
+
+    if isinstance(indent_chars, str):
+        indented_lines = [indent_chars * level + line for line in text_lines]
+    elif isinstance(indent_chars, list):
+        if len(indent_chars) != len(text_lines):
+            raise ValueError('Must provide indentation chars for each line')
+
+        indented_lines = [
+            ind * level + line
+            for ind, line
+            in zip(indent_chars, text_lines)
+        ]
+    else:
+        raise ValueError('Unrecognized indentation characters value')
+
+    return ''.join(indented_lines)
+
+
+def annotate_source_code(
+    source_code: str,
+    lineno: int,
+    col_offset: int = None,
+    context_lines: int = 0,
+    line_numbers: bool = False,
+) -> str:
+    """
+    Annotate the location specified by ``lineno`` and ``col_offset`` in the
+    source code given by ``source_code`` with a location marker and optional
+    line numbers and context lines.
+
+    :param source_code: The source code containing the source location.
+    :param lineno: The 1-indexed line number of the source location.
+    :param col_offset: The 0-indexed column offset of the source location.
+    :param context_lines: The number of contextual lines to include above and
+        below the source location.
+    :param line_numbers: If true, line numbers are included in the location
+        representation.
+
+    :return: A string containing the annotated source code location.
+    """
+    source_lines = source_code.splitlines(keepends=True)
+    if lineno < 1 or lineno > len(source_lines):
+        raise ValueError('Line number is out of range')
+
+    line_offset = lineno - 1
+    start_offset = max(0, line_offset - context_lines)
+    end_offset = min(len(source_lines), line_offset + context_lines + 1)
+
+    line_repr = source_lines[line_offset]
+    if '\n' not in line_repr[-2:]:  # Handle certain edge cases
+        line_repr += '\n'
+    if col_offset is None:
+        mark_repr = ''
+    else:
+        mark_repr = '-' * col_offset + '^' + '\n'
+
+    before_lines = ''.join(source_lines[start_offset:line_offset])
+    after_lines = ''.join(source_lines[line_offset + 1:end_offset])
+    location_repr = ''.join((before_lines, line_repr, mark_repr, after_lines))
+
+    if line_numbers:
+        # Create line numbers
+        lineno_reprs = [f'{i} ' for i in range(start_offset + 1, end_offset + 1)]
+
+        # Highlight line identified by `lineno`
+        local_line_off = line_offset - start_offset
+        lineno_reprs[local_line_off] = '---> ' + lineno_reprs[local_line_off]
+
+        # Calculate width of widest line no
+        max_len = max(len(i) for i in lineno_reprs)
+
+        # Justify all line nos according to this width
+        justified_reprs = [i.rjust(max_len) for i in lineno_reprs]
+        if col_offset is not None:
+            justified_reprs.insert(local_line_off + 1, '-' * max_len)
+
+        location_repr = indent(location_repr, indent_chars=justified_reprs)
+
+    return location_repr


### PR DESCRIPTION
### What was wrong?

Today, I realized it's a bit hard to know anything about an instance of `vyper.ast.VyperNode` without inspecting its values.  While debugging some things, I hacked together a `__repr__` implementation for `VyperNode` and decided it could be useful to add to the project.

### How I fixed it

Added a utility function `vyper.utils.annotate_source_code` that annotates a position nicely in a source code file based on a `lineno` and `col_offset`.  Added usages of this new function in both `ParserException.__str__` and `VyperNode.__repr__`.  Also created a `settings` module that acts as a central store of settings pulled from environment variables.  Added two new settings vars to that module to control how source annotations are printed in compiler error messages.

### How to verify it

Added some tests for the formatting.  Run the tests.  The change in behavior of the source code printouts doesn't appear to affect any existing tests.

### Description for the changelog

- Added prettier source code printouts to compiler error messages.  Printout properties can be controlled via two new environment variable settings `VYPER_ERROR_CONTEXT_LINES` and `VYPER_ERROR_LINE_NUMBERS`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://nationalzoo.si.edu/sites/default/files/animals/redpanda-002.jpg)
