### PR TITLE
increase test deadline to 1 second

### DIFF
--- a/tests/parser/types/numbers/test_sqrt.py
+++ b/tests/parser/types/numbers/test_sqrt.py
@@ -152,7 +152,7 @@ def test(a: decimal) -> decimal:
 @hypothesis.example(Decimal(SizeLimits.MAXNUM))
 @hypothesis.example(Decimal(0))
 @hypothesis.settings(
-    deadline=400,
+    deadline=1000,
 )
 def test_sqrt_valid_range(sqrt_contract, value):
     vyper_sqrt = sqrt_contract.test(value)


### PR DESCRIPTION
### What I did

Per https://github.com/ethereum/vyper/pull/1560#issuecomment-518024254, I increased the deadline for `test_sqrt_valid_range` to 1 second.  It keeps failing locally and makes me want to do a murder.

### How to verify it
Run the tests and enjoy non-flaky results.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/62752937-069b0d00-ba9c-11e9-8ac7-3a775d577058.png)

