### PR TITLE
Handle kwargs in self.* contract calls

### DIFF
--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -3,6 +3,7 @@ import itertools
 from vyper.exceptions import (
     ConstancyViolationException,
     StructureException,
+    TypeMismatchException,
 )
 from vyper.parser.external_call import (
     get_external_contract_keywords,
@@ -84,6 +85,11 @@ def call_self_private(stmt_expr, context, sig):
     push_local_vars = []
     pop_return_values = []
     push_args = []
+
+    if len(stmt_expr.keywords):
+        raise TypeMismatchException(
+            "Cannot call private functions with keyword arguments", stmt_expr
+        )
 
     # Push local variables.
     var_slots = [


### PR DESCRIPTION
### What I did
* Add use of `value` and `gas` kwargs `self.*` calls to public functions
* Raise when kwargs are used in private function calls
* Fixes #1554

### How I did it
* `parser.self_call.call_self_public` calls `parser.externalcall.get_external_contract_keywords` to convert gas and value to `LLLnode` objects, this also prevents use of unknown kwargs
* `parser.self_call.call_self_private` raises a `TypeMismatchException` if any kwargs are given

### How to verify it
I added tests to `tests/parser/features/test_internal_call.py`.

### Description for the changelog
* Disallow keyword arguments in private function calls
* Handle value and gas kwargs properly when calling public functions within the same contract

### Cute Animal Picture

![Marmosets are super cute](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2F3.bp.blogspot.com%2F-JcDkED3S2tk%2FVB0_ER-ViJI%2FAAAAAAAAr6c%2F_jhOz7LuIpg%2Fs1600%2Fa4.jpg&f=1)
