### PR TITLE
Add end offsets to AST and source map

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     python_requires='>=3.6',
     py_modules=['vyper'],
     install_requires=[
+        'asttokens>=1.1.13,<2',
         'pycryptodome>=3.5.1,<4',
     ],
     setup_requires=[

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -14,7 +14,14 @@ from vyper.utils import (
     annotate_source_code,
 )
 
-BASE_NODE_ATTRIBUTES = ('node_id', 'source_code', 'col_offset', 'lineno')
+BASE_NODE_ATTRIBUTES = (
+    'node_id',
+    'source_code',
+    'col_offset',
+    'lineno',
+    'end_col_offset',
+    'end_lineno'
+)
 
 
 class VyperNode:

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -1,4 +1,5 @@
 import ast as python_ast
+import asttokens
 from typing import (
     Generator,
 )
@@ -42,6 +43,10 @@ def _build_vyper_ast_init_kwargs(
     yield ('lineno', getattr(node, 'lineno', None))
     yield ('node_id', node.node_id)  # type: ignore
     yield ('source_code', source_code)
+
+    end = node.last_token.end if hasattr(node, 'last_token') else (None, None)
+    yield ('end_lineno', end[0])
+    yield ('end_col_offset', end[1])
 
     if isinstance(node, python_ast.ClassDef):
         yield ('class_type', node.class_type)  # type: ignore
@@ -92,6 +97,7 @@ def parse_to_ast(source_code: str) -> list:
     class_types, reformatted_code = pre_parse(source_code)
     py_ast = python_ast.parse(reformatted_code)
     annotate_ast(py_ast, source_code, class_types)
+    asttokens.ASTTokens(source_code, tree=py_ast)
     # Convert to Vyper AST.
     vyper_ast = parse_python_ast(
         source_code=source_code,

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -65,9 +65,9 @@ class instruction(str):
     def __init__(self, sstr, pos=None):
         self.pc_debugger = False
         if pos is not None:
-            self.lineno, self.col_offset = pos
+            self.lineno, self.col_offset, self.end_lineno, self.end_col_offset = pos
         else:
-            self.lineno, self.col_offset = None, None
+            self.lineno, self.col_offset, self.end_lineno, self.end_col_offset = [None] * 4
 
 
 def apply_line_numbers(func):
@@ -453,7 +453,8 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
 def note_line_num(line_number_map, item, pos):
     # Record line number attached to pos.
     if isinstance(item, instruction) and item.lineno is not None:
-        line_number_map['pc_pos_map'][pos] = item.lineno, item.col_offset
+        offsets = (item.lineno, item.col_offset, item.end_lineno, item.end_col_offset)
+        line_number_map['pc_pos_map'][pos] = offsets
     added_line_breakpoint = note_breakpoint(line_number_map, item, pos)
     return added_line_breakpoint
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -239,7 +239,12 @@ def get_length(arg):
 
 
 def getpos(node):
-    return (node.lineno, node.col_offset)
+    return (
+        node.lineno,
+        node.col_offset,
+        getattr(node, 'end_lineno', None),
+        getattr(node, 'end_col_offset', None)
+    )
 
 
 # Take a value representing a memory or storage location, and descend down to


### PR DESCRIPTION
### What I did
Added end offsets for the Vyper AST nodes and the source map.

### How I did it
* Add tokens to the python AST nodes using the [`asttokens`](https://github.com/gristlabs/asttokens) library.
* Use the tokens to add `end_lineno` and `end_col_offset` attributes to the final Vyper AST. (Attributes with these names are included in the standard ast library [as of Python 3.8](https://github.com/python/cpython/pull/11605))
* include these new attributes when generating the ``LLLnode`` objects, and add their values to the source map.

### How to verify it
I've checked it manually but tests still need to be written, as well existing tests will need updating. I will do so if and when the concept is finalized / approved.

### Comments / Thoughts
This PR is meant as a proof of concept.  I assume it will need some discussion and work before it can be merged. The following questions come to mind:

* Is it acceptable to introduce the `asttokens` library as a requirement?  If not, I can instead take heavy inspiration from it and include the same functionality without requiring the import.
* Is the output format for the source map offsets the correct approach?  I've handled it as a 4 item tuple of `(lineno, col_offset, end_lineno, end_col_offset)`. This is effectively a breaking change for any program expecting exactly a two item tuple. Other approaches could be:
  * a 2x2 tuple as `[(lineno, col_offset), (end_lineno, end_col_offset)]`
  * switch to using exact positions as `(start, length)` - more in line with solc output but less-so with python ASTs. Also a larger deviation from the current output and so a larger breaking change.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/35276322/62282886-f58e4280-b482-11e9-9262-1dfa53386bcd.png)
