### PR TITLE
Add context information to some error messages

### DIFF
--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -1020,11 +1020,13 @@ class Stmt(object):
                 "Cannot modify storage inside %s: %s" % (
                     self.context.pp_constancy(),
                     target.annotation,
-                )
+                ),
+                self.stmt,
             )
         if not target.mutable:
             raise ConstancyViolationException(
-                "Cannot modify function argument: %s" % target.annotation
+                "Cannot modify function argument: %s" % target.annotation,
+                self.stmt,
             )
         return target
 


### PR DESCRIPTION
### What I did

Added context information for a couple of compiler exceptions.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pgcpsmess.files.wordpress.com/2014/04/red_fox.jpg)
