### PR TITLE
Add vyper-json CLI tool

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -1,25 +1,250 @@
 Compiling a Contract
-####################
+********************
 
-To compile a contract, use:
-::
+Command-Line Tools
+==================
 
-    vyper yourFileName.vy
+Vyper includes the following command-line scripts for compiling contracts:
 
-You can also compile to other formats such as ABI using the below format:
-::
-
-    vyper -f ['abi', 'bytecode', 'bytecode_runtime', 'ir', 'asm', 'source_map', 'method_identifiers', 'combined_json'] yourFileName.vy
-
-It is also possible to use the `-f json` option, which is a legacy alias for `-f abi`.
+* ``vyper``: Compiles vyper contract files into ``LLL`` or bytecode
+* ``vyper-json``: Provides a JSON interface to the compiler
 
 .. note::
-    Since `.vy` is not officially a language supported by any syntax highlighters or linters,
-    it is recommended to name your Vyper file ending with `.py` in order to have Python syntax highlighting.
 
-An `online compiler <https://vyper.online/>`_ is available as well, which lets you experiment with
-the language without having to install Vyper. The online compiler allows you to compile to ``bytecode`` and/or ``LLL``.
+    The ``--help`` flag gives verbose explanations of how to use each of these scripts.
+
+vyper
+-----
+
+``vyper`` provides command-line access to the compiler. It can generate various outputs including simple binaries, ASTs, interfaces and source mappings.
+
+To compile a contract:
+
+::
+
+    $ vyper yourFileName.vy
+
+
+Include the ``-f`` flag to specify which output formats to return. Use ``vyper --help`` for a full list of output options.
+
+::
+
+    $ vyper -f abi,bytecode,bytecode_runtime,ir,asm,source_map,method_identifiers yourFileName.vy
+
+The ``-p`` flag allows you to set a root path that is used when searching for interface files to import.  If none is given, it will default to the current working directory. See :ref:`searching_for_imports` for more information.
+
+::
+
+    $ vyper -p yourProject yourProject/yourFileName.vy
+
+
+vyper-json
+----------
+
+``vyper-json`` provides a JSON interface for the compiler. It expects a JSON formatted input and returns the compilation result in a JSON formatted output.
+
+Where possible, the JSON formats used by this script follow those of `Solidity <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description>`_.
+
+To compile from JSON supplied via ``stdin``:
+
+::
+
+    $ vyper-json
+
+To compile from a JSON file:
+
+::
+
+    $ vyper-json yourProject.json
+
+By default, the output is sent to ``stdout``. To redirect to a file, use the ``-o`` flag:
+
+::
+
+    $ vyper-json -o compiled.json
+
+Input JSON Description
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following example describes the expected input format of ``vyper-json``. Comments are of course not permitted and used here only for explanatory purposes.
+
+.. code-block:: javascript
+
+    {
+        // Required: Source code language. Must be set to "Vyper".
+        "language": "Vyper",
+        // Required
+        // Source codes given here will be compiled.
+        "sources": {
+            "contracts/foo.vy": {
+                // Optional: keccak256 hash of the source file
+                "keccak256": "0x234...",
+                // Required: literal contents of the source file
+                "content": "@public\ndef foo() -> bool:\n    return True"
+            }
+        },
+        // Optional
+        // Interfaces given here are made available for import by the sources
+        // that are compiled. If the suffix is ".vy", the compiler will expect
+        // a contract-as-interface using proper Vyper syntax. If the suffix is
+        // "abi" the compiler will expect an ABI object.
+        "interfaces": {
+            "contracts/bar.vy": {
+                "content": ""
+            },
+            "contracts/baz.json": {
+                "abi": []
+            }
+        },
+        // Optional
+        "settings": {
+            "evmVersion": "byzantium"  // EVM version to compile for. Can be byzantium, constantinople or petersburg.
+        },
+        // The following is used to select desired outputs based on file names.
+        // File names are given as keys, a star as a file name matches all files.
+        // Outputs can also follow the Solidity format where second level keys
+        // denoting contract names - all 2nd level outputs are applied to the file.
+        //
+        // To select all possible compiler outputs: "outputSelection: { '*': ["*"] }"
+        // Note that this might slow down the compilation process needlessly.
+        //
+        // The available output types are as follows:
+        //
+        //    abi - The contract ABI
+        //    ast - Abstract syntax tree
+        //    interface - Derived interface of the contract, in proper Vyper syntax
+        //    ir - LLL intermediate representation of the code
+        //    evm.bytecode.object - Bytecode object
+        //    evm.bytecode.opcodes - Opcodes list
+        //    evm.deployedBytecode.object - Deployed bytecode object
+        //    evm.deployedBytecode.opcodes - Deployed opcodes list
+        //    evm.deployedBytecode.sourceMap - Deployed source mapping (useful for debugging)
+        //    evm.methodIdentifiers - The list of function hashes
+        //
+        // Using `evm`, `evm.bytecode`, etc. will select every target part of that output.
+        // Additionally, `*` can be used as a wildcard to request everything.
+        //
+        "outputSelection": {
+            "*": ["evm.bytecode", "abi"],  // Enable the abi and bytecode outputs for every single contract
+            "contracts/foo.vy": ["ast"]  // Enable the ast output for contracts/foo.vy
+        }
+    }
+
+Output JSON Description
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example describes the output format of ``vyper-json``. Comments are of course not permitted and used here only for explanatory purposes.
+
+.. code-block:: javascript
+
+    {
+        // Optional: not present if no errors/warnings were encountered
+        "errors": [
+            {
+            // Optional: Location within the source file.
+            "sourceLocation": {
+                "file": "source_file.vy",
+                "lineno": 5,
+                "col_offset": 11
+            },
+            // Mandatory: Exception type, such as "JSONError", "KeyError", "StructureException", etc.
+            "type": "TypeMismatchException",
+            // Mandatory: Component where the error originated, such as "json", "compiler", "vyper", etc.
+            "component": "compiler",
+            // Mandatory ("error" or "warning")
+            "severity": "error",
+            // Mandatory
+            "message": "Unsupported type conversion: int128 to bool"
+            // Optional: the message formatted with source location
+            "formattedMessage": "line 5:11 Unsupported type conversion: int128 to bool"
+            }
+        ],
+        // This contains the file-level outputs. Can be limited/filtered by the outputSelection settings.
+        "sources": {
+            "source_file.vy": {
+                // Identifier of the source (used in source maps)
+                "id": 0,
+                // The AST object
+                "ast": {},
+            }
+        },
+        // This contains the contract-level outputs. Can be limited/filtered by the outputSelection settings.
+        "contracts": {
+            "source_file.vy": {
+                // The contract name will always be the file name without a suffix
+                "source_file": {
+                    // The Ethereum Contract ABI.
+                    // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+                    "abi": [],
+                    // Intermediate representation (string)
+                    "ir": "",
+                    // EVM-related outputs
+                    "evm": {
+                        "bytecode": {
+                            // The bytecode as a hex string.
+                            "object": "00fe",
+                            // Opcodes list (string)
+                            "opcodes": ""
+                        },
+                        "deployedBytecode": {
+                            // The deployed bytecode as a hex string.
+                            "object": "00fe",
+                            // Deployed opcodes list (string)
+                            "opcodes": "",
+                            // The deployed source mapping as a string.
+                            "sourceMap": ""
+                        },
+                        // The list of function hashes
+                        "methodIdentifiers": {
+                            "delegate(address)": "5c19a95c"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+Importing Interfaces
+~~~~~~~~~~~~~~~~~~~~
+
+``vyper-json`` searches for imported interfaces in the following sequence:
+
+1. Interfaces defined in the ``interfaces`` field of the input JSON
+2. Derived interfaces generated from contracts in the ``sources`` field of the input JSON
+3. (Optional) The local filesystem, if a root path was explicitely declared via the ``-p`` flag.
+
+See :ref:`searching_for_imports` for more information on Vyper's import system.
+
+Errors
+~~~~~~
+
+Each error includes a ``component`` field, indicating the stage at which it occurred:
+
+* ``json``: Errors that occur while parsing the input JSON. Usually a result of invalid JSON or a required value that is missing.
+* ``parser``: Errors that occur while parsing the contracts. Usually a result of invalid Vyper syntax.
+* ``compiler``: Errors that occur while compiling the contracts.
+* ``vyper``: Unexpected errors that occur within Vyper. If you receive an error of this type, please open an issue.
+
+You can also use the ``--traceback`` flag to receive a standard Python traceback when an error is encountered.
+
+
+Online Compilers
+================
+
+Vyper Online Compiler
+---------------------
+
+`Vyper Online Compiler <https://vyper.online/>`_ is an online compiler which lets you experiment with the language without having to install Vyper. It allows you to compile to ``bytecode`` as well as ``LLL``.
 
 .. note::
-    While the vyper version of the online compiler is updated on a regular basis it might
-    be a bit behind the latest version found in the master branch of the repository.
+
+    While the vyper version of the online compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository.
+
+Remix IDE
+---------
+
+`Remix IDE <https://remix.ethereum.org>`_ is a compiler and Javascript VM for developing and testing contracts in Vyper as well as Solidity.
+
+.. note::
+
+   While the vyper version of the Remix IDE compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository. Make sure the byte code matches the output from your local compiler.

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -138,6 +138,8 @@ The following example describes the output format of ``vyper-json``. Comments ar
 .. code-block:: javascript
 
     {
+        // The compiler version used to generate the JSON
+        "compiler": "vyper-0.1.0b12",
         // Optional: not present if no errors/warnings were encountered
         "errors": [
             {

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -291,6 +291,8 @@ Relative imports are possible by prepending dots to the contract name. A single 
     from . import foo
     from ..interfaces import baz
 
+.. _searching_for_imports:
+
 Searching For Interface Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
-import subprocess, os, tempfile
+import os
+from setuptools import (
+    find_packages,
+    setup,
+)
+import subprocess
 
 test_deps = [
     'pytest>=3.6',
@@ -34,8 +38,8 @@ hashfile = os.path.relpath(hash_file_rel_path)
 try:
     commithash = subprocess.check_output("git rev-parse HEAD".split())
     commithash = commithash.decode('utf-8').strip()
-    with open(hashfile, 'w') as f :
-        f.write(commithash)
+    with open(hashfile, 'w') as fh:
+        fh.write(commithash)
 except subprocess.CalledProcessError:
     pass
 
@@ -68,7 +72,8 @@ setup(
         'console_scripts': [
             "vyper=vyper.cli.vyper_compile:_parse_cli_args",
             "vyper-serve=vyper.cli.vyper_serve:_parse_cli_args",
-            "vyper-lll=vyper.cli.vyper_lll:_parse_cli_args"
+            "vyper-lll=vyper.cli.vyper_lll:_parse_cli_args",
+            "vyper-json=vyper.cli.vyper_json:_parse_cli_args",
         ]
     },
     classifiers=[

--- a/tests/cli/vyper_json/test_compile_from_input_dict.py
+++ b/tests/cli/vyper_json/test_compile_from_input_dict.py
@@ -6,6 +6,7 @@ from copy import (
 
 import pytest
 
+import vyper
 from vyper.cli.vyper_json import (
     TRANSLATE_MAP,
     compile_from_input_dict,
@@ -103,7 +104,8 @@ def test_exc_handler_to_dict_compiler():
     input_json = deepcopy(INPUT_JSON)
     input_json['sources']['badcode.vy'] = {'content': BAD_COMPILER_CODE}
     result, _ = compile_from_input_dict(input_json, exc_handler_to_dict)
-    assert 'errors' in result
+    assert sorted(result.keys()) == ['compiler', 'errors']
+    assert result['compiler'] == f"vyper-{vyper.__version__}"
     assert len(result['errors']) == 1
     error = result['errors'][0]
     assert error['component'] == "compiler"

--- a/tests/cli/vyper_json/test_compile_from_input_dict.py
+++ b/tests/cli/vyper_json/test_compile_from_input_dict.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+from copy import (
+    deepcopy,
+)
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    TRANSLATE_MAP,
+    compile_from_input_dict,
+    exc_handler_raises,
+    exc_handler_to_dict,
+)
+from vyper.exceptions import (
+    JSONError,
+    TypeMismatchException,
+)
+
+FOO_CODE = """
+import contracts.bar as Bar
+
+@public
+def foo(a: address) -> bool:
+    return Bar(a).bar(1)
+"""
+
+BAR_CODE = """
+@public
+def bar(a: uint256) -> bool:
+    return True
+"""
+
+BAD_SYNTAX_CODE = """
+def bar()>:
+"""
+
+BAD_COMPILER_CODE = """
+@public
+def oopsie(a: uint256) -> bool:
+    return 42
+"""
+
+BAR_ABI = [{
+    'name': 'bar',
+    'outputs': [{'type': 'bool', 'name': 'out'}],
+    'inputs': [{'type': 'uint256', 'name': 'a'}],
+    'constant': False,
+    'payable': False,
+    'type': 'function',
+    'gas': 313
+}]
+
+INPUT_JSON = {
+    'language': "Vyper",
+    'sources': {
+        'contracts/foo.vy': {'content': FOO_CODE},
+        'contracts/bar.vy': {'content': BAR_CODE},
+    },
+    'interfaces': {
+        'contracts/bar.json': {'abi': BAR_ABI}
+    },
+    'outputSelection': {'*': ["*"]}
+}
+
+
+def test_root_folder_not_exists():
+    with pytest.raises(FileNotFoundError):
+        compile_from_input_dict({}, root_folder="/path/that/does/not/exist")
+
+
+def test_wrong_language():
+    with pytest.raises(JSONError):
+        compile_from_input_dict({'language': "Solidity"})
+
+
+def test_exc_handler_raises_syntax():
+    input_json = deepcopy(INPUT_JSON)
+    input_json['sources']['badcode.vy'] = {'content': BAD_SYNTAX_CODE}
+    with pytest.raises(SyntaxError):
+        compile_from_input_dict(input_json, exc_handler_raises)
+
+
+def test_exc_handler_to_dict_syntax():
+    input_json = deepcopy(INPUT_JSON)
+    input_json['sources']['badcode.vy'] = {'content': BAD_SYNTAX_CODE}
+    result, _ = compile_from_input_dict(input_json, exc_handler_to_dict)
+    assert 'errors' in result
+    assert len(result['errors']) == 1
+    error = result['errors'][0]
+    assert error['component'] == "parser"
+    assert error['type'] == "SyntaxError"
+
+
+def test_exc_handler_raises_compiler():
+    input_json = deepcopy(INPUT_JSON)
+    input_json['sources']['badcode.vy'] = {'content': BAD_COMPILER_CODE}
+    with pytest.raises(TypeMismatchException):
+        compile_from_input_dict(input_json, exc_handler_raises)
+
+
+def test_exc_handler_to_dict_compiler():
+    input_json = deepcopy(INPUT_JSON)
+    input_json['sources']['badcode.vy'] = {'content': BAD_COMPILER_CODE}
+    result, _ = compile_from_input_dict(input_json, exc_handler_to_dict)
+    assert 'errors' in result
+    assert len(result['errors']) == 1
+    error = result['errors'][0]
+    assert error['component'] == "compiler"
+    assert error['type'] == "TypeMismatchException"
+
+
+def test_source_ids_increment():
+    input_json = deepcopy(INPUT_JSON)
+    input_json['outputSelection'] = {'*': ['evm.deployedBytecode.sourceMap']}
+    result, _ = compile_from_input_dict(input_json)
+    assert result['contracts/bar.vy']['source_map']['pc_pos_map_compressed'].startswith('-1:-1:0')
+    assert result['contracts/foo.vy']['source_map']['pc_pos_map_compressed'].startswith('-1:-1:1')
+
+
+def test_outputs():
+    result, _ = compile_from_input_dict(INPUT_JSON)
+    assert sorted(result.keys()) == ['contracts/bar.vy', 'contracts/foo.vy']
+    assert sorted(result['contracts/bar.vy'].keys()) == sorted(TRANSLATE_MAP.values())

--- a/tests/cli/vyper_json/test_compile_json.py
+++ b/tests/cli/vyper_json/test_compile_json.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from copy import (
+    deepcopy,
+)
+import json
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    compile_from_input_dict,
+    compile_json,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+
+FOO_CODE = """
+import contracts.bar as Bar
+
+@public
+def foo(a: address) -> bool:
+    return Bar(a).bar(1)
+"""
+
+BAR_CODE = """
+@public
+def bar(a: uint256) -> bool:
+    return True
+"""
+
+BAR_ABI = [{
+    'name': 'bar',
+    'outputs': [{'type': 'bool', 'name': 'out'}],
+    'inputs': [{'type': 'uint256', 'name': 'a'}],
+    'constant': False,
+    'payable': False,
+    'type': 'function',
+    'gas': 313
+}]
+
+INPUT_JSON = {
+    'language': "Vyper",
+    'sources': {
+        'contracts/foo.vy': {'content': FOO_CODE},
+        'contracts/bar.vy': {'content': BAR_CODE},
+    },
+    'interfaces': {
+        'contracts/bar.json': {'abi': BAR_ABI}
+    },
+    'outputSelection': {'*': ["*"]}
+}
+
+
+def test_input_formats():
+    assert compile_json(INPUT_JSON) == compile_json(json.dumps(INPUT_JSON))
+
+
+def test_bad_json():
+    with pytest.raises(JSONError):
+        compile_json("this probably isn't valid JSON, is it")
+
+
+def test_keyerror_becomes_jsonerror():
+    input_json = deepcopy(INPUT_JSON)
+    del input_json['sources']
+    with pytest.raises(KeyError):
+        compile_from_input_dict(input_json)
+    with pytest.raises(JSONError):
+        compile_json(input_json)

--- a/tests/cli/vyper_json/test_get_contracts.py
+++ b/tests/cli/vyper_json/test_get_contracts.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    get_input_dict_contracts,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+from vyper.utils import (
+    keccak256,
+)
+
+FOO_CODE = """
+import contracts.bar as Bar
+
+@public
+def foo(a: address) -> bool:
+    return Bar(a).bar(1)
+"""
+
+BAR_CODE = """
+@public
+def bar(a: uint256) -> bool:
+    return True
+"""
+
+
+def test_no_sources():
+    with pytest.raises(KeyError):
+        get_input_dict_contracts({})
+
+
+def test_contracts_urls():
+    with pytest.raises(JSONError):
+        get_input_dict_contracts({'sources': {'foo.vy': {'urls': ["https://foo.code.com/"]}}})
+
+
+def test_contracts_no_content_key():
+    with pytest.raises(JSONError):
+        get_input_dict_contracts({'sources': {'foo.vy': FOO_CODE}})
+
+
+def test_contracts_keccak():
+    hash_ = keccak256(FOO_CODE.encode()).hex()
+
+    input_json = {'sources': {'foo.vy': {'content': FOO_CODE, 'keccak256': hash_}}}
+    get_input_dict_contracts(input_json)
+
+    input_json['sources']['foo.vy']['keccak256'] = "0x"+hash_
+    get_input_dict_contracts(input_json)
+
+    input_json['sources']['foo.vy']['keccak256'] = "0x1234567890"
+    with pytest.raises(JSONError):
+        get_input_dict_contracts(input_json)
+
+
+def test_contracts_bad_path():
+    input_json = {'sources': {'../foo.vy': {'content': FOO_CODE}}}
+    with pytest.raises(JSONError):
+        get_input_dict_contracts(input_json)
+
+
+def test_contract_collision():
+    input_json = {
+        'sources': {
+            'foo.vy': {'content': FOO_CODE},
+            '/foo.vy': {'content': FOO_CODE}
+        }
+    }
+    with pytest.raises(JSONError):
+        get_input_dict_contracts(input_json)
+
+
+def test_contracts_return_value():
+    input_json = {
+        'sources': {
+            '/foo.vy': {'content': FOO_CODE},
+            'contracts/bar.vy': {'content': BAR_CODE},
+        }
+    }
+    result = get_input_dict_contracts(input_json)
+    assert result == {'foo.vy': FOO_CODE, 'contracts/bar.vy': BAR_CODE}

--- a/tests/cli/vyper_json/test_get_settings.py
+++ b/tests/cli/vyper_json/test_get_settings.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    get_input_dict_settings,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+
+
+def test_unknown_evm():
+    with pytest.raises(JSONError):
+        get_input_dict_settings({'settings': {'evmVersion': "foo"}})
+
+
+@pytest.mark.parametrize('evm_version', ['homestead', 'tangerineWhistle', 'spuriousDragon'])
+def test_early_evm(evm_version):
+    with pytest.raises(JSONError):
+        get_input_dict_settings({'settings': {'evmVersion': evm_version}})
+
+
+@pytest.mark.parametrize('evm_version', ['byzantium', 'constantinople', 'petersburg'])
+def test_valid_evm(evm_version):
+    get_input_dict_settings({'settings': {'evmVersion': evm_version}})

--- a/tests/cli/vyper_json/test_interfaces.py
+++ b/tests/cli/vyper_json/test_interfaces.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    get_input_dict_interfaces,
+    get_interface_codes,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+
+FOO_CODE = """
+import contracts.bar as Bar
+
+@public
+def foo(a: address) -> bool:
+    return Bar(a).bar(1)
+"""
+
+BAR_CODE = """
+@public
+def bar(a: uint256) -> bool:
+    return True
+"""
+
+BAR_ABI = [{
+    'name': 'bar',
+    'outputs': [{'type': 'bool', 'name': 'out'}],
+    'inputs': [{'type': 'uint256', 'name': 'a'}],
+    'constant': False,
+    'payable': False,
+    'type': 'function',
+    'gas': 313
+}]
+
+
+# get_input_dict_interfaces tests
+
+def test_no_interfaces():
+    result = get_input_dict_interfaces({})
+    assert isinstance(result, dict)
+    assert not result
+
+
+def test_interface_collision():
+    input_json = {
+        'interfaces': {
+            '/bar.json': {'abi': BAR_ABI},
+            'bar.vy': {'content': BAR_CODE}
+        }
+    }
+    with pytest.raises(JSONError):
+        get_input_dict_interfaces(input_json)
+
+
+def test_interfaces_wrong_suffix():
+    input_json = {'interfaces': {'foo.abi': {'content': FOO_CODE}}}
+    with pytest.raises(JSONError):
+        get_input_dict_interfaces(input_json)
+
+    input_json = {'interfaces': {'interface.folder/foo': {'content': FOO_CODE}}}
+    with pytest.raises(JSONError):
+        get_input_dict_interfaces(input_json)
+
+
+def test_json_no_abi():
+    input_json = {'interfaces': {'bar.json': {'content': BAR_ABI}}}
+    with pytest.raises(JSONError):
+        get_input_dict_interfaces(input_json)
+
+
+def test_vy_no_content():
+    input_json = {'interfaces': {'bar.vy': {'abi': BAR_CODE}}}
+    with pytest.raises(JSONError):
+        get_input_dict_interfaces(input_json)
+
+
+def test_interfaces_output():
+    input_json = {
+        'interfaces': {
+            '/bar.json': {'abi': BAR_ABI},
+            '/interface.folder/bar2.vy': {'content': BAR_CODE}
+        }
+    }
+    result = get_input_dict_interfaces(input_json)
+    assert isinstance(result, dict)
+    assert result == {
+        'bar': {'type': "json", 'code': BAR_ABI},
+        'interface.folder/bar2': {'type': "vyper", 'code': BAR_CODE}
+    }
+
+
+# get_interface_codes tests
+
+def test_interface_codes_from_contracts():
+    # interface should be generated from contract
+    assert get_interface_codes(
+        None,
+        'foo.vy',
+        {'foo.vy': FOO_CODE, 'contracts/bar.vy': BAR_CODE},
+        {}
+    )
+    assert get_interface_codes(
+        None,
+        'foo/foo.vy',
+        {'foo/foo.vy': FOO_CODE, 'contracts/bar.vy': BAR_CODE},
+        {}
+    )
+
+
+def test_interface_codes_from_interfaces():
+    # existing interface should be given preference over contract-as-interface
+    contracts = {'foo.vy': FOO_CODE, 'contacts/bar.vy': BAR_CODE}
+    result = get_interface_codes(None, 'foo.vy', contracts, {'contracts/bar': "bar"})
+    assert result['Bar'] == "bar"
+
+
+def test_root_path(tmp_path):
+    tmp_path.joinpath('contracts').mkdir()
+    with tmp_path.joinpath('contracts/bar.vy').open('w') as fp:
+        fp.write("bar")
+
+    with pytest.raises(FileNotFoundError):
+        get_interface_codes(None, 'foo.vy', {'foo.vy': FOO_CODE}, {})
+
+    # interface from file system should take lowest priority
+    result = get_interface_codes(tmp_path, 'foo.vy', {'foo.vy': FOO_CODE}, {})
+    assert result['Bar'] == {'code': "bar", 'type': "vyper"}
+    contracts = {'foo.vy': FOO_CODE, 'contracts/bar.vy': BAR_CODE}
+    result = get_interface_codes(None, 'foo.vy', contracts, {})
+    assert result['Bar'] == {'code': BAR_CODE, 'type': "vyper"}

--- a/tests/cli/vyper_json/test_output_dict.py
+++ b/tests/cli/vyper_json/test_output_dict.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from vyper.cli.vyper_json import (
+    format_to_output_dict,
+)
+from vyper.compiler import (
+    compile_codes,
+    output_formats_map,
+)
+
+FOO_CODE = """
+@public
+def foo() -> bool:
+    return True
+"""
+
+
+def test_keys():
+    compiler_data = compile_codes(
+        {'foo.vy': FOO_CODE},
+        output_formats=list(output_formats_map.keys())
+    )
+    output_json = format_to_output_dict(compiler_data)
+    data = compiler_data['foo.vy']
+    assert output_json['sources']['foo.vy'] == {'id': 0, 'ast': data['ast_dict']['ast']}
+    assert output_json['contracts']['foo.vy']['foo'] == {
+        'abi': data['abi'],
+        'interface': data['interface'],
+        'ir': data['ir'],
+        'evm': {
+            'bytecode': {
+                'object': data['bytecode'],
+                'opcodes': data['opcodes']
+            },
+            'deployedBytecode': {
+                'object': data['bytecode_runtime'],
+                'opcodes': data['opcodes_runtime'],
+                'sourceMap': data['source_map']['pc_pos_map_compressed']
+            },
+            'methodIdentifiers': data['method_identifiers'],
+        }
+    }

--- a/tests/cli/vyper_json/test_output_dict.py
+++ b/tests/cli/vyper_json/test_output_dict.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import vyper
 from vyper.cli.vyper_json import (
     format_to_output_dict,
 )
@@ -21,6 +22,8 @@ def test_keys():
         output_formats=list(output_formats_map.keys())
     )
     output_json = format_to_output_dict(compiler_data)
+    assert sorted(output_json.keys()) == ['compiler', 'contracts', 'sources']
+    assert output_json['compiler'] == f"vyper-{vyper.__version__}"
     data = compiler_data['foo.vy']
     assert output_json['sources']['foo.vy'] == {'id': 0, 'ast': data['ast_dict']['ast']}
     assert output_json['contracts']['foo.vy']['foo'] == {

--- a/tests/cli/vyper_json/test_output_selection.py
+++ b/tests/cli/vyper_json/test_output_selection.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    TRANSLATE_MAP,
+    get_input_dict_output_formats,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+
+
+def test_no_outputs():
+    with pytest.raises(KeyError):
+        get_input_dict_output_formats({}, {})
+
+
+def test_invalid_output():
+    input_json = {'outputSelection': {'foo.vy': ['abi', 'foobar']}}
+    sources = {'foo.vy': ""}
+    with pytest.raises(JSONError):
+        get_input_dict_output_formats(input_json, sources)
+
+
+def test_unknown_contract():
+    input_json = {'outputSelection': {'bar.vy': ['abi']}}
+    sources = {'foo.vy': ""}
+    with pytest.raises(JSONError):
+        get_input_dict_output_formats(input_json, sources)
+
+
+@pytest.mark.parametrize('output', TRANSLATE_MAP.items())
+def test_translate_map(output):
+    input_json = {'outputSelection': {'foo.vy': [output[0]]}}
+    sources = {'foo.vy': ""}
+    assert get_input_dict_output_formats(input_json, sources) == {'foo.vy': [output[1]]}
+
+
+def test_star():
+    input_json = {'outputSelection': {'*': ['*']}}
+    sources = {'foo.vy': "", 'bar.vy': ""}
+    expected = sorted(TRANSLATE_MAP.values())
+    result = get_input_dict_output_formats(input_json, sources)
+    assert result == {'foo.vy': expected, 'bar.vy': expected}
+
+
+def test_evm():
+    input_json = {'outputSelection': {'foo.vy': ['abi', 'evm']}}
+    sources = {'foo.vy': ""}
+    expected = ['abi'] + sorted(v for k, v in TRANSLATE_MAP.items() if k.startswith('evm'))
+    result = get_input_dict_output_formats(input_json, sources)
+    assert result == {'foo.vy': expected}
+
+
+def test_solc_style():
+    input_json = {'outputSelection': {'foo.vy': {'': ['abi'], 'foo.vy': ['ir']}}}
+    sources = {'foo.vy': ""}
+    assert get_input_dict_output_formats(input_json, sources) == {'foo.vy': ['abi', 'ir']}

--- a/tests/cli/vyper_json/test_parse_args_vyperjson.py
+++ b/tests/cli/vyper_json/test_parse_args_vyperjson.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+from copy import (
+    deepcopy,
+)
+import json
+
+import pytest
+
+from vyper.cli.vyper_json import (
+    _parse_args,
+)
+from vyper.exceptions import (
+    JSONError,
+)
+
+FOO_CODE = """
+import contracts.bar as Bar
+
+@public
+def foo(a: address) -> bool:
+    return Bar(a).bar(1)
+"""
+
+BAR_CODE = """
+@public
+def bar(a: uint256) -> bool:
+    return True
+"""
+
+BAR_ABI = [{
+    'name': 'bar',
+    'outputs': [{'type': 'bool', 'name': 'out'}],
+    'inputs': [{'type': 'uint256', 'name': 'a'}],
+    'constant': False,
+    'payable': False,
+    'type': 'function',
+    'gas': 313
+}]
+
+INPUT_JSON = {
+    'language': "Vyper",
+    'sources': {
+        'contracts/foo.vy': {'content': FOO_CODE},
+        'contracts/bar.vy': {'content': BAR_CODE},
+    },
+    'interfaces': {
+        'contracts/bar.json': {'abi': BAR_ABI}
+    },
+    'outputSelection': {'*': ["*"]}
+}
+
+
+def test_to_stdout(tmp_path, capfd):
+    path = tmp_path.joinpath('input.json')
+    with path.open('w') as fp:
+        json.dump(INPUT_JSON, fp)
+    _parse_args([path.absolute().as_posix()])
+    out, _ = capfd.readouterr()
+    output_json = json.loads(out)
+    assert 'errors' not in output_json
+    assert 'contracts/foo.vy' in output_json['sources']
+    assert 'contracts/bar.vy' in output_json['sources']
+
+
+def test_to_file(tmp_path):
+    path = tmp_path.joinpath('input.json')
+    with path.open('w') as fp:
+        json.dump(INPUT_JSON, fp)
+    output_path = tmp_path.joinpath('output.json')
+    _parse_args([path.absolute().as_posix(), '-o', output_path.absolute().as_posix()])
+    assert output_path.exists()
+    with output_path.open() as fp:
+        output_json = json.load(fp)
+    assert 'errors' not in output_json
+    assert 'contracts/foo.vy' in output_json['sources']
+    assert 'contracts/bar.vy' in output_json['sources']
+
+
+def test_pretty_json(tmp_path, capfd):
+    path = tmp_path.joinpath('input.json')
+    with path.open('w') as fp:
+        json.dump(INPUT_JSON, fp)
+    _parse_args([path.absolute().as_posix()])
+    out1, _ = capfd.readouterr()
+    _parse_args([path.absolute().as_posix(), '--pretty-json'])
+    out2, _ = capfd.readouterr()
+    assert len(out2) > len(out1)
+    assert json.loads(out1) == json.loads(out2)
+
+
+def test_traceback(tmp_path, capfd):
+    path = tmp_path.joinpath('input.json')
+    input_json = deepcopy(INPUT_JSON)
+    del input_json['sources']
+    with path.open('w') as fp:
+        json.dump(input_json, fp)
+    _parse_args([path.absolute().as_posix()])
+    out, _ = capfd.readouterr()
+    output_json = json.loads(out)
+    assert 'errors' in output_json
+    with pytest.raises(JSONError):
+        _parse_args([path.absolute().as_posix(), '--traceback'])

--- a/tests/compiler/test_source_map.py
+++ b/tests/compiler/test_source_map.py
@@ -78,9 +78,10 @@ def foo() -> uint256:
     compressed = compress_source_map(
         code,
         {'0': None, '2': (2, 0, 4, 13), '3': (2, 0, 2, 7), '5': (2, 0, 2, 7)},
-        {'3': 'o'}
+        {'3': 'o'},
+        2
     )
-    assert compressed == "-1:-1:0:-;1:43;:7::o;;"
+    assert compressed == "-1:-1:2:-;1:43;:7::o;;"
 
 
 def test_expand_source_map():

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -25,11 +25,12 @@ DICT_AST_SKIPLIST = ('source_code', )
 
 
 @iterable_cast(list)
-def _build_vyper_ast_list(source_code: str, node: list) -> Generator:
+def _build_vyper_ast_list(source_code: str, node: list, source_id: int) -> Generator:
     for n in node:
         yield parse_python_ast(
             source_code=source_code,
             node=n,
+            source_id=source_id,
         )
 
 
@@ -38,7 +39,8 @@ def _build_vyper_ast_init_kwargs(
     source_code: str,
     node: python_ast.AST,
     vyper_class: vyper_ast.VyperNode,
-    class_name: str
+    class_name: str,
+    source_id: int,
 ) -> Generator:
     start = node.first_token.start if hasattr(node, 'first_token') else (None, None)  # type: ignore
     yield ('col_offset', start[1])
@@ -52,7 +54,7 @@ def _build_vyper_ast_init_kwargs(
     if hasattr(node, 'last_token'):
         start_pos = node.first_token.startpos  # type: ignore
         end_pos = node.last_token.endpos  # type: ignore
-        yield ('src', f"{start_pos}:{end_pos-start_pos}:0")
+        yield ('src', f"{start_pos}:{end_pos-start_pos}:{source_id}")
 
     if isinstance(node, python_ast.ClassDef):
         yield ('class_type', node.class_type)  # type: ignore
@@ -74,19 +76,22 @@ def _build_vyper_ast_init_kwargs(
                 parse_python_ast(
                     source_code=source_code,
                     node=val,
+                    source_id=source_id
                 )
             )
 
 
-def parse_python_ast(source_code: str, node: python_ast.AST) -> vyper_ast.VyperNode:
+def parse_python_ast(source_code: str,
+                     node: python_ast.AST,
+                     source_id: int = 0) -> vyper_ast.VyperNode:
     if isinstance(node, list):
-        return _build_vyper_ast_list(source_code, node)
+        return _build_vyper_ast_list(source_code, node, source_id)
     elif isinstance(node, python_ast.AST):
         class_name = node.__class__.__name__
         if hasattr(vyper_ast, class_name):
             vyper_class = getattr(vyper_ast, class_name)
             init_kwargs = _build_vyper_ast_init_kwargs(
-                source_code, node, vyper_class, class_name
+                source_code, node, vyper_class, class_name, source_id
             )
             return vyper_class(**init_kwargs)
         else:
@@ -97,7 +102,7 @@ def parse_python_ast(source_code: str, node: python_ast.AST) -> vyper_ast.VyperN
         return node
 
 
-def parse_to_ast(source_code: str) -> list:
+def parse_to_ast(source_code: str, source_id: int = 0) -> list:
     if '\x00' in source_code:
         raise ParserException('No null bytes (\\x00) allowed in the source code.')
     class_types, reformatted_code = pre_parse(source_code)
@@ -108,6 +113,7 @@ def parse_to_ast(source_code: str) -> list:
     vyper_ast = parse_python_ast(
         source_code=source_code,
         node=py_ast,
+        source_id=source_id,
     )
     return vyper_ast.body  # type: ignore
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -54,6 +54,10 @@ ir                 - Print Intermediate Representation in LLL
 
 
 def _parse_cli_args():
+    return _parse_args(sys.argv[1:])
+
+
+def _parse_args(argv):
 
     warnings.simplefilter('always')
 
@@ -92,7 +96,7 @@ def _parse_cli_args():
         default='.', dest='root_folder'
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.traceback_limit is not None:
         sys.tracebacklimit = args.traceback_limit

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -198,9 +198,7 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
         suffix = next((i for i in ('.vy', '.json') if file_path.with_suffix(i).exists()), None)
         if suffix:
             return file_path.with_suffix(suffix)
-    raise Exception(
-        f'Imported interface "{import_path}{{.vy,.json}}" does not exist.'
-    )
+    raise FileNotFoundError(f" Cannot locate interface '{import_path}{{.vy,.json}}'")
 
 
 def compile_files(input_files: Iterable[str],

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -9,7 +9,6 @@ from pathlib import (
 )
 import sys
 from typing import (
-    Any,
     Dict,
     Iterable,
     Iterator,
@@ -155,7 +154,7 @@ def exc_handler(contract_path: ContractPath, exception: Exception) -> None:
     raise exception
 
 
-def get_interface_codes(root_path: Path, contract_sources: ContractCodes) -> Any:
+def get_interface_codes(root_path: Path, contract_sources: ContractCodes) -> Dict:
     interface_codes: Dict = {}
     interfaces: Dict = {}
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -31,7 +31,8 @@ from vyper.signatures.interface import (
 )
 from vyper.typing import (
     ContractCodes,
-    ContractName,
+    ContractPath,
+    OutputFormats,
 )
 
 T = TypeVar('T')
@@ -149,8 +150,8 @@ def uniq(seq: Iterable[T]) -> Iterator[T]:
         yield x
 
 
-def exc_handler(contract_name: ContractName, exception: Exception) -> None:
-    print('Error compiling: ', contract_name)
+def exc_handler(contract_path: ContractPath, exception: Exception) -> None:
+    print(f'Error compiling: {contract_path}')
     raise exception
 
 
@@ -203,7 +204,7 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
 
 
 def compile_files(input_files: Iterable[str],
-                  output_formats: Sequence[str],
+                  output_formats: OutputFormats,
                   root_folder: str = '.',
                   show_gas_estimates: bool = False) -> OrderedDict:
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -155,11 +155,11 @@ def exc_handler(contract_path: ContractPath, exception: Exception) -> None:
     raise exception
 
 
-def get_interface_codes(root_path: Path, codes: ContractCodes) -> Any:
+def get_interface_codes(root_path: Path, contract_sources: ContractCodes) -> Any:
     interface_codes: Dict = {}
     interfaces: Dict = {}
 
-    for file_path, code in codes.items():
+    for file_path, code in contract_sources.items():
         interfaces[file_path] = {}
         parent_path = root_path.joinpath(file_path).parent
 
@@ -215,12 +215,12 @@ def compile_files(input_files: Iterable[str],
     if not root_path.exists():
         raise FileNotFoundError(f"Invalid root path - '{root_path.as_posix()}' does not exist")
 
-    codes: ContractCodes = OrderedDict()
+    contract_sources: ContractCodes = OrderedDict()
     for file_name in input_files:
         file_path = Path(file_name).resolve()
         file_str = file_path.relative_to(root_path).as_posix()
         with file_path.open() as fh:
-            codes[file_str] = fh.read()
+            contract_sources[file_str] = fh.read()
 
     show_version = False
     if 'combined_json' in output_formats:
@@ -230,10 +230,10 @@ def compile_files(input_files: Iterable[str],
         show_version = True
 
     compiler_data = vyper.compile_codes(
-        codes,
+        contract_sources,
         output_formats,
         exc_handler=exc_handler,
-        interface_codes=get_interface_codes(root_path, codes)
+        interface_codes=get_interface_codes(root_path, contract_sources)
     )
     if show_version:
         compiler_data['version'] = vyper.__version__

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import (
+    Path,
+)
+from typing import (
+    Any,
+    Dict,
+    Sequence,
+    Union,
+)
+
+import vyper
+from vyper.signatures.interface import (
+    extract_file_interface_imports,
+)
+from vyper.typing import (
+    ContractCodes,
+    ContractPath,
+)
+
+
+def exc_handler(contract_path: ContractPath, exception: Exception) -> None:
+    # TODO - return error message as JSON
+    raise exception
+
+
+def get_interface_codes(root_path: Union[Path, None],
+                        contract_sources: ContractCodes,
+                        interface_sources: ContractCodes) -> Any:
+    interface_codes: Dict = {}
+    interfaces: Dict = {}
+
+    for file_path, code in contract_sources.items():
+        interfaces[file_path] = {}
+
+        interface_codes = extract_file_interface_imports(code)
+        for interface_name, interface_path in interface_codes.items():
+
+            keys = [
+                Path(file_path).parent.joinpath(interface_path).as_posix()+".vy",
+                interface_path+".vy"
+            ]
+            for sources in (interface_sources, contract_sources):
+                key = next((i for i in keys if i in sources), None)
+                if key:
+                    interfaces[file_path][interface_name] = {
+                        'type': 'vyper',
+                        'code': sources[key]
+                    }
+                    break
+            if key:
+                continue
+
+            if root_path is None:
+                raise Exception(f'Imported interface "{interface_path}.vy" does not exist.')
+
+            parent_path = root_path.joinpath(file_path).parent
+            base_paths = [parent_path]
+            if not interface_path.startswith('.'):
+                base_paths.append(root_path)
+            elif interface_path.startswith('../') and parent_path == root_path:
+                raise FileNotFoundError(
+                    f"{file_path} - Cannot perform relative import outside of base folder"
+                )
+
+            valid_path = get_interface_file_path(base_paths, interface_path)
+            with valid_path.open() as fh:
+                code = fh.read()
+                if valid_path.suffix == '.json':
+                    interfaces[file_path][interface_name] = {
+                        'type': 'json',
+                        'code': json.loads(code.encode())
+                    }
+                else:
+                    interfaces[file_path][interface_name] = {
+                        'type': 'vyper',
+                        'code': code
+                    }
+
+    return interfaces
+
+
+def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
+    relative_path = Path(import_path)
+
+    for path in base_paths:
+        file_path = path.joinpath(relative_path)
+        suffix = next((i for i in ('.vy', '.json') if file_path.with_suffix(i).exists()), None)
+        if suffix:
+            return file_path.with_suffix(suffix)
+    raise Exception(
+        f'Imported interface "{import_path}{{.vy,.json}}" does not exist.'
+    )
+
+
+def _standardize_path(path_str: str) -> str:
+    path = Path("/vyper/" + path_str.lstrip('/')).resolve()
+    try:
+        path = path.relative_to("/vyper")
+    except ValueError:
+        raise ValueError(f"{path_str} - path exists outside base folder")
+    return path.as_posix()
+
+
+def compile_from_input_dict(input_dict, root_folder=None):
+    root_path = None
+    if root_folder is not None:
+        root_path = Path(root_folder).resolve()
+        if not root_path.exists():
+            raise FileNotFoundError(f"Invalid root path - '{root_path.as_posix()}' does not exist")
+
+    if input_dict['language'] != "Vyper":
+        raise ValueError("Wrong language.")
+
+    if 'settings' in input_dict:
+        evm_version = input_dict['settings'].get('evmVersion', 'byzantium')
+        if evm_version in ('homestead', 'tangerineWhistle', 'spuriousDragon'):
+            raise ValueError("Vyper does not support pre-byzantium EVM versions")
+        if evm_version not in ('byzantium', 'constantinople', 'petersburg'):
+            raise ValueError(f"Unknown EVM version - '{evm_version}'")
+
+    contract_sources: ContractCodes = {}
+    for path, value in input_dict['sources'].items():
+        # TODO support for URLs
+        # TODO support for keccack
+        key = _standardize_path(path)
+        contract_sources[key] = value['content']
+
+    interface_sources: ContractCodes = {}
+    for path, value in input_dict.get('interfaces', {}).items():
+        # TODO support for URLs
+        # TODO support for keccack
+        key = _standardize_path(path)
+        interface_sources[key] = value['content']
+
+    output_formats = {}
+    for path, outputs in input_dict['outputSelection'].items():
+
+        translate_map = {
+            'ast': 'ast_dict',
+            'evm.methodIdentifiers': 'method_identifiers',
+            'evm.bytecode.object': 'bytecode',
+            'evm.bytecode.opcodes': 'opcodes',
+            'evm.deployedBytecode.object': 'bytecode_runtime',
+            'evm.deployedBytecode.opcodes': 'opcodes_runtime',
+            'evm.deployedBytecode.sourceMap': 'source_map',
+            'interface': 'interface',
+            'ir': 'ir',
+        }
+
+        if isinstance(outputs, dict):
+            # if outputs are given in solc json format, collapse them into a single list
+            outputs = set(x for i in outputs.values() for x in i)
+        else:
+            outputs = set(outputs)
+
+        for key in [i for i in ('evm', 'evm.bytecode', 'evm.deployedBytecode') if i in outputs]:
+            outputs.remove(key)
+            outputs.update([i for i in translate_map if i.startswith(key)])
+        if '*' in outputs:
+            outputs = list(translate_map.values())
+        else:
+            try:
+                outputs = [translate_map[i] for i in outputs]
+            except KeyError as e:
+                raise ValueError(f"Invalid outputSelection - {e}")
+
+        if path == "*":
+            output_keys = contract_sources.keys()
+        else:
+            output_keys = [_standardize_path(path)]
+            if output_keys[0] not in contract_sources:
+                raise KeyError("outputSelection references an unknown contract - '{}'")
+
+        for key in output_keys:
+            output_formats[key] = outputs
+
+    interface_codes = get_interface_codes(root_path, contract_sources, interface_sources)
+    return vyper.compile_codes(
+        contract_sources,
+        output_formats,
+        exc_handler=exc_handler,
+        interface_codes=interface_codes
+    )
+
+
+def format_to_output_dict(compiler_data):
+    output_dict = {
+        'compiler': f"vyper-{vyper.__version__}",
+        'contracts': {},
+        'sources': {},
+    }
+    for id_, (path, data) in enumerate(compiler_data.items()):
+
+        output_dict['sources'][path] = {'id': id_}
+        if 'ast_dict' in data:
+            output_dict['sources'][path]['ast'] = data['ast_dict']['ast']
+
+        name = Path(path).stem
+        output_dict['contracts'][path] = {name: {}}
+        output_contracts = output_dict['contracts'][path][name]
+        if 'abi' in data:
+            output_contracts['abi'] = data['abi']
+        if 'interface' in data:
+            output_contracts['interface'] = data['interface']
+        if 'ir' in data:
+            output_contracts['ir'] = data['ir']
+        if 'method_identifiers' in data:
+            output_contracts['evm'] = {'methodIdentifiers': data['method_identifiers']}
+
+        evm_keys = ('bytecode', 'opcodes')
+        if next((i for i in evm_keys if i in data), False):
+            evm = output_contracts.setdefault('evm', {}).setdefault('bytecode', {})
+            if 'bytecode' in data:
+                evm['object'] = data['bytecode']
+            if 'opcodes' in data:
+                evm['opcodes'] = data['opcodes']
+
+        if next((i for i in evm_keys if i+'_runtime' in data), False) or 'source_map' in data:
+            evm = output_contracts.setdefault('evm', {}).setdefault('deployedBytecode', {})
+            if 'bytecode_runtime' in data:
+                evm['object'] = data['bytecode_runtime']
+            if 'opcodes_runtime' in data:
+                evm['opcodes'] = data['opcodes_runtime']
+            if 'source_map' in data:
+                evm['sourceMap'] = data['source_map']['pc_pos_map_compressed']
+
+    return output_dict
+
+
+def compile_json(input_json):
+    input_dict = json.loads(input_json)
+    compiler_data = compile_from_input_dict(input_dict)
+    output_dict = format_to_output_dict(compiler_data)
+    return json.dumps(output_dict, indent=2, default=str, sort_keys=True)

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -111,7 +111,7 @@ def _parse_cli_args():
 
 def exc_handler_raises(file_path: Union[str, None],
                        exception: Exception,
-                       component: str = "compiler") -> None:
+                       component: str) -> None:
     if file_path:
         print(f"Unhandled exception in '{file_path}':")
     exception._exc_handler = True  # type: ignore
@@ -120,7 +120,7 @@ def exc_handler_raises(file_path: Union[str, None],
 
 def exc_handler_to_dict(file_path: Union[str, None],
                         exception: Exception,
-                        component: str = "compiler") -> Dict:
+                        component: str) -> Dict:
     err_dict: Dict = {
         "type": type(exception).__name__,
         "component": component,
@@ -320,6 +320,9 @@ def compile_from_input_dict(input_dict: Dict,
                     contract_sources,
                     interface_sources
                 )
+            except Exception as exc:
+                return exc_handler(contract_path, exc, "parser"), {}
+            try:
                 data = vyper.compile_codes(
                     {contract_path: contract_sources[contract_path]},
                     output_formats[contract_path],
@@ -327,7 +330,7 @@ def compile_from_input_dict(input_dict: Dict,
                     initial_id=id_
                 )
             except Exception as exc:
-                return exc_handler(contract_path, exc), {}
+                return exc_handler(contract_path, exc, "compiler"), {}
             compiler_data[contract_path] = data[contract_path]
             if caught_warnings:
                 warning_data[contract_path] = caught_warnings

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -47,6 +47,10 @@ TRANSLATE_MAP = {
 
 
 def _parse_cli_args():
+    return _parse_args(sys.argv[1:])
+
+
+def _parse_args(argv):
     parser = argparse.ArgumentParser(
         description='Vyper programming language for Ethereum - JSON Compiler',
         formatter_class=argparse.RawTextHelpFormatter
@@ -83,7 +87,7 @@ def _parse_cli_args():
         action='store_true'
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.input_file:
         with Path(args.input_file).open() as fh:
             input_json = fh.read()

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -143,7 +143,12 @@ def exc_handler_to_dict(file_path: Union[str, None],
                 'lineno': exception.lineno,  # type: ignore
                 'col_offset': getattr(exception, 'col_offset', None),
             })
-    return {'errors': [err_dict]}
+
+    output_json = {
+        'compiler': f"vyper-{vyper.__version__}",
+        'errors': [err_dict],
+    }
+    return output_json
 
 
 def _standardize_path(path_str: str) -> str:

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -18,6 +18,9 @@ from vyper.signatures.interface import (
 from vyper.typing import (
     ContractCodes,
 )
+from vyper.utils import (
+    keccak256,
+)
 
 
 def get_interface_codes(root_path: Union[Path, None],
@@ -117,15 +120,22 @@ def compile_from_input_dict(input_dict, root_folder=None):
 
     contract_sources: ContractCodes = {}
     for path, value in input_dict['sources'].items():
-        # TODO support for URLs
-        # TODO support for keccack
+        if 'content' not in value:
+            raise ValueError(f"{path} missing required field - 'content'")
+        if 'keccak256' in value:
+            hash_ = value['keccak256'].lower()
+            if hash_.startswith('0x'):
+                hash_ = hash_[2:]
+            if hash_ != keccak256(value['content'].encode('utf-8')):
+                raise ValueError(
+                    f"Calculated keccak of {path} does not match keccak given in input json"
+                )
         key = _standardize_path(path)
         contract_sources[key] = value['content']
 
     interface_sources: ContractCodes = {}
     for path, value in input_dict.get('interfaces', {}).items():
-        # TODO support for URLs
-        # TODO support for keccack
+        # TODO support for ABIs
         key = _standardize_path(path)
         interface_sources[key] = value['content']
 

--- a/vyper/cli/vyper_lll.py
+++ b/vyper/cli/vyper_lll.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import sys
 
 import vyper
 from vyper import (
@@ -15,6 +16,10 @@ from vyper.parser.s_expressions import (
 
 
 def _parse_cli_args():
+    return _parse_args(sys.argv[1:])
+
+
+def _parse_args(argv):
     parser = argparse.ArgumentParser(description='Vyper LLL for Ethereum')
     parser.add_argument(
         'input_file',
@@ -37,7 +42,7 @@ def _parse_cli_args():
         action='store_true',
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     output_formats = set(dict.fromkeys(args.format.split(',')))
     compiler_data = compile_to_lll(args.input_file, output_formats, args.show_gas_estimates)
 

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -9,6 +9,7 @@ import json
 from socketserver import (
     ThreadingMixIn,
 )
+import sys
 
 import vyper
 from vyper.exceptions import (
@@ -20,6 +21,10 @@ from vyper.parser import (
 
 
 def _parse_cli_args():
+    return _parse_args(sys.argv[1:])
+
+
+def _parse_args(argv):
     parser = argparse.ArgumentParser(
         description='Serve Vyper compiler as an HTTP Service'
     )
@@ -31,7 +36,7 @@ def _parse_cli_args():
         dest='bind_address'
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if ':' in args.bind_address:
         lll_node.VYPER_COLOR_OUTPUT = False

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -474,7 +474,7 @@ def note_breakpoint(line_number_map, item, pos):
 
 
 # Assembles assembly into EVM
-def assembly_to_evm(assembly, map_line_numbers=True):
+def assembly_to_evm(assembly, start_pos=0):
     line_number_map = {
         'breakpoints': set(),
         'pc_breakpoints': set(),
@@ -484,7 +484,7 @@ def assembly_to_evm(assembly, map_line_numbers=True):
     posmap = {}
     sub_assemblies = []
     codes = []
-    pos = 0
+    pos = start_pos
     for i, item in enumerate(assembly):
         note_line_num(line_number_map, item, pos)
         if item == 'DEBUG':
@@ -504,16 +504,18 @@ def assembly_to_evm(assembly, map_line_numbers=True):
         if is_symbol(item):
             if assembly[i + 1] == 'JUMPDEST' or assembly[i + 1] == 'BLANK':
                 # Don't increment position as the symbol itself doesn't go into code
-                posmap[item] = pos
+                posmap[item] = pos - start_pos
             else:
                 pos += 3  # PUSH2 highbits lowbits
         elif item == 'BLANK':
             pos += 0
         elif isinstance(item, list):
-            c, line_number_map = assembly_to_evm(item)
+            c, sub_map = assembly_to_evm(item, start_pos=pos)
             sub_assemblies.append(item)
             codes.append(c)
             pos += len(c)
+            for key in line_number_map:
+                line_number_map[key].update(sub_map[key])
         else:
             pos += 1
 
@@ -546,7 +548,7 @@ def assembly_to_evm(assembly, map_line_numbers=True):
             # Should never reach because, assembly is create in compile_to_assembly.
             raise Exception("Weird symbol in assembly: " + str(item))  # pragma: no cover
 
-    assert len(o) == pos
+    assert len(o) == pos - start_pos
     line_number_map['breakpoints'] = list(line_number_map['breakpoints'])
     line_number_map['pc_breakpoints'] = list(line_number_map['pc_breakpoints'])
     return o, line_number_map

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -296,7 +296,8 @@ output_formats_map = {
 def compile_codes(contract_sources: ContractCodes,
                   output_formats: Union[OutputDict, OutputFormats, None] = None,
                   exc_handler: Union[Callable, None] = None,
-                  interface_codes: Union[InterfaceDict, InterfaceImports, None] = None) -> OrderedDict:  # NOQA: E501
+                  interface_codes: Union[InterfaceDict, InterfaceImports, None] = None,
+                  initial_id: int = 0) -> OrderedDict:
 
     if output_formats is None:
         output_formats = ('bytecode',)
@@ -304,7 +305,7 @@ def compile_codes(contract_sources: ContractCodes,
         output_formats = dict((k, output_formats) for k in contract_sources.keys())
 
     out: OrderedDict = OrderedDict()
-    for source_id, contract_name in enumerate(sorted(contract_sources)):
+    for source_id, contract_name in enumerate(sorted(contract_sources), start=initial_id):
         code = contract_sources[contract_name]
         for output_format in output_formats[contract_name]:
             if output_format not in output_formats_map:

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -327,7 +327,9 @@ def compile_codes(contract_sources: ContractCodes,
                 )
             except Exception as exc:
                 if exc_handler is not None:
-                    exc_handler(contract_name, exc)
+                    response = exc_handler(contract_name, exc)
+                    if response is not None:
+                        return response
                 else:
                     raise exc
 

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -328,9 +328,7 @@ def compile_codes(contract_sources: ContractCodes,
                 )
             except Exception as exc:
                 if exc_handler is not None:
-                    response = exc_handler(contract_name, exc)
-                    if response is not None:
-                        return response
+                    exc_handler(contract_name, exc)
                 else:
                     raise exc
 

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -293,7 +293,7 @@ output_formats_map = {
 }
 
 
-def compile_codes(codes: ContractCodes,
+def compile_codes(contract_sources: ContractCodes,
                   output_formats: Union[OutputDict, OutputFormats, None] = None,
                   exc_handler: Union[Callable, None] = None,
                   interface_codes: Union[InterfaceDict, InterfaceImports, None] = None) -> OrderedDict:  # NOQA: E501
@@ -301,11 +301,11 @@ def compile_codes(codes: ContractCodes,
     if output_formats is None:
         output_formats = ('bytecode',)
     if isinstance(output_formats, Sequence):
-        output_formats = dict((k, output_formats) for k in codes.keys())
+        output_formats = dict((k, output_formats) for k in contract_sources.keys())
 
     out: OrderedDict = OrderedDict()
-    for source_id, contract_name in enumerate(sorted(codes)):
-        code = codes[contract_name]
+    for source_id, contract_name in enumerate(sorted(contract_sources)):
+        code = contract_sources[contract_name]
         for output_format in output_formats[contract_name]:
             if output_format not in output_formats_map:
                 raise ValueError(f'Unsupported format type {repr(output_format)}')
@@ -338,10 +338,10 @@ UNKNOWN_CONTRACT_NAME = '<unknown>'
 
 
 def compile_code(code, output_formats=None, interface_codes=None):
-    codes = {UNKNOWN_CONTRACT_NAME: code}
+    contract_sources = {UNKNOWN_CONTRACT_NAME: code}
 
     return compile_codes(
-        codes,
+        contract_sources,
         output_formats,
         interface_codes=interface_codes,
     )[UNKNOWN_CONTRACT_NAME]

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -2,6 +2,12 @@ from collections import (
     OrderedDict,
     deque,
 )
+from typing import (
+    Any,
+    Callable,
+    Sequence,
+    Union,
+)
 import warnings
 
 import asttokens
@@ -25,6 +31,13 @@ from vyper.signatures import (
 from vyper.signatures.interface import (
     extract_external_interface,
     extract_interface_str,
+)
+from vyper.typing import (
+    ContractCodes,
+    InterfaceDict,
+    InterfaceImports,
+    OutputDict,
+    OutputFormats,
 )
 
 
@@ -269,21 +282,24 @@ output_formats_map = {
 }
 
 
-def compile_codes(codes,
-                  output_formats=None,
-                  exc_handler=None,
-                  interface_codes=None):
+def compile_codes(codes: ContractCodes,
+                  output_formats: Union[OutputDict, OutputFormats, None] = None,
+                  exc_handler: Union[Callable, None] = None,
+                  interface_codes: Union[InterfaceDict, InterfaceImports, None] = None) -> OrderedDict:  # NOQA: E501
+
     if output_formats is None:
         output_formats = ('bytecode',)
+    if isinstance(output_formats, Sequence):
+        output_formats = dict((k, output_formats) for k in codes.keys())
 
-    out = OrderedDict()
+    out: OrderedDict = OrderedDict()
     for contract_name, code in codes.items():
-        for output_format in output_formats:
+        for output_format in output_formats[contract_name]:
             if output_format not in output_formats_map:
                 raise ValueError(f'Unsupported format type {repr(output_format)}')
 
             try:
-                interfaces = interface_codes
+                interfaces: Any = interface_codes
                 if (
                     isinstance(interfaces, dict) and
                     contract_name in interfaces and

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -102,3 +102,11 @@ class CompilerPanic(Exception):
 
     def __str__(self):
         return self.message + ' Please create an issue.'
+
+
+class JSONError(Exception):
+
+    def __init__(self, msg, lineno=None, col_offset=None):
+        super().__init__(msg)
+        self.lineno = lineno
+        self.col_offset = col_offset

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -1,5 +1,6 @@
 from typing import (
     Dict,
+    Sequence,
     Tuple,
 )
 
@@ -8,11 +9,14 @@ ClassTypes = Dict[str, str]
 ParserPosition = Tuple[int, int]
 
 # Compiler
-ContractName = str
+ContractPath = str
 SourceCode = str
-ContractCodes = Dict[ContractName, SourceCode]
+ContractCodes = Dict[ContractPath, SourceCode]
+OutputFormats = Sequence[str]
+OutputDict = Dict[ContractPath, OutputFormats]
 
 # Interfaces
 InterfaceAsName = str
 InterfaceImportPath = str
 InterfaceImports = Dict[InterfaceAsName, InterfaceImportPath]
+InterfaceDict = Dict[ContractPath, InterfaceImports]


### PR DESCRIPTION
### What I did
Added `vyper-json` CLI tool - closes #1520

### How I did it
See the [updated documentation](https://github.com/iamdefinitelyahuman/vyper/blob/13db68acfbee9084c4e4664bdff868117fcbc302/docs/compiling-a-contract.rst) for a detailed explanation of how `vyper-json` works.

Other changes in this PR:
* `vyper/compiler.py`: `compile_codes` accepts a dict of lists for `output_formats`, for specifying different outputs for each contract. Added annotations to make this clearer when reading the code.
* `vyper/compiler.py`: Added `source_id` arg to various functions, to allow different IDs when compiling multiple contracts
* `vyper/compile_lll.py`: modified `assembly_to_evm` to allow source maps from constructor bytecode
* `vyper/cli/vyper_compile.py`: Renamed variables in to be more verbose / consistent with `vyper_json`
* `vyper/cli/*.py`:  Refactored `_parse_cli_args` to simplify `argparse` testing

### How to verify it
Run the tests at `tests/cli/vyper_json`


### Description for the changelog
Added `vyper-json` CLI tool

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/64071443-006c0b00-ccad-11e9-9c7c-d74db591fa54.png)

