### PR TITLE
Compile-time check for missing args in private calls

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vyper.exceptions import (
     InvalidTypeException,
     StructureException,
@@ -674,27 +676,53 @@ bar_contract: Barr
     )
 
 
-def test_invalid_contract_declaration_pass(assert_compile_failed, get_contract_with_gas_estimation):
-
-    contract_1 = """
+FAILING_CONTRACTS_STRUCTURE_EXCEPTION = [
+    """
+# invalid contract declaration (pass)
 contract Bar:
     def set_lucky(arg1: int128): pass
+    """,
     """
-
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(contract_1), StructureException)
-
-
-def test_invalid_contract_declaration_assign(assert_compile_failed,
-                                             get_contract_with_gas_estimation):
-
-    contract_1 = """
 contract Bar:
+# invalud contract declaration (assignment)
     def set_lucky(arg1: int128):
         arg1 = 1
         arg1 = 3
+    """,
     """
+# wrong arg count
+contract Bar:
+    def bar(arg1: int128) -> bool: constant
 
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(contract_1), StructureException)
+@public
+def foo(a: address):
+    Bar(a).bar(1, 2)
+    """,
+    """
+# expected args, none given
+contract Bar:
+    def bar(arg1: int128) -> bool: constant
+
+@public
+def foo(a: address):
+    Bar(a).bar()
+    """,
+    """
+# expected no args, args given
+contract Bar:
+    def bar() -> bool: constant
+
+@public
+def foo(a: address):
+    Bar(a).bar(1)
+    """
+]
+
+
+@pytest.mark.parametrize('bad_code', FAILING_CONTRACTS_STRUCTURE_EXCEPTION)
+def test_bad_code_struct_exc(assert_compile_failed, get_contract_with_gas_estimation, bad_code):
+
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(bad_code), StructureException)
 
 
 def test_external__value_arg_without_return(w3, get_contract_with_gas_estimation):

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -61,7 +61,7 @@ def external_contract_call(node,
         sig,
         [Expr(arg, context).lll_node for arg in node.args],
         context,
-        pos=pos,
+        node.func,
     )
     output_placeholder, output_size, returner = get_external_contract_call_output(sig, context)
     sub = [

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -2,6 +2,7 @@ import itertools
 
 from vyper.exceptions import (
     ConstancyViolationException,
+    StructureException,
     TypeMismatchException,
 )
 from vyper.parser.lll_node import (
@@ -135,6 +136,7 @@ def call_self_private(stmt_expr, context, sig):
             push_local_vars = [['mload', pos] for pos in range(mem_from, mem_to, 32)]
             pop_local_vars = [['mstore', pos, 'pass'] for pos in range(mem_to-32, mem_from-32, -32)]
 
+
     # Push Arguments
     if expr_args:
         inargs, inargsize, arg_pos = pack_arguments(
@@ -197,6 +199,11 @@ def call_self_private(stmt_expr, context, sig):
         push_args += [
             ['mload', pos] for pos in reversed(range(arg_pos, static_pos, 32))
         ]
+    elif sig.args:
+        raise StructureException(
+            f"Wrong number of args for: {sig.name} (0 args given, expected {len(sig.args)})",
+            stmt_expr
+        )
 
     # Jump to function label.
     jump_to_func = [

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -136,15 +136,14 @@ def call_self_private(stmt_expr, context, sig):
             push_local_vars = [['mload', pos] for pos in range(mem_from, mem_to, 32)]
             pop_local_vars = [['mstore', pos, 'pass'] for pos in range(mem_to-32, mem_from-32, -32)]
 
-
     # Push Arguments
     if expr_args:
         inargs, inargsize, arg_pos = pack_arguments(
             sig,
             expr_args,
             context,
+            stmt_expr,
             return_placeholder=False,
-            pos=getpos(stmt_expr),
         )
         push_args += [inargs]  # copy arguments first, to not mess up the push/pop sequencing.
 
@@ -306,7 +305,7 @@ def call_self_public(stmt_expr, context, sig):
     # self.* style call to a public function.
     method_name, expr_args, sig = call_lookup_specs(stmt_expr, context)
     add_gas = sig.gas  # gas of call
-    inargs, inargsize, _ = pack_arguments(sig, expr_args, context, pos=getpos(stmt_expr))
+    inargs, inargsize, _ = pack_arguments(sig, expr_args, context, stmt_expr)
     output_placeholder, returner, output_size = call_make_placeholder(stmt_expr, context, sig)
     assert_call = [
         'assert',


### PR DESCRIPTION
### What I did
Added a check for calls to private functions where no args are given but the call expects args. Prior to this PR, the following code would compile:

```python
@private
def bar(a: int128) -> int128:
    return 1

@public
def foo() -> int128:
    return self.bar()
```

I also tweaked the inputs to `pack_arguments`, allowing for code highlights in the exceptions raised there.

### How I did it
* `vyper.parser.self_call.call_self_private`
  * added a check when no args are given that raises if args were expected
* `vyper.parser.parser_utils.pack_arguments`
   * replaced input arg `pos` with `stmt_expr`, derive position using `getpos(stmt_expr)`
   * include `stmt_expr` when raising exceptions
   

### How to verify it
Run the tests.  I've added tests to check for args when none should be given, no args when args should be given, and the wrong number of args.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/63635357-6bf21f00-c694-11e9-9c38-7736b9b211bb.png)

