### PR TITLE
Move kwarg check to more meaningful location

### DIFF
--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -27,19 +27,31 @@ from vyper.types import (
 
 def call_lookup_specs(stmt_expr, context):
     from vyper.parser.expr import Expr
+
     method_name = stmt_expr.func.attr
-    expr_args = [Expr(arg, context).lll_node for arg in stmt_expr.args]
-    sig = FunctionSignature.lookup_sig(context.sigs, method_name, expr_args, stmt_expr, context)
+
+    if len(stmt_expr.keywords):
+        raise TypeMismatchException(
+            "Cannot use keyword arguments in calls to functions via 'self'",
+            stmt_expr,
+        )
+    expr_args = [
+        Expr(arg, context).lll_node
+        for arg in stmt_expr.args
+    ]
+
+    sig = FunctionSignature.lookup_sig(
+        context.sigs,
+        method_name,
+        expr_args,
+        stmt_expr,
+        context,
+    )
+
     return method_name, expr_args, sig
 
 
 def make_call(stmt_expr, context):
-
-    if len(stmt_expr.keywords):
-        raise TypeMismatchException(
-            "Cannot use keyword arguments in calls to functions via 'self'", stmt_expr
-        )
-
     method_name, _, sig = call_lookup_specs(stmt_expr, context)
 
     if context.is_constant() and not sig.const:


### PR DESCRIPTION
### What I did

Moved the recently added kwarg check for self calls to a more meaningful location.  Now, the check is done just before the line of code where it makes a difference.

### How to verify it

Run the tests.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pgcpsmess.files.wordpress.com/2014/07/o-red-fox-facebook.jpg)
