### PR TITLE
Build process was missing git as a dependency for containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 # coincurve requires libgmp
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-utils gcc libc6-dev libc-dev libssl-dev libgmp-dev && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+        apt-utils \
+        gcc \
+        git \
+        libc6-dev \
+        libc-dev \
+        libssl-dev \
+        libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD . /code
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ parts:
       - --prefix=/usr
     build-packages:
       - gcc
+      - git
       - libreadline-dev
       - libncursesw5-dev
       - zlib1g-dev


### PR DESCRIPTION
Wasn't able to build snap or docker images for the library, noticed the `git` subprocess was failing because it wasn't installed