### PR TITLE
Disallow kwargs in private function calls

### DIFF
--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -2,8 +2,11 @@ from decimal import (
     Decimal,
 )
 
+import pytest
+
 from vyper.exceptions import (
     StructureException,
+    TypeMismatchException,
 )
 
 
@@ -362,3 +365,59 @@ def foo() -> int128:
     return self.bar(1)
 """
     assert_tx_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
+
+
+def test_selfcall_with_value_private(get_contract_with_gas_estimation, assert_tx_failed):
+    code = """
+@private
+def foo():
+    pass
+
+@public
+def bar():
+    self.foo(value=100)"""
+
+    with pytest.raises(TypeMismatchException):
+        get_contract_with_gas_estimation(code)
+
+
+def test_selfcall_with_gas_private(get_contract_with_gas_estimation, assert_tx_failed):
+    code = """
+@private
+def foo():
+    pass
+
+@public
+def bar():
+    self.foo(gas=100)"""
+
+    with pytest.raises(TypeMismatchException):
+        get_contract_with_gas_estimation(code)
+
+
+def test_selfcall_unknown_kwargs_private(get_contract_with_gas_estimation, assert_tx_failed):
+    code = """
+@private
+def foo():
+    pass
+
+@public
+def bar():
+    self.foo(foo=100)"""
+
+    with pytest.raises(TypeMismatchException):
+        get_contract_with_gas_estimation(code)
+
+
+def test_selfcall_args_as_kwargs_private(get_contract_with_gas_estimation, assert_tx_failed):
+    code = """
+@private
+def foo(baz: int128):
+    pass
+
+@public
+def bar():
+    self.foo(baz=100)"""
+
+    with pytest.raises(TypeMismatchException):
+        get_contract_with_gas_estimation(code)

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -4,6 +4,9 @@ from decimal import (
 
 import pytest
 
+from vyper import (
+    compiler,
+)
 from vyper.exceptions import (
     StructureException,
     TypeMismatchException,
@@ -367,57 +370,51 @@ def foo() -> int128:
     assert_tx_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
 
 
-def test_selfcall_with_value_private(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+FAILING_CONTRACTS = [
+    """
+# should not compile - value kwarg when calling private function
 @private
 def foo():
     pass
 
 @public
 def bar():
-    self.foo(value=100)"""
-
-    with pytest.raises(TypeMismatchException):
-        get_contract_with_gas_estimation(code)
-
-
-def test_selfcall_with_gas_private(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+    self.foo(value=100)
+    """,
+    """
+# should not compile - gas kwarg when calling private function
 @private
 def foo():
     pass
 
 @public
 def bar():
-    self.foo(gas=100)"""
-
-    with pytest.raises(TypeMismatchException):
-        get_contract_with_gas_estimation(code)
-
-
-def test_selfcall_unknown_kwargs_private(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+    self.foo(gas=100)
+    """,
+    """
+# should not compile - arbitrary kwargs when calling private function
 @private
 def foo():
     pass
 
 @public
 def bar():
-    self.foo(foo=100)"""
-
-    with pytest.raises(TypeMismatchException):
-        get_contract_with_gas_estimation(code)
-
-
-def test_selfcall_args_as_kwargs_private(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+    self.foo(baz=100)
+    """,
+    """
+# should not compile - args-as-kwargs to a private function
 @private
 def foo(baz: int128):
     pass
 
 @public
 def bar():
-    self.foo(baz=100)"""
+    self.foo(baz=100)
+    """,
+]
 
+
+@pytest.mark.parametrize('failing_contract_code', FAILING_CONTRACTS)
+def test_selfcall_kwarg_raises(failing_contract_code):
     with pytest.raises(TypeMismatchException):
-        get_contract_with_gas_estimation(code)
+        compiler.compile_code(failing_contract_code)

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -372,8 +372,8 @@ def foo() -> int128:
 
 FAILING_CONTRACTS = [
     """
-# should not compile - value kwarg when calling private function
-@private
+# should not compile - value kwarg when calling {0} function
+@{0}
 def foo():
     pass
 
@@ -382,8 +382,8 @@ def bar():
     self.foo(value=100)
     """,
     """
-# should not compile - gas kwarg when calling private function
-@private
+# should not compile - gas kwarg when calling {0} function
+@{0}
 def foo():
     pass
 
@@ -392,8 +392,8 @@ def bar():
     self.foo(gas=100)
     """,
     """
-# should not compile - arbitrary kwargs when calling private function
-@private
+# should not compile - arbitrary kwargs when calling {0} function
+@{0}
 def foo():
     pass
 
@@ -402,8 +402,8 @@ def bar():
     self.foo(baz=100)
     """,
     """
-# should not compile - args-as-kwargs to a private function
-@private
+# should not compile - args-as-kwargs to a {0} function
+@{0}
 def foo(baz: int128):
     pass
 
@@ -415,6 +415,8 @@ def bar():
 
 
 @pytest.mark.parametrize('failing_contract_code', FAILING_CONTRACTS)
-def test_selfcall_kwarg_raises(failing_contract_code):
+@pytest.mark.parametrize('decorator', ['public', 'private'])
+def test_selfcall_kwarg_raises(failing_contract_code, decorator):
+    code = failing_contract_code.format(decorator)
     with pytest.raises(TypeMismatchException):
-        compiler.compile_code(failing_contract_code)
+        compiler.compile_code(code)

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -2,6 +2,7 @@ import itertools
 
 from vyper.exceptions import (
     ConstancyViolationException,
+    TypeMismatchException,
 )
 from vyper.parser.lll_node import (
     LLLnode,
@@ -80,6 +81,11 @@ def call_self_private(stmt_expr, context, sig):
     push_local_vars = []
     pop_return_values = []
     push_args = []
+
+    if len(stmt_expr.keywords):
+        raise TypeMismatchException(
+            "Cannot call private functions with keyword arguments", stmt_expr
+        )
 
     # Push local variables.
     var_slots = [

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -34,6 +34,12 @@ def call_lookup_specs(stmt_expr, context):
 
 
 def make_call(stmt_expr, context):
+
+    if len(stmt_expr.keywords):
+        raise TypeMismatchException(
+            "Cannot use keyword arguments in calls to functions via 'self'", stmt_expr
+        )
+
     method_name, _, sig = call_lookup_specs(stmt_expr, context)
 
     if context.is_constant() and not sig.const:
@@ -81,11 +87,6 @@ def call_self_private(stmt_expr, context, sig):
     push_local_vars = []
     pop_return_values = []
     push_args = []
-
-    if len(stmt_expr.keywords):
-        raise TypeMismatchException(
-            "Cannot call private functions with keyword arguments", stmt_expr
-        )
 
     # Push local variables.
     var_slots = [


### PR DESCRIPTION
### What I did
Raise when kwargs are used in `private` function calls (#1554)

### How I did it
`parser.self_call.call_self_private` raises a `TypeMismatchException` if any kwargs are given

### How to verify it
I added tests to `tests/parser/features/test_internal_call.py`.

### Description for the changelog
* Disallow keyword arguments in private function calls

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/jNY86.jpg)
