### PR TITLE
Typechecks for default parameters and int arrays

### DIFF
--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -158,6 +158,44 @@ def callMeMaybe() -> (bytes[100], uint256, bytes[20]):
     assert c.callMeMaybe() == [b'here is my number', 555123456, b'baby']
 
 
+PASSING_CONTRACTS = [
+    """
+@public
+def foo(a: bool = True, b: bool[2] = [True, False]): pass
+    """,
+    """
+@public
+def foo(
+    a: address = 0x0c04792e92e6b2896a18568fD936781E9857feB7,
+    b: address[2] = [
+        0x0c04792e92e6b2896a18568fD936781E9857feB7,
+        0x0c04792e92e6b2896a18568fD936781E9857feB7
+    ]): pass
+    """,
+    """
+@public
+def foo(a: uint256 = 12345, b: uint256[2] = [31337, 42]): pass
+    """,
+    """
+@public
+def foo(a: int128 = -31, b: int128[2] = [64, -46]): pass
+    """,
+    """
+@public
+def foo(a: bytes[6] = "potato"): pass
+    """,
+    """
+@public
+def foo(a: decimal = 3.14, b: decimal[2] = [1.337, 2.69]): pass
+    """
+]
+
+
+@pytest.mark.parametrize('code', PASSING_CONTRACTS)
+def test_good_default_params(code):
+    assert compile_code(code)
+
+
 FAILING_CONTRACTS = [
     ("""
 # default params must be literals
@@ -196,6 +234,25 @@ def foo(a: uint256[2] = [12, True]): pass
 @public
 def foo(a: uint256[2] = [1, 2, 3]): pass
     """, TypeMismatchException),
+    ("""
+# default params must be literals
+x: uint256
+
+@public
+def foo(a: uint256 = self.x): pass
+     """, FunctionDeclarationException),
+    ("""
+# default params must be literals inside array
+x: uint256
+
+@public
+def foo(a: uint256[2] = [2, self.x]): pass
+     """, FunctionDeclarationException),
+    ("""
+# default params still must be literals
+@public
+def foo(a: uint256 = 2**8): pass
+     """, FunctionDeclarationException),
 ]
 
 

--- a/tests/parser/syntax/test_ann_assign.py
+++ b/tests/parser/syntax/test_ann_assign.py
@@ -7,6 +7,7 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
+    InvalidLiteralException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
@@ -77,7 +78,25 @@ struct S:
 def foo() -> int128:
     s: S = S({b: 1.2, c: 1, d: 33, e: 55})
     return s.a
-    """, TypeMismatchException)
+    """, TypeMismatchException),
+    ("""
+@public
+def foo() -> bool:
+    a: uint256 = -1
+    return True
+""", InvalidLiteralException),
+    ("""
+@public
+def foo() -> bool:
+    a: uint256[2] = [13, -42]
+    return True
+""", InvalidLiteralException),
+    ("""
+@public
+def foo() -> bool:
+    a: int128 = 170141183460469231731687303715884105728
+    return True
+""", TypeMismatchException),
 ]
 
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -535,6 +535,12 @@ def make_setter(left, right, location, pos, in_function_call=False):
             pos,
             in_function_call=in_function_call,
         )
+        if 'int' in left.typ.typ and isinstance(right.value, int):
+            if not SizeLimits.in_bounds(left.typ.typ, right.value):
+                raise InvalidLiteralException(
+                    f"Number out of range for {left.typ}: {right.value}",
+                    pos
+                )
         if location == 'storage':
             return LLLnode.from_list(['sstore', left, right], typ=None)
         elif location == 'memory':

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -535,6 +535,8 @@ def make_setter(left, right, location, pos, in_function_call=False):
             pos,
             in_function_call=in_function_call,
         )
+        # TODO this overlaps a type check in parser.stmt.Stmt._check_valid_assign
+        # and should be examined during a refactor (@iamdefinitelyahuman)
         if 'int' in left.typ.typ and isinstance(right.value, int):
             if not SizeLimits.in_bounds(left.typ.typ, right.value):
                 raise InvalidLiteralException(

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -170,9 +170,7 @@ class FunctionSignature:
 
         # Validate default values.
         for default_value in getattr(code.args, 'defaults', []):
-            allowed_types = (ast.Num, ast.Str, ast.Bytes, ast.List, ast.NameConstant)
-            if not isinstance(default_value, allowed_types):
-                raise FunctionDeclarationException("Default parameter values have to be literals.")
+            validate_default_values(default_value)
 
         # Determine the arguments, expects something of the form def foo(arg1:
         # int128, arg2: int128 ...
@@ -467,3 +465,12 @@ class FunctionSignature:
         # Run balanced return statement check.
         UnmatchedReturnChecker().visit(to_python_ast(self.func_ast_code))
         EnsureSingleExitChecker().visit(to_python_ast(self.func_ast_code))
+
+
+def validate_default_values(node):
+    allowed_types = (ast.Num, ast.Str, ast.Bytes, ast.List, ast.NameConstant)
+    if not isinstance(node, allowed_types):
+        raise FunctionDeclarationException("Default parameter values have to be literals.", node)
+    if isinstance(node, ast.List):
+        for n in node.elts:
+            validate_default_values(n)


### PR DESCRIPTION
### What I did
* Fixed #1469 
* Fixed https://github.com/ethereum/vyper/pull/1466#issuecomment-504485443
* Added a type check for integer arrays, prior to this PR the following code would compile:
```python
@public
def foo():
   a: uint256[2] = [-1, -1]
```
### How I did it
* `vyper/parser/parser_utils.py` in `make_setter`, raise `InvalidLiteralException` when left type is `BaseType` and right value is out of bounds. This works for arrays as well because `make_setter` recursively calls itself until the left type is reduced to a `BaseType`.
* `vyper/signatures/function_signature.py` moved param check to `validate_default_values` to allow recursive calls for checking arrays

### How to verify it
I added test cases for default parameters and array assignment.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/64107559-5f18ae00-cdad-11e9-9317-8788caa9d7f0.png)

