### PR TITLE
CLI - Allow compiling contracts outside of root path

### DIFF
--- a/tests/cli/vyper_compile/test_import_paths.py
+++ b/tests/cli/vyper_compile/test_import_paths.py
@@ -228,3 +228,15 @@ def test_get_interface_file_path(tmp_path):
 
     with pytest.raises(Exception):
         get_interface_file_path(base_paths, 'potato')
+
+
+def test_compile_outside_root_path(tmp_path):
+    foo_path = tmp_path.joinpath('foo.vy')
+    with foo_path.open('w') as fp:
+        fp.write(FOO_CODE.format('import bar as Bar'))
+
+    bar_path = tmp_path.joinpath('bar.vy')
+    with bar_path.open('w') as fp:
+        fp.write(BAR_CODE)
+
+    assert compile_files([foo_path, bar_path], ['combined_json'], root_folder=".")

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -167,7 +167,7 @@ def get_interface_codes(root_path: Path, codes: ContractCodes) -> Any:
         for interface_name, interface_path in interface_codes.items():
 
             base_paths = [parent_path]
-            if not interface_path.startswith('.'):
+            if not interface_path.startswith('.') and root_path.joinpath(file_path).exists():
                 base_paths.append(root_path)
             elif interface_path.startswith('../') and parent_path == root_path:
                 raise FileNotFoundError(
@@ -199,7 +199,7 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
         if suffix:
             return file_path.with_suffix(suffix)
     raise Exception(
-        f'Imported interface "{import_path}{{.vy,.json}}" does not exist.'
+        f'Cannot locate interface "{import_path}{{.vy,.json}}"'
     )
 
 
@@ -217,8 +217,11 @@ def compile_files(input_files: Iterable[str],
 
     codes: ContractCodes = OrderedDict()
     for file_name in input_files:
-        file_path = Path(file_name).resolve()
-        file_str = file_path.relative_to(root_path).as_posix()
+        file_path = Path(file_name)
+        try:
+            file_str = file_path.resolve().relative_to(root_path).as_posix()
+        except ValueError:
+            file_str = file_path.as_posix()
         with file_path.open() as fh:
             codes[file_str] = fh.read()
 


### PR DESCRIPTION
### What I did
When using the `vyper` command line script, allow contract paths outside of the root path

### How I did it
If a contract path is given that is outside of the root path, vyper still attempts to compile it but does not search for interfaces from the root path.

### How to verify it
I added a test case to `vyper/cli/test_import_paths.py`.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/63992518-d258c080-cb1e-11e9-9cef-638643853c00.png)
