### PR TITLE
Added more detailed release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 
 ifeq (, $(shell which pip3))
 	pip := $(shell which pip3)
@@ -63,7 +64,11 @@ clean-snap: $(vyper-snap)
 endif
 
 release: clean
-	bumpversion devnum
-	git push upstream && git push upstream --tags
+	@echo -n "Bump the part number? [y/N]: "
+	@read line; if [ $$line == "y" ]; then \
+		bumpversion devnum; \
+		git push upstream && git push upstream --tags; \
+	 fi
 	python setup.py sdist bdist_wheel
+	twine check dist/*
 	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ docker-build:
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` .
 
+# Get the part number from the built docker image, before the '+' symbol
+docker-release:
+	docker login
+	docker push vyper:latest
+	docker push vyper:$(firstword $(subst +, ,$(shell docker run vyper --version)))
+
 snap-build:
 	snapcraft
 

--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,27 @@ snap-release: $(vyper-snap)
 	snapcraft push $<
 endif
 
-release: clean
+# Asks to bump the dev partnumber
+# TODO Use semver automatic versioning via git log
+git-tag:
 	@echo -n "Bump the part number? [y/N]: "
 	@read line; if [ $$line == "y" ]; then \
 		bumpversion devnum; \
 		git push upstream && git push upstream --tags; \
 	 fi
+
+pypi-build:
 	python setup.py sdist bdist_wheel
+
+pypi-release:
 	twine check dist/*
 	twine upload dist/*
+
+release: clean
+	$(MAKE) git-tag
+	$(MAKE) snap-build
+	$(MAKE) snap-release
+	$(MAKE) docker-build
+	$(MAKE) docker-release
+	$(MAKE) pypi-build
+	$(MAKE) pypi-release

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ docker-build:
 # Get the part number from the built docker image, before the '+' symbol
 docker-release:
 	docker login
+	docker tag vyper ethereum/vyper:latest
 	docker push ethereum/vyper:latest
+	docker tag vyper ethereum/vyper:$(firstword $(subst +, ,$(shell docker run vyper --version)))
 	docker push ethereum/vyper:$(firstword $(subst +, ,$(shell docker run vyper --version)))
 
 snap-build:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 lint:
 	tox -e lint
 
-clean: clean-build clean-pyc clean-test
+clean: clean-build clean-pyc clean-snap clean-test
 
 clean-build:
 	rm -fr build/
@@ -54,13 +54,14 @@ snap-build:
 
 vyper-snap := $(wildcard vyper*.snap)
 
+clean-snap: $(vyper-snap)
+	snapcraft clean
 ifdef vyper-snap
+	rm -fr $<
+
 snap-release: $(vyper-snap)
 	snapcraft login
 	snapcraft push $<
-
-clean-snap: $(vyper-snap)
-	rm -fr $<
 endif
 
 release: clean

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,18 @@ pypi-release:
 	twine upload dist/*
 
 release: clean
+ifndef SKIP_TAG
 	$(MAKE) git-tag
+endif
+ifndef SKIP_SNAP
 	$(MAKE) snap-build
 	$(MAKE) snap-release
+endif
+ifndef SKIP_DOCKER
 	$(MAKE) docker-build
 	$(MAKE) docker-release
+endif
+ifndef SKIP_PYPI
 	$(MAKE) pypi-build
 	$(MAKE) pypi-release
+endif

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,21 @@ lint:
 clean: clean-build clean-pyc clean-snap clean-test
 
 clean-build:
-	rm -fr build/
-	rm -fr dist/
-	rm -fr *.egg-info
+	@echo Cleaning python build files...
+	@rm -fr build/
+	@rm -fr dist/
+	@rm -fr *.egg-info
 
 clean-pyc:
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rmdir {} +
+	@echo Cleaning python files...
+	@find . -name '*.pyc' -exec rm -f {} +
+	@find . -name '*.pyo' -exec rm -f {} +
+	@find . -name '*~' -exec rm -f {} +
+	@find . -name '__pycache__' -exec rmdir {} +
 
 clean-test:
-	find . -name 'htmlcov' -exec rm -rf {} +
+	@echo Cleaning test files...
+	@find . -name 'htmlcov' -exec rm -rf {} +
 
 docs:
 	rm -f docs/vyper.rst
@@ -61,9 +64,10 @@ snap-build:
 vyper-snap := $(wildcard vyper*.snap)
 
 clean-snap: $(vyper-snap)
-	snapcraft clean
+	@echo Cleaning snapcraft build files...
+	@snapcraft clean
 ifdef vyper-snap
-	rm -fr $<
+	@rm -fr $<
 
 snap-release: $(vyper-snap)
 	snapcraft login

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ docker-build:
 # Get the part number from the built docker image, before the '+' symbol
 docker-release:
 	docker login
-	docker push vyper:latest
-	docker push vyper:$(firstword $(subst +, ,$(shell docker run vyper --version)))
+	docker push ethereum/vyper:latest
+	docker push ethereum/vyper:$(firstword $(subst +, ,$(shell docker run vyper --version)))
 
 snap-build:
 	snapcraft


### PR DESCRIPTION
### What I did
Cleaned up and added commands for an explicit release process, which should make it easier to perform correctly.

Biggest changes were:
- Ask whether to apply devnum part number change and push new tag upstream
- Split release process into pypi, snapcraft, and docker release processes
- Added new clean rules

### How to verify it
Perform it yourself!

Note: All login credentials must be provided separately during the login steps of each build platform release step.

### Cute Animal Picture
![Cute koala](https://i.ytimg.com/vi/vvmMxju9xNE/maxresdefault.jpg)