### PR TITLE
Documentation fixes and updates

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -10,453 +10,261 @@ contracts.
 
 .. _functions:
 
-Functions
-=========
+.. py:function:: floor(value: decimal) -> int128
 
-**floor**
----------
-::
+    Rounds a decimal down to the nearest integer.
 
-  def floor(a) -> b:
-    """
-    :param a: value to round down
-    :type a: decimal
+    * ``value``: Decimal value to round down
 
-    :output b: int128
-    """
+.. py:function:: ceil(value: decimal) -> int128
 
-Rounds a decimal down to the nearest integer.
+    Rounds a decimal up to the nearest integer.
 
-**ceil**
----------
-::
+    * ``value``: Decimal value to round up
 
-  def ceil(a) -> b:
-    """
-    :param a: value to round up
-    :type a: decimal
+.. py:function:: convert(value, type_) -> Any
 
-    :output b: int128
-    """
+    Converts a variable or literal from one type to another.
 
-Rounds a decimal up to the nearest integer.
+    * ``value``: Value to convert
+    * ``type_``: The destination type to convert to (``bool``, ``decimal``, ``int128``, ``uint256`` or ``bytes32``)
 
-**convert**
------------
-::
+    Returns a value of the type specified by ``type_``.
 
-  def convert(a, b) -> c:
-    """
-    :param a: value to convert
-    :type a: either bool, decimal, int128, uint256 or bytes32
-    :param b: the destination type to convert to
-    :type b: type of either bool, decimal, int128, uint256 or bytes32
+    For more details on available type conversions, see :ref:`type_conversions`.
 
-    :output c: either decimal, int128, uint256 or bytes32
-    """
+.. py:function:: clear(var: Any) -> None
 
-Converts a variable or literal from one type to another.
+    Clears a variable's contents to the default value of its type.
 
-For more details on available type conversions, see :ref:`type_conversions`.
+    * ``var``: Variable to clear
 
-**clear**
----------
-::
+.. py:function:: as_wei_value(value: int, unit: str) -> wei_value
 
-  def clear(a):
-    """
-    :param a: variable to reset to its default value
-    :type a: all types
-    """
+    Takes an amount of ether currency specified by a number and a unit and returns the integer quantity of wei equivalent to that amount.
 
-Clears a variable's contents to the default value of its type.
+    * ``value``: Value for the ether unit
+    * ``unit``: Ether unit name (e.g. ``"wei"``, ``"ether"``, ``"gwei"``, etc.)
 
-**as_wei_value**
-----------------
-::
+.. py:function:: as_unitless_number(value) -> int
 
-  def as_wei_value(a, b) -> c:
-    """
-    :param a: value for the ether unit
-    :type a: uint256 or int128 or decimal
-    :param b: ether unit name (e.g. ``"wei"``)
-    :type b: str_literal
+    Converts a ``int128``, ``uint256``, or ``decimal`` value with units into one without units (used for assignment and math).
 
-    :output c: wei_value
-    """
+.. py:function:: slice(b: bytes, start: int128, length: int128) -> bytes
 
-Takes an amount of ether currency specified by a number and a unit (e.g. ``"wei"``, ``"ether"``,
-``"gwei"``, etc.) and returns the integer quantity of wei equivalent to that amount.
+    Copies a list of bytes and returns a specified slice.
 
-**as_unitless_number**
-----------------------
-::
+    * ``b``: ``bytes`` or ``bytes32`` to be sliced
+    * ``start``: start position of the slice
+    * ``length``: length of the slice
 
-  def as_unitless_number(a) -> b:
-    """
-    :param a: value to remove units from
-    :type a: either decimal or int128
+.. py:function:: len(b: bytes) -> int128
 
-    :output b: either decimal or int128
-    """
+    Returns the length of a given ``bytes`` list.
 
-Converts a ``int128``, ``uint256``, or ``decimal`` value with units into one without units (used for
-assignment and math).
+.. py:function:: concat(a, b, *args) -> bytes
 
-**slice**
----------
-::
+    Takes 2 or more bytes arrays of type ``bytes32`` or ``bytes`` and combines them into a single ``bytes`` list.
 
-  def slice(a, start=b, len=c) -> d:
-    """
-    :param a: bytes to be sliced
-    :type a: either bytes or bytes32
-    :param b: start position of the slice
-    :type b: int128
-    :param c: length of the slice
-    :type c: int128
+.. py:function:: keccak256(value) -> bytes32
 
-    :output d: bytes
-    """
+    Returns a ``keccak256`` hash of the given value.
 
-Takes a list of bytes and copies, then returns a specified chunk.
+    * ``value``: Value to hash. Can be ``str_literal``, ``bytes``, or ``bytes32``.
 
-**len**
--------
-::
+.. py:function:: sha256(value) -> bytes32
 
-  def len(a) -> b:
-    """
-    :param a: value to get the length of
-    :type a: bytes
+    Returns a ``sha256`` (SHA2 256bit output) hash of the given value.
 
-    :output b: int128
-    """
+    * ``value``: Value to hash. Can be ``str_literal``, ``bytes``, or ``bytes32``.
 
-Returns the length of a given list of bytes.
+.. py:function:: sqrt(d: decimal) -> decimal
 
-**concat**
-----------
-::
+    Returns the square root of the provided decimal number, using the Babylonian square root algorithm.
 
-  def concat(a, b, ...) -> c:
-    """
-    :param a: value to combine
-    :type a: bytes, bytes32
-    :param b: value to combine
-    :type b: bytes, bytes32
+.. py:function:: method_id(method, type_) -> Union[bytes32, bytes[4]]
 
-    :output c: bytes
-    """
+    Takes a function declaration and returns its method_id (used in data field to call it).
 
-Takes 2 or more bytes arrays of type ``bytes32`` or ``bytes`` and combines them into one.
+    * ``method``: Method declaration as ``str_literal``
+    * ``type_``: Type of output (``bytes32`` or ``bytes[4]``)
 
-**keccak256**
--------------
-::
+    Returns a value of the type specified by ``type_``.
 
-  def keccak256(a) -> b:
-    """
-    :param a: value to hash
-    :type a: either str_literal, bytes, bytes32
+.. py:function:: ecrecover(hash: bytes32, v: uint256, r: uint256, s: uint256) -> address
 
-    :output b: bytes32
-    """
+    Takes a signed hash and vrs and returns the public key of the signer.
 
-Returns ``keccak256`` hash of input.
+.. py:function:: ecadd(a: uint256[2], b: uint256[2]) -> uint256[2]
 
-**sha256**
-----------
-::
+    Takes two points on the Alt-BN128 curve and adds them together.
 
-  def sha256(a) -> b:
-    """
-    :param a: value to hash
-    :type a: either str_literal, bytes, bytes32
-
-    :output b: bytes32
-    """
-
-Returns ``sha256`` (SHA2 256bit output) hash of input.
+.. py:function:: ecmul(point: uint256[2], scalar: uint256) -> uint256[2]
 
-**sqrt**
---------
-::
+    Takes a point on the Alt-BN128 curve (``p``) and a scalar value (``s``), and returns the result of adding the point to itself ``s`` times, i.e. ``p * s``.
 
-  def sqrt(a: decimal) -> decimal:
-    """
-    :param a:
-    :type a: decimal, larger than 0.0
-
-    :output sqrt: decimal
-    """
-
-Returns the suare of the provided decimal number, using the Babylonian square root algorithm.
-
-**method_id**
--------------
-::
+    * ``point``: Point to be multiplied
+    * ``scalar``: Scalar value
 
-  def method_id(a, b) -> c:
-    """
-    :param a: method declaration
-    :type a: str_literal
-    :param b: type of output
-    :type b: either bytes32 or bytes[4]
+.. py:function:: extract32(b: bytes, start: int128, type_=bytes32) -> Union[bytes32, int128, address]
 
-    :output c: either bytes32 or bytes[4]
-    """
+    Extracts a value from a ``bytes`` list.
 
-Takes a function declaration and returns its method_id (used in data field to call it).
+    * ``b``: ``bytes`` list to extract from
+    * ``start``: Start point to extract from
+    * ``type_``: Type of output (``bytes32``, ``int128``, or ``address``). Defaults to ``bytes32``.
 
-**ecrecover**
--------------
-::
+    Returns a value of the type specified by ``type_``.
 
-  def ecrecover(hash, v, r, s) -> b:
-    """
-    :param hash: a signed hash
-    :type hash: bytes32
-    :param v:
-    :type v: uint256
-    :param r: elliptic curve point
-    :type r: uint256
-    :param s: elliptic curve point
-    :type s: uint256
+.. py:function:: RLPList(b: bytes, types_list: List) -> LLLnode
 
-    :output b: address
-    """
+    Takes encoded RLP data and an unencoded list of types.
 
-Takes a signed hash and vrs and returns the public key of the signer.
+    * ``b``: Encoded data
+    * ``types_list``: List of types
 
-**ecadd**
----------
-::
+    Example usage:
 
-  def ecadd(a, b) -> sum:
-    """
-    :param a: pair to be added
-    :type a: uint256[2]
-    :param b: pair to be added
-    :type b: uint256[2]
+    .. code-block:: python
 
-    :output sum: uint256[2]
-    """
+        vote_msg: bytes <= 1024 = ...
 
-Takes two elliptic curves and adds them together.
+        values = RLPList(vote_msg, [int128, int128, bytes32, bytes, bytes])
 
-**ecmul**
----------
-::
+        var1: int128 = values[0]
+        var2: int128 = values[1]
+        var3: bytes32 = values[2]
+        var4: bytes <= 1024 = values[3]
+        var5: bytes <= 1024 = values[4]
 
-  def ecmul(a, b) -> product:
-    """
-    :param a: pair to be multiplied
-    :type a: uint256[2]
-    :param b: number to be multiplied
-    :type b: uint256
+    RLP decoder needs to be deployed if one wishes to use it outside of the Vyper test suite. Eventually, the decoder will be available on mainnet at a fixed address. But for now, here's how to create RLP decoder on other chains:
 
-    :output product: uint256[2]
-    """
+    \1. send 6270960000000000 wei to ``0xd2c560282c9C02465C2dAcdEF3E859E730848761``
 
-Takes two elliptic curves and multiplies them together.
+    \2. Publish this tx to create the contract
 
-**extract32**
--------------
-::
+    ::
 
-  def extract32(a, b, type=c) -> d:
-    """
-    :param a: where 32 bytes are extracted from
-    :type a: bytes
-    :param b: start point of bytes to be extracted
-    :type b: int128
-    :param c: type of output (Optional, default: bytes32)
-    :type c: either bytes32, int128, or address
+        0xf90237808506fc23ac00830330888080b902246102128061000e60003961022056600060007f010000000000000000000000000000000000000000000000000000000000000060003504600060c082121515585760f882121561004d5760bf820336141558576001905061006e565b600181013560f783036020035260005160f6830301361415585760f6820390505b5b368112156101c2577f010000000000000000000000000000000000000000000000000000000000000081350483602086026040015260018501945060808112156100d55760018461044001526001828561046001376001820191506021840193506101bc565b60b881121561014357608081038461044001526080810360018301856104600137608181141561012e5760807f010000000000000000000000000000000000000000000000000000000000000060018401350412151558575b607f81038201915060608103840193506101bb565b60c08112156101b857600182013560b782036020035260005160388112157f010000000000000000000000000000000000000000000000000000000000000060018501350402155857808561044001528060b6838501038661046001378060b6830301830192506020810185019450506101ba565bfe5b5b5b5061006f565b601f841315155857602060208502016020810391505b6000821215156101fc578082604001510182826104400301526020820391506101d8565b808401610420528381018161044003f350505050505b6000f31b2d4f
 
-    :output d: either bytes32, int128, or address
-    """
-
-**RLPList**
------------
-::
-
-  def _RLPList(a, b) -> c:
-    """
-    :param a: encoded data
-    :type a: bytes
-    :param b: RLP list
-    :type b: list
-
-    :output c: LLLnode
-    """
-
-Takes encoded RLP data and an unencoded list of types. Usage::
-
-  vote_msg: bytes <= 1024 = ...
-
-  values = RLPList(vote_msg, [int128, int128, bytes32, bytes, bytes])
-
-  var1: int128 = values[0]
-  var2: int128 = values[1]
-  var3: bytes32 = values[2]
-  var4: bytes <= 1024 = values[3]
-  var5: bytes <= 1024 = values[4]
-
-Note: RLP decoder needs to be deployed if one wishes to use it outside of the Vyper test suite. Eventually, the decoder will be available on mainnet at a fixed address. But for now, here's how to create RLP decoder on other chains:
-
-\1. send 6270960000000000 wei to 0xd2c560282c9C02465C2dAcdEF3E859E730848761
-
-\2. Publish this tx to create the contract::
-
-   0xf90237808506fc23ac00830330888080b902246102128061000e60003961022056600060007f010000000000000000000000000000000000000000000000000000000000000060003504600060c082121515585760f882121561004d5760bf820336141558576001905061006e565b600181013560f783036020035260005160f6830301361415585760f6820390505b5b368112156101c2577f010000000000000000000000000000000000000000000000000000000000000081350483602086026040015260018501945060808112156100d55760018461044001526001828561046001376001820191506021840193506101bc565b60b881121561014357608081038461044001526080810360018301856104600137608181141561012e5760807f010000000000000000000000000000000000000000000000000000000000000060018401350412151558575b607f81038201915060608103840193506101bb565b60c08112156101b857600182013560b782036020035260005160388112157f010000000000000000000000000000000000000000000000000000000000000060018501350402155857808561044001528060b6838501038661046001378060b6830301830192506020810185019450506101ba565bfe5b5b5b5061006f565b601f841315155857602060208502016020810391505b6000821215156101fc578082604001510182826104400301526020820391506101d8565b808401610420528381018161044003f350505050505b6000f31b2d4f
-
-\3. This is the contract address: 0xCb969cAAad21A78a24083164ffa81604317Ab603
+    \3. This is the contract address: ``0xCb969cAAad21A78a24083164ffa81604317Ab603``
 
 Low Level Built in Functions
 ****************************
 
-Vyper contains a set of built in functions which executes unique OPCODES such as send or selfdestruct.
+Vyper contains a set of built in functions which execute opcodes such as ``SEND`` or ``SELFDESTRUCT``.
 
-.. low_level_functions:
+.. py:function:: send(to: address, value: uint256(wei)) -> None
 
-Low Level Functions
-===================
+    Sends ether from the contract to the specified Ethereum address.
 
-**send**
---------
-::
+    * ``to``: The destination address to send ether to
+    * ``value``: The wei value to send to the address
 
-  def send(a, b):
-    """
-    :param a: the destination address to send ether to
-    :type a: address
-    :param b: the wei value to send to the address
-    :type b: uint256(wei)
-    """
+    .. note::
 
-Sends ether from the contract to the specified Ethereum address.
-Note that the amount to send should be specified in wei.
+        The amount to send is always specified in ``wei``.
 
-**raw_call**
-------------
-::
+.. py:function:: raw_call(to: address, data: bytes, outsize: int, gas: uint256, value: uint256(wei) = 0, is_delegate_call: bool = False) -> bytes[outsize]
 
-  def raw_call(a, b, outsize=c, gas=d, value=e, delegate_call=f) -> g:
-    """
-    :param a: the destination address to call to
-    :type a: address
-    :param b: the data to send the called address
-    :type b: bytes
-    :param c: the max-length for the bytes array returned from the call.
-    :type c: fixed literal value
-    :param d: the gas amount to attach to the call.
-    :type d: uint256
-    :param e: the wei value to send to the address (Optional, default: 0)
-    :type e: uint256
-    :param f: the bool of whether or not to use DELEGATECALL (Optional, default: False)
-    :type f: bool
+    Calls to the specified Ethereum address.
 
-    :output g: bytes[outsize]
-    """
+    * ``to``: Destination address to call to
+    * ``data``: Data to send to the destination address
+    * ``outsize``: Maximum length of the bytes array returned from the call
+    * ``gas``: Amount of gas to atttach to the call
+    * ``value``: The wei value to send to the address (Optional, default ``0``)
+    * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)
 
-Calls to the specified Ethereum address.
-The call should pass data and may optionally send eth value (specified in wei) as well.
-The call must specify a gas amount to attach the call and and the outsize.
-Returns the data returned by the call as a bytes array with the outsize as the max length.
+    Returns the data returned by the call as a ``bytes`` list, with ``outsize`` as the max length.
 
-**selfdestruct**
-----------------
-::
+.. py:function:: selfdestruct(to: address) -> None
 
-  def selfdestruct(a):
-    """
-    :param a: the address to send the contracts left ether to
-    :type a: address
-    """
+    Triggers the ``SELFDESTRUCT`` opcode (``0xFF``), causing the contract to be destroyed.
 
-Causes a self destruction of the contract, triggers the ``SELFDESTRUCT`` opcode (0xff).
-CAUTION! This method will delete the contract from the Ethereum blockchain. All none ether assets associated with this contract will be "burned" and the contract will be inaccessible.
+    * ``to``: Address to forward the contract's ether balance to
 
-**raise**
-----------
-::
+    .. warning::
 
-  def raise(a):
-    """
-    :param a: the exception reason (must be <= 32 bytes)
-    :type a: str
-    """
+        This method will delete the contract from the Ethereum blockchain. All non-ether assets associated with this contract will be "burned" and the contract will be inaccessible.
 
-Raises an exception by triggering the OPCODE ``REVERT`` (0xfd) with the provided reason given as the error message. The code will stop operation, the contract's state will be reverted to the state before the transaction took place and the remaining gas will be returned to the transaction's sender.
+.. py:function:: raise(reason: str) -> None
 
-Note: To give it a more Python-like syntax, the raise function can be called without parenthesis, the syntax would be ``raise "An exception"``. Even though both options will compile, it's recommended to use the Pythonic version without parentheses.
+    Raises an exception.
 
-**assert**
-----------
-::
+    * ``reason``: The exception reason (must be <= 32 bytes)
 
-  def assert(a, reason=None):
-    """
-    :param a: the boolean condition to assert
-    :type a: bool
-    :param reason: the reason provided to REVERT
-    :param reason=UNREACHABLE: generate an INVALID opcode
-    :type b: str
-    """
+    This method triggers the ``REVERT`` opcode (``0xFD``) with the provided reason given as the error message. The code will stop operation, the contract's state will be reverted to the state before the transaction took place and the remaining gas will be returned to the transaction's sender.
 
-Asserts the specified condition. The behavior is equivalent to::
+    .. note::
 
-  if not a:
-    raise reason
+        To give it a more Python-like syntax, the raise function can be called without parenthesis, the syntax would be ``raise "An exception"``. Even though both options will compile, it's recommended to use the Pythonic version without parentheses.
 
-(the only difference in behavior is that ``assert`` can be called without a reason string, while ``raise`` requires a reason string).
+.. py:function:: assert(cond: bool, reason: str = None) -> None
 
-If assert is passed to an assert statement, an INVALID (0xFE) opcode will be used instead of an REVERT opcode.
+    Asserts the specified condition.
 
-Note: To give it a more Python-like syntax, the assert function can be called without parenthesis, the syntax would be ``assert your_bool_condition``. Even though both options will compile, it's recommended to use the Pythonic version without parenthesis.
+    * ``cond``: The boolean condition to assert
+    * ``reason``: The exception reason (must be <= 32 bytes)
 
-**raw_log**
------------
-::
+    This method's behavior is equivalent to:
 
-  def raw_log(a, b):
-    """
-    :param a: 0-4 topics.
-    :type a: list of bytes32 of length 0-4
-    :param b: the name of the logged event
-    :type b: bytes
-    """
+    .. code-block:: python
 
-Emits a log without specifying the abi type, with the arguments entered as the first input.
+        if not cond:
+            raise reason
 
-**create_forwarder_to**
------------------------
-::
+    The only difference in behavior is that ``assert`` can be called without a reason string, while ``raise`` requires one.
 
-  def create_forwarder_to(a, value=b):
-    """
-    :param a: the address of the contract to duplicate.
-    :type a: address
-    :param b: the wei value to send to the new contract instance (Optional, default: 0)
-    :type b: uint256(wei)
-    """
+    If the reason string is set to ``UNREACHABLE``, an ``INVALID`` opcode (``0xFE``) will be used instead of ``REVERT``. In this case, calls that revert will not receive a gas refund.
 
-Duplicates a contract's code and deploys it as a new instance, by means of a DELEGATECALL.
-You can also specify wei value to send to the new contract as ``value=the_value``.
+    You cannot directly ``assert`` the result of a non-constant function call. The proper pattern for doing so is to assign the result to a memory variable, and then call assert on that variable. Alternatively, use the :ref:`assert_modifiable<assert-modifiable>` method.
 
-**blockhash**
--------------
-::
+    .. note::
 
-  def blockhash(a) -> hash:
-    """
-    :param a: the number of the block to get
-    :type a: uint256
+        To give it a more Python-like syntax, the assert function can be called without parenthesis, the syntax would be ``assert your_bool_condition``. Even though both options will compile, it's recommended to use the Pythonic version without parenthesis.
 
-    :output hash: bytes32
-    """
+.. _assert-modifiable:
 
-Returns the hash of the block at the specified height.
+.. py:function:: assert_modifiable(cond: bool) -> None
 
-**Note: The EVM only provides access to the most 256 blocks. This function will return 0 if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.**
+    Asserts a specified condition, without checking for constancy on a callable condition.
+
+    * ``cond``: The boolean condition to assert
+
+    Use ``assert_modifiable`` in place of ``assert`` when you wish to directly assert the result of a potentially state-changing call.
+
+    For example, a common use case is verifying the results of an ERC20 token transfer:
+
+    .. code-block:: python
+
+        @public
+        def transferTokens(token: address, to: address, amount: uint256) -> bool:
+            assert_modifiable(ERC20(token).transfer(to, amount))
+            return True
+
+.. py:function:: raw_log(topics: bytes32[4], data: bytes) -> None
+
+    Provides low level access to the ``LOG`` opcodes, emitting a log without having to specify an ABI type.
+
+    * ``topics``: List of ``bytes32`` log topics
+    * ``data``: Unindexed event data to include in the log
+
+    This method provides low-level access to the ``LOG`` opcodes (``0xA0``..``0xA4``). The length of ``topics`` determines which opcode will be used.
+
+.. py:function:: create_forwarder_to(target: address, value: uint256(wei) = 0) -> address
+
+    Duplicates a contract's code and deploys it as a new instance, by means of a ``DELEGATECALL``.
+
+    * ``target``: Address of the contract to duplicate
+    * ``value``: The wei value to send to the new contract address (Optional, default 0)
+
+    Returns the address of the duplicated contract.
+
+.. py:function:: blockhash(block_num: uint256) -> bytes32
+
+    Returns the hash of the block at the specified height.
+
+    .. note::
+
+        The EVM only provides access to the most 256 blocks. This function will return 0 if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,14 +65,14 @@ Glossary
     :maxdepth: 2
 
     installing-vyper.rst
-    compiling-a-contract.rst
-    testing-contracts.rst
-    deploying-contracts.rst
-    structure-of-a-contract.rst
     vyper-by-example.rst
-    logging.rst
-    contributing.rst
-    frequently-asked-questions.rst
+    structure-of-a-contract.rst
     built-in-functions.rst
     types.rst
+    logging.rst
+    compiling-a-contract.rst
+    deploying-contracts.rst
+    testing-contracts.rst
+    frequently-asked-questions.rst
+    contributing.rst
     release-notes.rst

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -32,8 +32,8 @@ Ubuntu
 Start by making sure your packages are up-to-date:
 ::
 
-    sudo apt-get update
-    sudo apt-get -y upgrade
+    $ sudo apt-get update
+    $ sudo apt-get -y upgrade
 
 Install Python 3.6 and some necessary packages:
 ::
@@ -49,7 +49,7 @@ Install Python 3.6 and some necessary packages:
 16.10 and newer
 ^^^^^^^^^^^^^^^
 
-From Ubuntu 16.10 onwards, the Python 3.6 version is in the `universe`
+From Ubuntu 16.10 onwards, the Python 3.6 version is in the ``universe``
 repository.
 
 Run the following commands to install:
@@ -59,7 +59,7 @@ Run the following commands to install:
     sudo apt-get install python3.6
 
 .. note::
-   If you get the error `Python.h: No such file or directory` you need to install the python header files for the Python C API with
+   If you get the error ``Python.h: No such file or directory`` you need to install the python header files for the Python C API with
    ::
 
        sudo apt-get install python3-dev
@@ -68,17 +68,19 @@ Using a BASH script
 ^^^^^^^^^^^^^^^^^^^
 
 Vyper can be installed using a bash script.
+
 ::
 
     https://github.com/balajipachai/Scripts/blob/master/install_vyper/install_vyper_ubuntu.sh
 
 
-*Reminder*: Please read and understand the commands in any bash script before executing, especially with `sudo`.
+**Reminder**: Please read and understand the commands in any bash script before executing, especially with ``sudo``.
 
 Arch
 ----
 
-Using your aur helper of choice (`yay` here).
+Using your aur helper of choice (``yay`` in this example).
+
 ::
 
     yay -S vyper
@@ -86,18 +88,18 @@ Using your aur helper of choice (`yay` here).
 MacOS
 -----
 
-Make sure you have Homebrew installed. If you don't have the `brew` command
+Make sure you have Homebrew installed. If you don't have the ``brew`` command
 available on the terminal, follow `these instructions <https://docs.brew.sh/Installation.html>`_
 to get Homebrew on your system.
 
 To install Python 3.6, follow the instructions here:
-`Installing Python 3 on Mac OS X <http://python-guide.readthedocs.io/en/latest/starting/install3/osx/>`_
+`Installing Python 3 on Mac OS X <https://python-guide.readthedocs.io/en/latest/starting/install3/osx/>`_
 
-Also, ensure the following libraries are installed using `brew`:
+Also, ensure the following libraries are installed using ``brew``:
 ::
 
     brew install gmp leveldb
-	
+
 Windows
 --------
 
@@ -106,7 +108,7 @@ Windows users can first `install Windows Subsystem for Linux <https://docs.micro
 .. note::
     - Windows Subsystem for Linux is only available for Windows 10.
     - Windows versions that are < 10 and Windows 10 Home should install the slightly outdated `Docker Toolbox <https://docs.docker.com/toolbox/toolbox_install_windows/>`_, as explained in the link.
-   
+
 
 Creating a virtual environment
 ==============================
@@ -156,10 +158,10 @@ Additionally, you may try to compile an example contract by running:
     vyper examples/crowdfund.vy
 
 If everything works correctly, you are now able to compile your own smart contracts written in Vyper.
-If any unexpected errors or exceptions are encountered, please feel free to `create an issue <https://github.com/ethereum/vyper/issues/new>`_.
+If any unexpected errors or exceptions are encountered, please feel free to `open an issue <https://github.com/ethereum/vyper/issues/new>`_.
 
 .. note::
-    If you get the error `fatal error: openssl/aes.h: No such file or directory` in the output of `make`, then run `sudo apt-get install libssl-dev1`, then run `make` again.
+    If you get the error ``fatal error: openssl/aes.h: No such file or directory`` in the output of ``make``, then run ``sudo apt-get install libssl-dev1``, then run ``make`` again.
 
     **For MacOS users:**
 
@@ -181,18 +183,18 @@ If any unexpected errors or exceptions are encountered, please feel free to `cre
         make dev-deps
         make test
 
-    If you get the error `ld: library not found for -lyaml` in the output of `make`, make sure `libyaml` is installed using `brew info libyaml`. If it is installed, add its location to the compile flags as well:
+    If you get the error ``ld: library not found for -lyaml`` in the output of `make`, make sure ``libyaml`` is installed using ``brew info libyaml``. If it is installed, add its location to the compile flags as well:
     ::
 
         export CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libyaml)/include"
         export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libyaml)/lib"
 
-    You can then run `make` and `make test` again.
+    You can then run ``make`` and ``make test`` again.
 
 PIP
 ***
 
-Each tagged version of vyper is also uploaded to pypi, and can be installed using pip.
+Each tagged version of vyper is also uploaded to `pypi <https://pypi.org/project/vyper/>`_, and can be installed using ``pip``.
 ::
 
     pip install vyper
@@ -249,7 +251,7 @@ and try compiling a contract:
 Snap
 ****
 
-Vyper is published in the snap store. In any of the `supported Linux distros <https://snapcraft.io/docs/core/install>`_, install it with (Note that installing the above snap is the latest master):
+Vyper is published in the snap store. In any of the `supported Linux distros <https://snapcraft.io/docs/installing-snapd>`_, install it with (Note that installing the above snap is the latest master):
 ::
 
     sudo snap install vyper --edge --devmode

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -32,8 +32,8 @@ Ubuntu
 Start by making sure your packages are up-to-date:
 ::
 
-    $ sudo apt-get update
-    $ sudo apt-get -y upgrade
+    sudo apt-get update
+    sudo apt-get -y upgrade
 
 Install Python 3.6 and some necessary packages:
 ::

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -7,7 +7,7 @@ Like Solidity and other EVM languages, Vyper can log events to be caught and dis
 Example of Logging
 ==================
 
-This example is taken from the `sample ERC20 contract <https://github.com/ethereum/vyper/blob/master/examples/tokens/ERC20_solidity_compatible/ERC20.vy>`_ and shows the basic flow of event logging.
+This example is taken from the `sample ERC20 contract <https://github.com/ethereum/vyper/blob/master/examples/tokens/ERC20.vy>`_ and shows the basic flow of event logging.
 
 ::
 
@@ -25,11 +25,11 @@ This example is taken from the `sample ERC20 contract <https://github.com/ethere
 
 Let's look at what this is doing. First, we declare two event types to log. The two events are similar in that they contain
 two indexed address fields. Indexed fields do not make up part of the event data itself, but can be searched by clients that
-want to catch the event. Also, each event contains one single data field, in each case called _value. Events can contain several arguments with any names desired.
+want to catch the event. Also, each event contains one single data field, in each case called ``_value``. Events can contain several arguments with any names desired.
 
 Next, in the ``transfer`` function, after we do whatever work is necessary, we log the event. We pass three arguments, corresponding with the three arguments of the Transfer event declaration.
 
-Clients listening to the events will declare and handle the events they are interested in using a `library such as web3.js <http://solidity.readthedocs.io/en/develop/contracts.html#events>`_:
+Clients listening to the events will declare and handle the events they are interested in using a `library such as web3.js <https://solidity.readthedocs.io/en/latest/contracts.html#events>`_:
 
 ::
 
@@ -58,17 +58,17 @@ Let's look at an event declaration in more detail.
 
 Event declarations look like state variable declarations but use the special keyword event. event takes its arguments that consists of all the arguments to be passed as part of the event. Typical events will contain two kinds of arguments:
 
-* Indexed arguments, which can be searched for by listeners. Each indexed argument is identified by the `indexed` keyword.  Here, each indexed argument is an address. You can have any number of indexed arguments, but indexed arguments are not passed directly to listeners, although some of this information (such as the sender) may be available in the listener's `results` object.
+* Indexed arguments, which can be searched for by listeners. Each indexed argument is identified by the ``indexed`` keyword.  Here, each indexed argument is an address. You can have any number of indexed arguments, but indexed arguments are not passed directly to listeners, although some of this information (such as the sender) may be available in the listener's `results` object.
 * Value arguments, which are passed through to listeners. You can have any number of value arguments and they can have arbitrary names, but each is limited by the EVM to be no more than 32 bytes.
 
-Note that while the argument definition syntax looks like a Python dictionary, it's actually an order-sensitive definition. (Python dictionaries `maintain order starting with 3.7 <https://mail.python.org/pipermail/python-dev/2017-December/151283.html>`_.) Thus, the first element (_from) will be matched up with the first argument passed in the log.Transfer call.
+Note that while the argument definition syntax looks like a Python dictionary, it's actually an order-sensitive definition. (Python dictionaries `maintain order starting with 3.7 <https://mail.python.org/pipermail/python-dev/2017-December/151283.html>`_.) Thus, the first element (``_from``) will be matched up with the first argument passed in the log.Transfer call.
 
 Logging Events
 ==============
 
 Once an event is declared, you can log (send) events. You can send events as many times as you want to. Please note that events sent do not take state storage and thus do not cost gas: this makes events a good way to save some information. However, the drawback is that events are not available to contracts, only to clients.
 
-Logging events is done using the magic keyword `log`:
+Logging events is done using the magic keyword ``log``:
 
 ::
 
@@ -79,4 +79,4 @@ The order and types of arguments sent needs to match up with the order of declar
 Listening for Events
 ====================
 
-In the example listener above, the `result` arg actually passes a `large amount of information <https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events>`_. Here we're most interested in `result.args`. This is an object with properties that match the properties declared in the event. Note that this object does not contain the indexed properties, which can only be searched in the original `myToken.Transfer` that created the callback.
+In the example listener above, the ``result`` arg actually passes a `large amount of information <https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events>`_. Here we're most interested in ``result.args``. This is an object with properties that match the properties declared in the event. Note that this object does not contain the indexed properties, which can only be searched in the original ``myToken.Transfer`` that created the callback.

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,7 +16,7 @@ Some of the bug and stability fixes:
 
 - ``@nonreentrant``/``@constant`` logical inconsistency (`#1544 <https://github.com/ethereum/vyper/issues/1544>`_)
 - Struct passthrough issue (`#1551 <https://github.com/ethereum/vyper/issues/1551>`_)
-- Private underflow issue (`#1470 <https://github.com/ethereum/vyper/issues/1470>`_)
+- Private underflow issue (`#1470 <https://github.com/ethereum/vyper/pull/1470>`_)
 - Constancy check issue (`#1480 <https://github.com/ethereum/vyper/pull/1480>`_)
 - Prevent use of conflicting method IDs (`#1530 <https://github.com/ethereum/vyper/pull/1530>`_)
 - Missing arg check for private functions (`#1579 <https://github.com/ethereum/vyper/pull/1579>`_)
@@ -37,12 +37,12 @@ Beta 11 brings some performance and stability fixes.
 - Reducing of contract size, for large parameter functions. (`#1486 <https://github.com/ethereum/vyper/pull/1486>`_)
 - Improvements for Windows users (`#1486 <https://github.com/ethereum/vyper/pull/1486>`_)  (`#1488 <https://github.com/ethereum/vyper/pull/1488>`_)
 - Array copy optimisation (`#1487 <https://github.com/ethereum/vyper/pull/1487>`_)
-- Fixing `@nonreentrant` decorator for return statements (`#1532 <https://github.com/ethereum/vyper/pull/1532>`_)
+- Fixing ``@nonreentrant`` decorator for return statements (`#1532 <https://github.com/ethereum/vyper/pull/1532>`_)
 - `sha3` builtin function removed  (`#1328 <https://github.com/ethereum/vyper/issues/1328>`_)
 - Disallow conflicting method IDs (`#1530 <https://github.com/ethereum/vyper/pull/1530>`_)
-- Additional `convert()` supported types (`#1524 <https://github.com/ethereum/vyper/pull/1524>`_) (`#1500 <https://github.com/ethereum/vyper/pull/1500>`_)
+- Additional ``convert()`` supported types (`#1524 <https://github.com/ethereum/vyper/pull/1524>`_) (`#1500 <https://github.com/ethereum/vyper/pull/1500>`_)
 - Equality operator for strings and bytes (`#1507 <https://github.com/ethereum/vyper/pull/1507>`_)
-- Change in `compile_codes` interface function (`#1504 <https://github.com/ethereum/vyper/pull/1504>`_)
+- Change in ``compile_codes`` interface function (`#1504 <https://github.com/ethereum/vyper/pull/1504>`_)
 
 Thanks to all the contributors!
 
@@ -54,12 +54,12 @@ Date released: 24-05-2019
 - Lots of linting and refactoring!
 - Bugfix with regards to using arrays as parameters to private functions (`#1418 <https://github.com/ethereum/vyper/issues/1418>`_). Please check your contracts, and upgrade to latest version, if you do use this.
 - Slight shrinking in init produced bytecode. (`#1399 <https://github.com/ethereum/vyper/issues/1399>`_)
-- Additional constancy protection in the `for .. range` expression. (`#1397 <https://github.com/ethereum/vyper/issues/1397>`_)
+- Additional constancy protection in the ``for .. range`` expression. (`#1397 <https://github.com/ethereum/vyper/issues/1397>`_)
 - Improved bug report (`#1394 <https://github.com/ethereum/vyper/issues/1394>`_)
 - Fix returning of External Contract from functions (`#1376 <https://github.com/ethereum/vyper/issues/1376>`_)
 - Interface unit fix (`#1303 <https://github.com/ethereum/vyper/issues/1303>`_)
 - Not Equal (!=) optimisation (`#1303 <https://github.com/ethereum/vyper/issues/1303>`_) 1386
-- New `assert <condition>, UNREACHABLE` statement. (`#711 <https://github.com/ethereum/vyper/issues/711>`_)
+- New ``assert <condition>, UNREACHABLE`` statement. (`#711 <https://github.com/ethereum/vyper/issues/711>`_)
 
 Special thanks to (`Charles Cooper <https://github.com/charles-cooper>`_), for some excellent contributions this release.
 
@@ -72,7 +72,7 @@ Date released: 12-03-2019
 - Add sha256 function (`#1327 <https://github.com/ethereum/vyper/issues/1327>`_)
 - Renamed create_with_code_of to create_forwarder_to (`#1177 <https://github.com/ethereum/vyper/issues/1177>`_)
 - @nonreentrant Decorator  (`#1204 <https://github.com/ethereum/vyper/issues/1204>`_)
-- Add opcodes and opcodes_runtime flags to compiler (`#1255 <https://github.com/ethereum/vyper/issues/1255>`_)
+- Add opcodes and opcodes_runtime flags to compiler (`#1255 <https://github.com/ethereum/vyper/pull/1255>`_)
 - Improved External contract call interfaces (`#885 <https://github.com/ethereum/vyper/issues/885>`_)
 
 Prior to v0.1.0-beta.9
@@ -82,18 +82,18 @@ Prior to this release, we managed our change log in a different fashion.
 Here is the old changelog:
 
 * **2019.04.05**: Add stricter checking of unbalanced return statements. (`#590 <https://github.com/ethereum/vyper/issues/590>`_)
-* **2019.03.04**: `create_with_code_of` has been renamed to `create_forwarder_to`. (`#1177 <https://github.com/ethereum/vyper/issues/1177>`_)
-* **2019.02.14**: Assigning a persistent contract address can only be done using the `bar_contact = ERC20(<address>)` syntax.
-* **2019.02.12**: ERC20 interface has to be imported using `from vyper.interfaces import ERC20` to use.
-* **2019.01.30**: Byte array literals need to be annoted using `b""`, strings are represented as `""`.
-* **2018.12.12**: Disallow use of `None`, disallow use of `del`, implemented `clear()` built-in function.
-* **2018.11.19**: Change mapping syntax to use map(). (`VIP564 <https://github.com/ethereum/vyper/issues/564>`_)
+* **2019.03.04**: ``create_with_code_of`` has been renamed to ``create_forwarder_to``. (`#1177 <https://github.com/ethereum/vyper/issues/1177>`_)
+* **2019.02.14**: Assigning a persistent contract address can only be done using the ``bar_contact = ERC20(<address>)`` syntax.
+* **2019.02.12**: ERC20 interface has to be imported using ``from vyper.interfaces import ERC20`` to use.
+* **2019.01.30**: Byte array literals need to be annoted using ``b""``, strings are represented as `""`.
+* **2018.12.12**: Disallow use of ``None``, disallow use of ``del``, implemented ``clear()`` built-in function.
+* **2018.11.19**: Change mapping syntax to use ``map()``. (`VIP564 <https://github.com/ethereum/vyper/issues/564>`_)
 * **2018.10.02**: Change the convert style to use types instead of string. (`VIP1026 <https://github.com/ethereum/vyper/issues/1026>`_)
 * **2018.09.24**: Add support for custom constants.
 * **2018.08.09**: Add support for default parameters.
 * **2018.06.08**: Tagged first beta.
-* **2018.05.23**: Changed `wei_value` to be `uint256`.
-* **2018.04.03**: Changed bytes declaration from 'bytes <= n' to 'bytes[n]'.
+* **2018.05.23**: Changed ``wei_value`` to be ``uint256``.
+* **2018.04.03**: Changed bytes declaration from ``bytes <= n`` to ``bytes[n]``.
 * **2018.03.27**: Renaming ``signed256`` to ``int256``.
 * **2018.03.22**: Add modifiable and static keywords for external contract calls.
 * **2018.03.20**: Renaming ``__log__`` to ``event``.

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -94,9 +94,9 @@ Default function
 
 A contract can also have a default function, which is executed on a call to the contract if no other functions match the given function identifier (or if none was supplied at all, such as through someone sending it Eth). It is the same construct as fallback functions `in Solidity <https://solidity.readthedocs.io/en/latest/contracts.html?highlight=fallback#fallback-function>`_.
 
-This function is always named `__default__` and must be annotated with `@public`. It cannot have arguments and cannot return anything.
+This function is always named ``__default__`` and must be annotated with ``@public``. It cannot have arguments and cannot return anything.
 
-If the function is annotated as `@payable`, this function is executed whenever the contract is sent Ether (without data). This is why the default function cannot accept arguments and return values - it is a design decision of Ethereum to make no differentiation between sending ether to a contract or a user address.
+If the function is annotated as ``@payable``, this function is executed whenever the contract is sent Ether (without data). This is why the default function cannot accept arguments and return values - it is a design decision of Ethereum to make no differentiation between sending ether to a contract or a user address.
 
 **Example:**
 

--- a/docs/testing-contracts.rst
+++ b/docs/testing-contracts.rst
@@ -6,7 +6,7 @@ Testing a Contract
 ******************
 
 This documentation recommends the use of the `pytest <https://docs.pytest.org/en/latest/contents.html>`_ framework with
-the `ethereum-tester <https://github.com/ethereum/ethereum-tester>`_ package.
+the `ethereum-tester <https://github.com/ethereum/eth-tester>`_ package.
 Prior to testing, the vyper specific contract conversion and the blockchain related fixtures need to be set up.
 These fixtures will be used in every test file and should therefore be defined in
 `conftest.py <https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions>`_.

--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -30,6 +30,7 @@ Let's get started!
 
 .. literalinclude:: ../examples/auctions/simple_open_auction.vy
   :language: python
+  :lineno-start: 3
   :lines: 3-14
 
 We begin by declaring a few variables to keep track of our contract state.
@@ -53,7 +54,8 @@ Now, the constructor.
 
 .. literalinclude:: ../examples/auctions/simple_open_auction.vy
   :language: python
-  :pyobject: __init__
+  :lineno-start: 22
+  :lines: 22-26
 
 The contract is initialized with two arguments: ``_beneficiary`` of type
 ``address`` and ``_bidding_time`` with type ``timedelta``, the time difference
@@ -70,7 +72,8 @@ With initial setup out of the way, lets look at how our users can make bids.
 
 .. literalinclude:: ../examples/auctions/simple_open_auction.vy
   :language: python
-  :pyobject: bid
+  :lineno-start: 32
+  :lines: 32-43
 
 The ``@payable`` decorator will allow a user to send some ether to the
 contract in order to call the decorated method. In this case, a user wanting
@@ -95,7 +98,8 @@ the previous ``highestBid`` to the previous ``highestBidder`` and set our new
 
 .. literalinclude:: ../examples/auctions/simple_open_auction.vy
   :language: python
-  :pyobject: endAuction
+  :lineno-start: 57
+  :lines: 57-82
 
 With the ``endAuction()`` method, we check whether our current time is past
 the ``auctionEnd`` time we set upon initialization of the contract. We also
@@ -146,6 +150,7 @@ While this blind auction is almost functionally identical to the blind auction i
 
 .. literalinclude:: ../examples/auctions/blind_auction.vy
   :language: python
+  :lineno-start: 22
   :lines: 22-24
 
 One key difference is that, because Vyper does not allow for dynamic arrays, we
@@ -189,6 +194,7 @@ logic. Let's break down this contract bit by bit.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.vy
   :language: python
+  :lineno-start: 16
   :lines: 16-19
 
 Like the other contracts, we begin by declaring our global variables public with
@@ -197,7 +203,8 @@ variables to be *readable* by an external caller, but not *writeable*.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.vy
   :language: python
-  :pyobject: __init__
+  :lineno-start: 22
+  :lines: 22-29
 
 With a ``@payable`` decorator on the constructor, the contract creator will be
 required to make an initial deposit equal to twice the item's ``value`` to
@@ -211,7 +218,8 @@ in the contract variable ``self.value`` and saves the contract creator into
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.vy
   :language: python
-  :pyobject: abort
+  :lineno-start: 31
+  :lines: 31-36
 
 The ``abort()`` method is a method only callable by the seller and while the
 contract is still ``unlocked``—meaning it is callable only prior to any buyer
@@ -226,7 +234,8 @@ subsequently destroys the contract.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.vy
   :language: python
-  :pyobject: purchase
+  :lineno-start: 38
+  :lines: 38-45
 
 Like the constructor, the ``purchase()`` method has a ``@payable`` decorator,
 meaning it can be called with a payment. For the buyer to make a valid
@@ -238,7 +247,8 @@ send the item to the buyer.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.vy
   :language: python
-  :pyobject: received
+  :lineno-start: 47
+  :lines: 47-61
 
 Finally, upon the buyer's receipt of the item, the buyer can confirm their
 receipt by calling the ``received()`` method to distribute the funds as
@@ -276,7 +286,8 @@ previous examples. Let's dive right in.
 
 .. literalinclude:: ../examples/crowdfund.vy
   :language: python
-  :lines: 1-8
+  :lineno-start: 3
+  :lines: 3-13
 
 Like other examples, we begin by initiating our variables - except this time,
 we're not calling them with the ``public`` function. Variables initiated this
@@ -302,7 +313,8 @@ order to avoid gas limit issues in the scenario of a refund.
 
 .. literalinclude:: ../examples/crowdfund.vy
   :language: python
-  :pyobject: __init__
+  :lineno-start: 17
+  :lines: 17-22
 
 Our constructor function takes 3 arguments: the beneficiary's address, the goal
 in wei value, and the difference in time from start to finish of the
@@ -314,7 +326,8 @@ Now lets take a look at how a person can participate in the crowdfund.
 
 .. literalinclude:: ../examples/crowdfund.vy
   :language: python
-  :pyobject: participate
+  :lineno-start: 26
+  :lines: 26-34
 
 Once again, we see the ``@payable`` decorator on a method, which allows a
 person to send some ether along with a call to the method. In this case,
@@ -327,7 +340,8 @@ each participant.
 
 .. literalinclude:: ../examples/crowdfund.vy
   :language: python
-  :pyobject: finalize
+  :lineno-start: 38
+  :lines: 38-43
 
 The ``finalize()`` method is used to complete the crowdfunding process. However,
 to complete the crowdfunding, the method first checks to see if the crowdfunding
@@ -347,7 +361,8 @@ all the participants.
 
 .. literalinclude:: ../examples/crowdfund.vy
   :language: python
-  :pyobject: refund
+  :lineno-start: 47
+  :lines: 47-61
 
 In the ``refund()`` method, we first check that the crowdfunding period is
 indeed over and that the total collected balance is less than the ``goal`` with
@@ -379,6 +394,7 @@ section by section. Let’s begin!
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
+  :lineno-start: 3
   :lines: 3-25
 
 The variable ``voters`` is initialized as a mapping where the key is
@@ -399,7 +415,8 @@ Let’s move onto the constructor.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: __init__
+  :lineno-start: 53
+  :lines: 53-62
 
 .. note:: ``msg.sender`` and ``msg.value`` can only be accessed from public
   functions. If you require these values within a private function they must be
@@ -421,7 +438,8 @@ Now that the initial setup is done, lets take a look at the functionality.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: giveRightToVote
+  :lineno-start: 66
+  :lines: 66-75
 
 .. note:: Throughout this contract, we use a pattern where ``@public`` functions return data from ``@private`` functions that have the same name prepended with an underscore. This is because Vyper does not allow calls between public functions within the same contract. The private function handles the logic and allows internal access, while the public function acts as a getter to allow external viewing.
 
@@ -436,7 +454,8 @@ total number of voters by incrementing ``voterCount``.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: delegate
+  :lineno-start: 120
+  :lines: 120-135
 
 In the method ``delegate``, firstly, we check to see that ``msg.sender`` has not
 already voted and secondly, that the target delegate and the ``msg.sender`` are
@@ -450,7 +469,8 @@ if the delegate has not yet voted.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: vote
+  :lineno-start: 139
+  :lines: 139-151
 
 Now, let’s take a look at the logic inside the ``vote()`` method, which is
 surprisingly simple. The method takes the key of the proposal in the ``proposals``
@@ -469,6 +489,7 @@ is a read-only function and we benefit by saving gas fees.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
+  :lineno-start: 153
   :lines: 153-170
 
 The ``_winningProposal()`` method returns the key of proposal in the ``proposals``
@@ -480,7 +501,8 @@ respectively by looping through all the proposals.
 
 .. literalinclude:: ../examples/voting/ballot.vy
   :language: python
-  :pyobject: winnerName
+  :lineno-start: 175
+  :lines: 175-178
 
 And finally, the ``winnerName()`` method returns the name of the proposal by
 key’ing into the ``proposals`` mapping with the return result of the
@@ -521,7 +543,8 @@ function definitions.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :lines: 11-18
+  :lineno-start: 11
+  :lines: 11-17
 
 We initiate the ``company`` variable to be of type ``address`` that's public.
 The ``totalShares`` variable is of type ``currency_value``, which in this case
@@ -531,7 +554,8 @@ address to the number of shares the address owns.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: __init__
+  :lineno-start: 20
+  :lines: 20-31
 
 In the constructor, we set up the contract to check for valid inputs during
 the initialization of the contract via the two ``assert`` statements. If the
@@ -541,7 +565,8 @@ company's address is initialized to hold all shares of the company in the
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :lines: 33-44
+  :lineno-start: 34
+  :lines: 34-43
 
 We will be seeing a few ``@constant`` decorators in this contract—which is
 used to decorate methods that simply read the contract state or return a simple
@@ -559,7 +584,8 @@ company's holding.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: buyStock
+  :lineno-start: 46
+  :lines: 46-61
 
 The ``buyStock()`` method is a ``@payable`` method which takes an amount of
 ether sent and calculates the ``buyOrder`` (the stock value equivalence at
@@ -570,7 +596,8 @@ Now that people can buy shares, how do we check someone's holdings?
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :lines: 63-74
+  :lineno-start: 63
+  :lines: 63-73
 
 The ``_getHolding()`` is another ``@constant`` method that takes an ``address``
 and returns its corresponding stock holdings by keying into ``self.holdings``.
@@ -578,14 +605,16 @@ Again, a public function ``getHolding()`` is included to allow external access.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: cash
+  :lineno-start: 76
+  :lines: 76-79
 
 To check the ether balance of the company, we can simply call the getter method
 ``cash()``.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: sellStock
+  :lineno-start: 82
+  :lines: 82-98
 
 To sell a stock, we have the ``sellStock()`` method which takes a number of
 stocks a person wishes to sell, and sends the equivalent value in ether to the
@@ -597,7 +626,8 @@ from the seller and given to the company. The ethers are then sent to the seller
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: transferStock
+  :lineno-start: 102
+  :lines: 102-113
 
 A stockholder can also transfer their stock to another stockholder with the
 ``transferStock()`` method. The method takes a receiver address and the number
@@ -607,7 +637,8 @@ both conditions are satisfied, the transfer is made.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: payBill
+  :lineno-start: 116
+  :lines: 116-127
 
 The company is also allowed to pay out an amount in ether to an address by
 calling the ``payBill()`` method. This method should only be callable by the
@@ -618,7 +649,8 @@ sends its ether to an address.
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :lines: 129-140
+  :lineno-start: 130
+  :lines: 130-139
 
 We can also check how much the company has raised by multiplying the number of
 shares the company has sold and the price of each share. Internally, we get
@@ -626,7 +658,8 @@ this value by calling the ``_debt()`` method. Externally it is accessed via ``de
 
 .. literalinclude:: ../examples/stock/company.vy
   :language: python
-  :pyobject: worth
+  :lineno-start: 144
+  :lines: 144-147
 
 Finally, in this ``worth()`` method, we can check the worth of a company by
 subtracting its debt from its ether balance.


### PR DESCRIPTION
### What I did
Various fixes and updates to documentation.

### How I did it
* Rebuilt `docs/built-in-functions.rst` to use sphinx directives - closes #1513 
* Fix explanations for `ecadd` and `ecmul` - closes #1533 
* Fixed broken and forwarded links, replaced broken `:pyobject:` references - closes #1562 
* Added documentation for `assert_modifiable` - closes #1581 
* Fixed markdown-style code highlights that display as italics in RST
* Highly opinionated reorder of table of contents, feels much more logical to me now :)

### How to verify it
Read the docs.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/64073799-4a68e700-ccd5-11e9-98cd-9cb8f1539522.png)
