### PR TITLE
use pathlib instead of os.path

### DIFF
--- a/bin/vyper
+++ b/bin/vyper
@@ -4,7 +4,9 @@ from collections import (
     OrderedDict,
 )
 import json
-import os
+from pathlib import (
+    Path,
+)
 import sys
 from typing import (
     Any,
@@ -121,21 +123,19 @@ def get_interface_codes(codes: ContractCodes) -> Any:
 
     if interface_codes:
         for interface_name, interface_path in interface_codes.items():
-            file_path = os.path.join(os.path.normpath(interface_path.replace('.', '/')))
-            extensions = ('.vy', '.json')
-            valid_paths = [
-                file_path + ex
-                for ex in extensions if os.path.exists(file_path + ex)
-            ]
-            if not valid_paths:
+            file_path = Path(interface_path.replace('.', '/')).resolve()
+
+            try:
+                suffix = next(i for i in ('.vy', '.json') if file_path.with_suffix(i).exists())
+            except StopIteration:
                 raise Exception(
                     f'Imported interface "{interface_path}{{.vy,.json}}" does not exist.'
                 )
 
-            valid_path = valid_paths[0]
-            with open(valid_path) as fh:
+            valid_path = file_path.with_suffix(suffix)
+            with valid_path.open() as fh:
                 code = fh.read()
-                if valid_path.endswith('.json'):
+                if valid_path.suffix == '.json':
                     interfaces[interface_name] = {
                         'type': 'json',
                         'code': json.loads(code.encode())

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -1,6 +1,8 @@
 import copy
 import importlib
-import os
+from pathlib import (
+    Path,
+)
 import pkgutil
 from typing import (
     Sequence,
@@ -184,7 +186,7 @@ def extract_external_interface(code, contract_name, interface_codes=None):
         interface_codes=interface_codes,
     )
     functions = [sig for sig, _ in sigs if isinstance(sig, FunctionSignature)]
-    cname = os.path.basename(contract_name).split('.')[0].capitalize()
+    cname = Path(contract_name).stem.capitalize()
 
     out = ""
     offset = 4 * " "


### PR DESCRIPTION
### What I did
Replace `os.path` with `pathlib.Path` - it makes for much cleaner code and reduces headaches when dealing with Windows file systems.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/62711419-99e82a00-ba2b-11e9-8b2a-7d21e01a6713.png)

