### PR TITLE
Bugfix - calls to private functions with multiple lists as parameters

### DIFF
--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -324,6 +324,29 @@ def bar() -> (int128, decimal):
     assert c.bar() == [66, Decimal('66.77')]
 
 
+def test_private_function_multiple_lists(get_contract_with_gas_estimation):
+    code = """
+@private
+def _fooa(x: int128[5], y: bytes[42], z: uint256[3], a: bytes[2]) -> uint256:
+    return z[2]
+
+@private
+def _foob(x: bytes[42], y: uint256[3], z: bytes[2], a: int128[5]) -> bytes[42]:
+    return x
+
+@public
+def bar() -> (uint256, bytes[42]):
+    x: int128[5] = [1, 2, 3, 4, 5]
+    y: bytes[42] = b"you can do the thing!you can do the thing!"
+    z: uint256[3] = [44, 11, 2]
+    a: bytes[2] = "hi"
+    return self._fooa(x, y, z, a), self._foob(y, z, a, x)
+"""
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.bar() == [2, b"you can do the thing!you can do the thing!"]
+
+
 def test_multi_mixed_arg_list_bytes_call(get_contract_with_gas_estimation):
     code = """
 @public

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -324,27 +324,28 @@ def bar() -> (int128, decimal):
     assert c.bar() == [66, Decimal('66.77')]
 
 
-def test_private_function_multiple_lists(get_contract_with_gas_estimation):
+def test_private_function_multiple_lists_as_args(get_contract_with_gas_estimation):
     code = """
 @private
-def _fooa(x: int128[5], y: bytes[42], z: uint256[3], a: bytes[2]) -> uint256:
-    return z[2]
+def _foo(y: int128[2], x: bytes[5]) -> int128:
+    return y[0]
 
 @private
-def _foob(x: bytes[42], y: uint256[3], z: bytes[2], a: int128[5]) -> bytes[42]:
-    return x
+def _foo2(x: bytes[5], y: int128[2]) -> int128:
+    return y[0]
 
 @public
-def bar() -> (uint256, bytes[42]):
-    x: int128[5] = [1, 2, 3, 4, 5]
-    y: bytes[42] = b"you can do the thing!you can do the thing!"
-    z: uint256[3] = [44, 11, 2]
-    a: bytes[2] = "hi"
-    return self._fooa(x, y, z, a), self._foob(y, z, a, x)
+def bar() -> int128:
+    return self._foo([1, 2], b"hello")
+
+@public
+def bar2() -> int128:
+    return self._foo2(b"hello", [1, 2])
 """
 
     c = get_contract_with_gas_estimation(code)
-    assert c.bar() == [2, b"you can do the thing!you can do the thing!"]
+    assert c.bar() == 1
+    assert c.bar2() == 1
 
 
 def test_multi_mixed_arg_list_bytes_call(get_contract_with_gas_estimation):

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -149,9 +149,11 @@ def call_self_private(stmt_expr, context, sig):
             # by taking ceil32(len<arg>) + offset<arg> + arg_pos
             # for the last dynamic argument and arg_pos is the start
             # the whole argument section.
-            for idx, arg in enumerate(expr_args):
+            idx = 0
+            for arg in expr_args:
                 if isinstance(arg.typ, ByteArrayLike):
                     last_idx = idx
+                idx += get_static_size_of_type(arg.typ)
             push_args += [
                 ['with', 'offset', ['mload', arg_pos + last_idx * 32],
                     ['with', 'len_pos', ['add', arg_pos, 'offset'],


### PR DESCRIPTION
### What I did
Fixed an bug stemming from #1470 - calls to private functions that had a bytes list following an integer list of length > 1 were underflowing.

In the following example calls to `bar` would underflow, but `bar2` would succeed:

```python
@private
def _foo(y: int128[2], x: bytes[5]) -> int128:
    return y[0]

@private
def _foo2(x: bytes[5], y: int128[2]) -> int128:
    return y[0]

@public
def bar() -> int128:
    return self._foo([1, 2], b"hello")

@public
def bar2() -> int128:
    return self._foo2(b"hello", [1, 2])
```

### How I did it
Used `get_static_size_of_type` to verify the memory size of each argument during iteration.

### How to verify it
I have included a test as the first commit, if you run it without the 2nd commit you can see the bug in action.


### Description for the changelog
* Bugfix - multiple arrays as inputs in a private function

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/35276322/62415476-bd425c00-b65c-11e9-876f-1aa091e38d89.png)
