### PR TITLE
Added markdown content type for readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     version='0.1.0-beta.12',
     description='Vyper Programming Language for Ethereum',
     long_description_markdown_filename='README.md',
+    long_description_content_type='text/markdown',
     author='Vitalik Buterin',
     author_email='',
     url='https://github.com/ethereum/vyper',


### PR DESCRIPTION
For a while now, I noticed the main docs page doesn't render quite effectively. I realized that the field 'long_description_markdown_filename' does not automatically set the content type to markdown, and instead it is rST. This should fix the problem of proper rendering in the docs.