### PR TITLE
Add check for only single @+@nonreentrant decorator.

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -185,6 +185,13 @@ struct S:
     x: int128
 s: S = S()
     """,
+    """
+@public
+@nonreentrant("B")
+@nonreentrant("C")
+def double_nonreentrant():
+    pass
+    """
 ]
 
 

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -236,6 +236,11 @@ class FunctionSignature:
             elif isinstance(dec, ast.Name) and dec.id == "public":
                 public = True
             elif isinstance(dec, ast.Call) and dec.func.id == "nonreentrant":
+                if nonreentrant_key:
+                    raise StructureException(
+                        "Only one @nonreentrant decorator allowed per function",
+                        dec
+                    )
                 if dec.args and len(dec.args) == 1 and isinstance(dec.args[0], ast.Str) and dec.args[0].s:  # noqa: E501
                     nonreentrant_key = dec.args[0].s
                 else:


### PR DESCRIPTION
### What I did
As the code currently stands, only a single nonreentrant decorator is supported.
### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://cdn.thefunnybeaver.com/wp-content/uploads/2016/12/Super-Funny-And-Cute-Animal-Pictures-026.jpg)
