### PR TITLE
Disallow self.* calls to public functions - round 2

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -156,7 +156,7 @@ Additionally, you may try to compile an example contract by running:
     vyper examples/crowdfund.vy
 
 If everything works correctly, you are now able to compile your own smart contracts written in Vyper.
-If any unexpected errors or exceptions are encountered, please feel free create an issue <https://github.com/ethereum/vyper/issues/new>.
+If any unexpected errors or exceptions are encountered, please feel free to `create an issue <https://github.com/ethereum/vyper/issues/new>`_.
 
 .. note::
     If you get the error `fatal error: openssl/aes.h: No such file or directory` in the output of `make`, then run `sudo apt-get install libssl-dev1`, then run `make` again.

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -36,27 +36,52 @@ Functions are the executable units of code within a contract.
     // ...
 
 Function calls can happen internally or externally and have different levels of visibility (see
-:ref:`structure-decorators`) towards other contracts. Functions must be decorated with either
-@public or @private.
+:ref:`structure-decorators`) towards other contracts. Functions must be explicitely declared as public or private.
+
+Public Functions
+----------------
+
+Public functions (decorated with ``@public``) are a part of the contract interface and may be called via transactions or from other contracts. They cannot be called internally.
+
+Public functions in Vyper are equivalent to external functions in Solidity.
+
+Private Functions
+-----------------
+
+Private functions (decorated with ``@private``) are only accessible from other functions within the same contract. They are called via the ``self`` variable:
+
+::
+
+    @private
+    def _times_two(amount: uint256) -> uint256:
+        return amount * 2
+
+    @public
+    def calculate(amount: uint256) -> uint256:
+        return self._times_two(amount)
+
+Private functions do not have access to ``msg.sender`` or ``msg.value``. If you require these values within a private function they must be passed as parameters.
 
 .. _structure-decorators:
 
 Decorators
 ----------
 
-============================= ===========================================
-Decorator                     Description
-============================= ===========================================
-`@public`                     Can be called from external contracts.
-`@private`                    Can only be called within current contract.
-`@constant`                   Does not alter contract state.
-`@payable`                    The contract is open to receive Ether.
-`@nonreentrant(<unique_key>)` Function can only be called once,
-                              both externally and internally. Used to
-                              prevent reentrancy attacks.
-============================= ===========================================
+The following decorators are available:
 
-The visibility decorators `@public` or `@private` are mandatory on function declarations, whilst the other decorators(@constant, @payable, @nonreentrant) are optional.
+=============================== ===========================================
+Decorator                       Description
+=============================== ===========================================
+``@public``                     Can only be called externally.
+``@private``                    Can only be called within current contract.
+``@constant``                   Does not alter contract state.
+``@payable``                    The contract is open to receive Ether.
+``@nonreentrant(<unique_key>)`` Function can only be called once,
+                                both externally and internally. Used to
+                                prevent reentrancy attacks.
+=============================== ===========================================
+
+The visibility decorators ``@public`` or ``@private`` are mandatory on function declarations, whilst the other decorators(``@constant``, ``@payable``, ``@nonreentrant``) are optional.
 
 Default function
 ----------------

--- a/docs/testing-contracts.rst
+++ b/docs/testing-contracts.rst
@@ -26,7 +26,7 @@ Vyper Contract and Basic Fixtures
 This is the base requirement to load a vyper contract and start testing. The last two fixtures are optional and will be
 discussed later. The rest of this chapter assumes, that you have this code set up in your ``conftest.py`` file.
 Alternatively, you can import the fixtures to ``conftest.py`` or use
-`pytest_plugins <https://docs.pytest.org/en/latest/plugins.html>`_.
+`pytest plugins <https://docs.pytest.org/en/latest/plugins.html>`_.
 
 Load Contract and Basic Tests
 =============================

--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -80,10 +80,8 @@ contract, we are provided with a built-in variable ``msg`` and we can access
 the public address of any method caller with ``msg.sender``. Similarly, the
 amount of ether a user sends can be accessed by calling ``msg.value``.
 
-.. warning:: ``msg.sender`` will change between internal function calls so that
-  if you're calling a function from the outside, it's correct for the first
-  function call. But then, for the function calls after, ``msg.sender`` will
-  reference the contract itself as opposed to the sender of the transaction.
+.. note:: ``msg.sender`` and ``msg.value`` can only be accessed from public
+  functions. If you require these values within a private function they must be passed as parameters.
 
 Here, we first check whether the current time is before the auction's end time
 using the ``assert`` function which takes any boolean statement. We also check
@@ -403,11 +401,9 @@ Let’s move onto the constructor.
   :language: python
   :pyobject: __init__
 
-.. warning:: Both ``msg.sender`` and ``msg.balance`` change between internal
-  function calls so that if you're calling a function from the outside, it's
-  correct for the first function call. But then, for the function calls after,
-  ``msg.sender`` and ``msg.balance`` reference the contract itself as opposed
-  to the sender of the transaction.
+.. note:: ``msg.sender`` and ``msg.value`` can only be accessed from public
+  functions. If you require these values within a private function they must be
+  passed as parameters.
 
 In the constructor, we hard-coded the contract to accept an
 array argument of exactly two proposal names of type ``bytes32`` for the contracts
@@ -426,6 +422,8 @@ Now that the initial setup is done, lets take a look at the functionality.
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
   :pyobject: giveRightToVote
+
+.. note:: Throughout this contract, we use a pattern where ``@public`` functions return data from ``@private`` functions that have the same name prepended with an underscore. This is because Vyper does not allow calls between public functions within the same contract. The private function handles the logic and allows internal access, while the public function acts as a getter to allow external viewing.
 
 We need a way to control who has the ability to vote. The method
 ``giveRightToVote()`` is a method callable by only the chairperson by taking

--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -469,12 +469,14 @@ is a read-only function and we benefit by saving gas fees.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: winningProposal
+  :lines: 153-170
 
-The ``winningProposal()`` method returns the key of proposal in the ``proposals``
+The ``_winningProposal()`` method returns the key of proposal in the ``proposals``
 mapping. We will keep track of greatest number of votes and the winning
 proposal with the variables ``winningVoteCount`` and ``winningProposal``,
 respectively by looping through all the proposals.
+
+``winningProposal()`` is a public function allowing external access to ``_winningProposal()``.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
@@ -510,6 +512,8 @@ Let's get started.
   :language: python
   :linenos:
 
+.. note:: Throughout this contract, we use a pattern where ``@public`` functions return data from ``@private`` functions that have the same name prepended with an underscore. This is because Vyper does not allow calls between public functions within the same contract. The private function handles the logic and allows internal access, while the public function acts as a getter to allow external viewing.
+
 The contract contains a number of methods that modify the contract state as
 well as a few 'getter' methods to read it. We first declare several events
 that the contract logs. We then declare our global variables, followed by
@@ -517,7 +521,7 @@ function definitions.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :lines: 7-13
+  :lines: 11-18
 
 We initiate the ``company`` variable to be of type ``address`` that's public.
 The ``totalShares`` variable is of type ``currency_value``, which in this case
@@ -537,16 +541,18 @@ company's address is initialized to hold all shares of the company in the
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: stockAvailable
+  :lines: 33-44
 
 We will be seeing a few ``@constant`` decorators in this contract—which is
 used to decorate methods that simply read the contract state or return a simple
 calculation on the contract state without modifying it. Remember, reading the
 blockchain is free, writing on it is not. Since Vyper is a statically typed
-language, we see an arrow following the definition of the ``stockAvailable()``
+language, we see an arrow following the definition of the ``_stockAvailable()``
 method, which simply represents the data type which the function is expected
 to return. In the method, we simply key into ``self.holdings`` with the
-company's address and check it's holdings.
+company's address and check it's holdings.  Because ``_stockAvailable()`` is a
+private method, we also include the public ``stockAvailable()`` method to allow
+external access.
 
 Now, lets take a look at a method that lets a person buy stock from the
 company's holding.
@@ -564,10 +570,11 @@ Now that people can buy shares, how do we check someone's holdings?
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: getHolding
+  :lines: 63-74
 
-The ``getHolding()`` is another ``@constant`` method that takes an ``address``
+The ``_getHolding()`` is another ``@constant`` method that takes an ``address``
 and returns its corresponding stock holdings by keying into ``self.holdings``.
+Again, a public function ``getHolding()`` is included to allow external access.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
@@ -611,11 +618,11 @@ sends its ether to an address.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: debt
+  :lines: 129-140
 
 We can also check how much the company has raised by multiplying the number of
-shares the company has sold and the price of each share. We can get this value
-by calling the ``debt()`` method.
+shares the company has sold and the price of each share. Internally, we get
+this value by calling the ``_debt()`` method. Externally it is accessed via ``debt()``.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python

--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -153,7 +153,7 @@ def set_greeting(_greeting: bytes[20]):
     if a + b + c + d + 3 == 1337:
         self.greeting = _greeting
 
-@public
+@private
 @constant
 def construct(greet: bytes[20]) -> bytes[40]:
     return concat(self.greeting, greet)

--- a/tests/parser/features/external_contracts/test_self_call_struct.py
+++ b/tests/parser/features/external_contracts/test_self_call_struct.py
@@ -9,7 +9,7 @@ struct MyStruct:
     e1: decimal
     e2: timestamp
 
-@public
+@private
 @constant
 def get_my_struct(_e1: decimal, _e2: timestamp) -> MyStruct:
     return MyStruct({e1: _e1, e2: _e2})

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -420,6 +420,30 @@ def bar(a: int128) -> int128:
 @public
 def foo() -> int128:
     return self.bar(1, 2)
+    """,
+    """
+# should not compile - public to public
+@public
+def bar() -> int128:
+    return 1
+
+@public
+def foo() -> int128:
+    return self.bar()
+    """,
+    """
+# should not compile - private to public
+@public
+def bar() -> int128:
+    return 1
+
+@private
+def _baz() -> int128:
+    return self.bar()
+
+@public
+def foo() -> int128:
+    return self._baz()
     """
 ]
 

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -15,13 +15,13 @@ from vyper.exceptions import (
 
 def test_selfcall_code(get_contract_with_gas_estimation):
     selfcall_code = """
-@public
-def foo() -> int128:
+@private
+def _foo() -> int128:
     return 3
 
 @public
 def bar() -> int128:
-    return self.foo()
+    return self._foo()
     """
 
     c = get_contract_with_gas_estimation(selfcall_code)
@@ -32,15 +32,15 @@ def bar() -> int128:
 
 def test_selfcall_code_2(get_contract_with_gas_estimation, keccak):
     selfcall_code_2 = """
-@public
-def double(x: int128) -> int128:
+@private
+def _double(x: int128) -> int128:
     return x * 2
 
 @public
 def returnten() -> int128:
-    return self.double(5)
+    return self._double(5)
 
-@public
+@private
 def _hashy(x: bytes32) -> bytes32:
     return keccak256(x)
 
@@ -58,7 +58,7 @@ def return_hash_of_rzpadded_cow() -> bytes32:
 
 def test_selfcall_code_3(get_contract_with_gas_estimation, keccak):
     selfcall_code_3 = """
-@public
+@private
 def _hashy2(x: bytes[100]) -> bytes32:
     return keccak256(x)
 
@@ -66,7 +66,7 @@ def _hashy2(x: bytes[100]) -> bytes32:
 def return_hash_of_cow_x_30() -> bytes32:
     return self._hashy2(b"cowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcow")  # noqa: E501
 
-@public
+@private
 def _len(x: bytes[100]) -> int128:
     return len(x)
 
@@ -84,37 +84,37 @@ def returnten() -> int128:
 
 def test_selfcall_code_4(get_contract_with_gas_estimation):
     selfcall_code_4 = """
-@public
-def summy(x: int128, y: int128) -> int128:
+@private
+def _summy(x: int128, y: int128) -> int128:
     return x + y
 
-@public
-def catty(x: bytes[5], y: bytes[5]) -> bytes[10]:
+@private
+def _catty(x: bytes[5], y: bytes[5]) -> bytes[10]:
     return concat(x, y)
 
-@public
-def slicey1(x: bytes[10], y: int128) -> bytes[10]:
+@private
+def _slicey1(x: bytes[10], y: int128) -> bytes[10]:
     return slice(x, start=0, len=y)
 
-@public
-def slicey2(y: int128, x: bytes[10]) -> bytes[10]:
+@private
+def _slicey2(y: int128, x: bytes[10]) -> bytes[10]:
     return slice(x, start=0, len=y)
 
 @public
 def returnten() -> int128:
-    return self.summy(3, 7)
+    return self._summy(3, 7)
 
 @public
 def return_mongoose() -> bytes[10]:
-    return self.catty(b"mon", b"goose")
+    return self._catty(b"mon", b"goose")
 
 @public
 def return_goose() -> bytes[10]:
-    return self.slicey1(b"goosedog", 5)
+    return self._slicey1(b"goosedog", 5)
 
 @public
 def return_goose2() -> bytes[10]:
-    return self.slicey2(5, b"goosedog")
+    return self._slicey2(5, b"goosedog")
     """
 
     c = get_contract_with_gas_estimation(selfcall_code_4)
@@ -130,14 +130,14 @@ def test_selfcall_code_5(get_contract_with_gas_estimation):
     selfcall_code_5 = """
 counter: int128
 
-@public
-def increment():
+@private
+def _increment():
     self.counter += 1
 
 @public
 def returnten() -> int128:
     for i in range(10):
-        self.increment()
+        self._increment()
     return self.counter
     """
     c = get_contract_with_gas_estimation(selfcall_code_5)
@@ -150,22 +150,22 @@ def test_selfcall_code_6(get_contract_with_gas_estimation):
     selfcall_code_6 = """
 excls: bytes[32]
 
-@public
-def set_excls(arg: bytes[32]):
+@private
+def _set_excls(arg: bytes[32]):
     self.excls = arg
 
-@public
-def underscore() -> bytes[1]:
+@private
+def _underscore() -> bytes[1]:
     return b"_"
 
-@public
-def hardtest(x: bytes[100], y: int128, z: int128, a: bytes[100], b: int128, c: int128) -> bytes[201]:  # noqa: E501
-    return concat(slice(x, start=y, len=z), self.underscore(), slice(a, start=b, len=c))
+@private
+def _hardtest(x: bytes[100], y: int128, z: int128, a: bytes[100], b: int128, c: int128) -> bytes[201]:  # noqa: E501
+    return concat(slice(x, start=y, len=z), self._underscore(), slice(a, start=b, len=c))
 
 @public
 def return_mongoose_revolution_32_excls() -> bytes[201]:
-    self.set_excls(b"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    return self.hardtest("megamongoose123", 4, 8, concat(b"russian revolution", self.excls), 8, 42)
+    self._set_excls(b"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    return self._hardtest("megamongoose123", 4, 8, concat(b"russian revolution", self.excls), 8, 42)
     """
 
     c = get_contract_with_gas_estimation(selfcall_code_6)
@@ -176,29 +176,33 @@ def return_mongoose_revolution_32_excls() -> bytes[201]:
 
 def test_list_call(get_contract_with_gas_estimation):
     code = """
-@public
-def foo0(x: int128[2]) -> int128:
+@private
+def _foo0(x: int128[2]) -> int128:
     return x[0]
 
-@public
-def foo1(x: int128[2]) -> int128:
+@private
+def _foo1(x: int128[2]) -> int128:
     return x[1]
 
 
 @public
+def foo1(x: int128[2]) -> int128:
+    return self._foo1(x)
+
+@public
 def bar() -> int128:
     x: int128[2]
-    return self.foo0(x)
+    return self._foo0(x)
 
 @public
 def bar2() -> int128:
     x: int128[2] = [55, 66]
-    return self.foo0(x)
+    return self._foo0(x)
 
 @public
 def bar3() -> int128:
     x: int128[2] = [55, 66]
-    return self.foo1(x)
+    return self._foo1(x)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -212,12 +216,12 @@ def test_list_storage_call(get_contract_with_gas_estimation):
     code = """
 y: int128[2]
 
-@public
-def foo0(x: int128[2]) -> int128:
+@private
+def _foo0(x: int128[2]) -> int128:
     return x[0]
 
-@public
-def foo1(x: int128[2]) -> int128:
+@private
+def _foo1(x: int128[2]) -> int128:
     return x[1]
 
 @public
@@ -226,11 +230,11 @@ def set():
 
 @public
 def bar0() -> int128:
-    return self.foo0(self.y)
+    return self._foo0(self.y)
 
 @public
 def bar1() -> int128:
-    return self.foo1(self.y)
+    return self._foo1(self.y)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -241,60 +245,64 @@ def bar1() -> int128:
 
 def test_multi_arg_list_call(get_contract_with_gas_estimation):
     code = """
-@public
-def foo0(y: decimal, x: int128[2]) -> int128:
+@private
+def _foo0(y: decimal, x: int128[2]) -> int128:
     return x[0]
 
-@public
-def foo1(x: int128[2], y: decimal) -> int128:
+@private
+def _foo1(x: int128[2], y: decimal) -> int128:
     return x[1]
 
-@public
-def foo2(y: decimal, x: int128[2]) -> decimal:
+@private
+def _foo2(y: decimal, x: int128[2]) -> decimal:
     return y
 
-@public
-def foo3(x: int128[2], y: decimal) -> int128:
+@private
+def _foo3(x: int128[2], y: decimal) -> int128:
     return x[0]
 
-@public
-def foo4(x: int128[2], y: int128[2]) -> int128:
+@private
+def _foo4(x: int128[2], y: int128[2]) -> int128:
     return y[0]
 
 
 @public
+def foo1(x: int128[2], y: decimal) -> int128:
+    return self._foo1(x, y)
+
+@public
 def bar() -> int128:
     x: int128[2]
-    return self.foo0(0.3434, x)
+    return self._foo0(0.3434, x)
 
 # list as second parameter
 @public
 def bar2() -> int128:
     x: int128[2] = [55, 66]
-    return self.foo0(0.01, x)
+    return self._foo0(0.01, x)
 
 @public
 def bar3() -> decimal:
     x: int128[2] = [88, 77]
-    return self.foo2(1.33, x)
+    return self._foo2(1.33, x)
 
 # list as first parameter
 @public
 def bar4() -> int128:
     x: int128[2] = [88, 77]
-    return self.foo1(x, 1.33)
+    return self._foo1(x, 1.33)
 
 @public
 def bar5() -> int128:
     x: int128[2] = [88, 77]
-    return self.foo3(x, 1.33)
+    return self._foo3(x, 1.33)
 
 # two lists
 @public
 def bar6() -> int128:
     x: int128[2] = [88, 77]
     y: int128[2] = [99, 66]
-    return self.foo4(x, y)
+    return self._foo4(x, y)
 
     """
 
@@ -309,12 +317,12 @@ def bar6() -> int128:
 
 def test_multi_mixed_arg_list_call(get_contract_with_gas_estimation):
     code = """
-@public
-def fooz(x: int128[2], y: decimal, z: int128[2], a: decimal) -> int128:
+@private
+def _fooz(x: int128[2], y: decimal, z: int128[2], a: decimal) -> int128:
     return z[1]
 
-@public
-def fooa(x: int128[2], y: decimal, z: int128[2], a: decimal) -> decimal:
+@private
+def _fooa(x: int128[2], y: decimal, z: int128[2], a: decimal) -> decimal:
     return a
 
 @public
@@ -324,7 +332,7 @@ def bar() -> (int128, decimal):
     z: int128[2] = [55, 66]
     a: decimal = 66.77
 
-    return self.fooz(x, y, z, a), self.fooa(x, y, z, a)
+    return self._fooz(x, y, z, a), self._fooa(x, y, z, a)
     """
     c = get_contract_with_gas_estimation(code)
     assert c.bar() == [66, Decimal('66.77')]
@@ -356,17 +364,18 @@ def bar2() -> int128:
 
 def test_multi_mixed_arg_list_bytes_call(get_contract_with_gas_estimation):
     code = """
-@public
-def fooz(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> bytes[11]:
+@private
+def _fooz(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> bytes[11]:
     return z
 
-@public
-def fooa(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> decimal:
+@private
+def _fooa(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> decimal:
     return a
 
-@public
-def foox(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> int128:
+@private
+def _foox(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> int128:
     return x[1]
+
 
 @public
 def bar() -> (bytes[11], decimal, int128):
@@ -375,7 +384,7 @@ def bar() -> (bytes[11], decimal, int128):
     z: bytes[11] = b"hello world"
     a: decimal = 66.77
 
-    return self.fooz(x, y, z, a), self.fooa(x, y, z, a), self.foox(x, y, z, a)
+    return self._fooz(x, y, z, a), self._fooa(x, y, z, a), self._foox(x, y, z, a)
     """
     c = get_contract_with_gas_estimation(code)
     assert c.bar() == [b"hello world", Decimal('66.77'), 44]

--- a/tests/parser/features/test_logging_from_call.py
+++ b/tests/parser/features/test_logging_from_call.py
@@ -3,12 +3,12 @@ def test_log_dynamic_static_combo(get_logs, get_contract_with_gas_estimation, w3
     code = """
 TestLog: event({testData1: bytes32,testData2: bytes[60], testData3: bytes[8]})
 
-@public
+@private
 @constant
 def to_bytes(value: uint256) -> bytes[8]:
     return slice(concat(b"", convert(value, bytes32)), start=24, len=8)
 
-@public
+@private
 @constant
 def to_bytes32(value: uint256) -> bytes32:
     return convert(value, bytes32)
@@ -44,12 +44,12 @@ def test_log_dynamic_static_combo2(get_logs, get_contract, w3):
     code = """
 TestLog: event({testData1: bytes32,testData2: bytes[133], testData3: bytes[8] })
 
-@public
+@private
 @constant
 def to_bytes(value: uint256) -> bytes[8]:
     return slice(concat(b"", convert(value, bytes32)), start=24, len=8)
 
-@public
+@private
 @constant
 def to_bytes32(value: uint256) -> bytes32:
     return convert(value, bytes32)
@@ -82,7 +82,7 @@ def test_log_single_function_call(get_logs, get_contract, w3):
     code = """
 TestLog: event({testData1: bytes32, testData2: bytes[133]})
 
-@public
+@private
 @constant
 def to_bytes32(value: uint256) -> bytes32:
     return convert(value, bytes32)
@@ -112,7 +112,7 @@ def test_original_problem_function(get_logs, get_contract, w3):
     code = """
 TestLog: event({testData1: bytes32,testData2: bytes[2064], testData3: bytes[8] })
 
-@public
+@private
 @constant
 def to_bytes(value: uint256) -> bytes[8]:
     return slice(concat(b"", convert(value, bytes32)), start=24, len=8)

--- a/tests/parser/features/test_units.py
+++ b/tests/parser/features/test_units.py
@@ -103,7 +103,7 @@ def foo(a: uint256, b: uint256, c: uint256) -> uint256:
 
 def test_function_call_explicit_unit_literal(get_contract, assert_compile_failed):
     code = """
-@public
+@private
 def unit_func(a: uint256(wei)) -> uint256(wei):
     return a + 1
 

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -83,19 +83,21 @@ def out_literals() -> (int128, address, bytes[6]):
 
 def test_return_tuple_assign(get_contract_with_gas_estimation):
     code = """
-@public
-def out_literals() -> (int128, address, bytes[10]):
+@private
+def _out_literals() -> (int128, address, bytes[10]):
     return 1, 0x0000000000000000000000000000000000000000, b"random"
 
+@public
+def out_literals() -> (int128, address, bytes[10]):
+    return self._out_literals()
 
 @public
 def test() -> (int128, address, bytes[10]):
     a: int128
     b: address
     c: bytes[10]
-    (a, b, c) = self.out_literals()
+    (a, b, c) = self._out_literals()
     return a, b, c
-
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -110,26 +112,29 @@ b: address
 c: bytes[20]
 d: bytes[20]
 
-@public
-def out_literals() -> (int128, bytes[20], address, bytes[20]):
+@private
+def _out_literals() -> (int128, bytes[20], address, bytes[20]):
     return 1, b"testtesttest", 0x0000000000000000000000000000000000000023, b"random"
 
+@public
+def out_literals() -> (int128, bytes[20], address, bytes[20]):
+    return self._out_literals()
 
 @public
 def test1() -> (int128, bytes[20], address, bytes[20]):
-    self.a, self.c, self.b, self.d = self.out_literals()
+    self.a, self.c, self.b, self.d = self._out_literals()
     return self.a, self.c, self.b, self.d
 
 @public
 def test2() -> (int128, address):
     x: int128
-    x, self.c, self.b, self.d = self.out_literals()
+    x, self.c, self.b, self.d = self._out_literals()
     return x, self.b
 
 @public
 def test3() -> (address, int128):
     x: address
-    self.a, self.c, x, self.d = self.out_literals()
+    self.a, self.c, x, self.d = self._out_literals()
     return x, self.a
     """
 

--- a/tests/parser/integration/test_basics.py
+++ b/tests/parser/integration/test_basics.py
@@ -23,7 +23,7 @@ def foo(x: int128) -> int128:
 
 def test_selfcall_code_3(get_contract_with_gas_estimation, keccak):
     selfcall_code_3 = """
-@public
+@private
 def _hashy2(x: bytes[100]) -> bytes32:
     return keccak256(x)
 
@@ -31,7 +31,7 @@ def _hashy2(x: bytes[100]) -> bytes32:
 def return_hash_of_cow_x_30() -> bytes32:
     return self._hashy2("cowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcow")  # noqa: E501
 
-@public
+@private
 def _len(x: bytes[100]) -> int128:
     return len(x)
 

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -213,7 +213,7 @@ def foo():
 """)
 
 must_succeed("""
-@public
+@private
 def foo():
     pass
 

--- a/tests/parser/syntax/test_send.py
+++ b/tests/parser/syntax/test_send.py
@@ -90,7 +90,7 @@ def foo():
     """,
     """
 # Test custom send method
-@public
+@private
 def send(a: address, w: wei_value):
     send(0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe, 1)
 

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -22,7 +22,7 @@ def test():
     a, b, c = 1, 2, 3
     """, VariableDeclarationException),
     """
-@public
+@private
 def out_literals() -> (int128, int128, bytes[10]):
     return 1, 2, b"3333"
 
@@ -34,7 +34,7 @@ def test() -> (int128, address, bytes[10]):
     return a, b, c
     """,
     """
-@public
+@private
 def out_literals() -> (int128, int128, bytes[10]):
     return 1, 2, b"3333"
 
@@ -46,7 +46,7 @@ def test() -> (int128, address, bytes[10]):
     return
     """,
     """
-@public
+@private
 def out_literals() -> (int128, int128, int128):
     return 1, 2, 3
 
@@ -59,7 +59,7 @@ def test() -> (int128, int128, bytes[10]):
     return a, b, c
     """,
     """
-@public
+@private
 def out_literals() -> (int128, int128, bytes[100]):
     return 1, 2, b"test"
 

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -47,6 +47,10 @@ def external_contract_call(node,
             f'Contract "{contract_name}" not declared yet',
             node
         )
+    if contract_address.value == "address":
+        raise StructureException(
+            f"External calls to self are not permitted.", node
+        )
     method_name = node.func.attr
     if method_name not in context.sigs[contract_name]:
         raise FunctionDeclarationException(

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -64,10 +64,10 @@ def make_call(stmt_expr, context):
             getpos(stmt_expr)
         )
 
-    if sig.private:
-        return call_self_private(stmt_expr, context, sig)
-    else:
-        return call_self_public(stmt_expr, context, sig)
+    if not sig.private:
+        raise StructureException("Cannot call public functions via 'self'", stmt_expr)
+
+    return call_self_private(stmt_expr, context, sig)
 
 
 def call_make_placeholder(stmt_expr, context, sig):
@@ -296,32 +296,6 @@ def call_self_private(stmt_expr, context, sig):
         pos=getpos(stmt_expr),
         annotation='Internal Call: %s' % method_name,
         add_gas_estimate=sig.gas
-    )
-    o.gas += sig.gas
-    return o
-
-
-def call_self_public(stmt_expr, context, sig):
-    # self.* style call to a public function.
-    method_name, expr_args, sig = call_lookup_specs(stmt_expr, context)
-    add_gas = sig.gas  # gas of call
-    inargs, inargsize, _ = pack_arguments(sig, expr_args, context, stmt_expr)
-    output_placeholder, returner, output_size = call_make_placeholder(stmt_expr, context, sig)
-    # don't have to use static call, trust self-call since constancy analysis
-    # already propagates.
-    assert_call = [
-        'assert',
-        ['call', ['gas'], ['address'], 0, inargs, inargsize, output_placeholder, output_size],
-    ]
-    if output_size > 0:
-        assert_call = ['seq', assert_call, returner]
-    o = LLLnode.from_list(
-        assert_call,
-        typ=sig.output_type,
-        location='memory',
-        pos=getpos(stmt_expr),
-        add_gas_estimate=add_gas,
-        annotation='Internal Call: %s' % method_name,
     )
     o.gas += sig.gas
     return o


### PR DESCRIPTION
### What I did
Prevent calls to public functions via `self` - fixes #1199

This is an amended version of #1561 without the awful mess I made rebasing.

### How I did it
* In `vyper/parser/self_call.py`, raise `StructureException` where previously there was a call to `call_self_public`
* Update tests
* Update examples
* Update documentation

### How to verify it
Run the tests.

### Description for the changelog
* Disallow calls to public functions via self

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/63647648-103c9a00-c757-11e9-9975-47a30ea8e6ad.png)
