### PR TITLE
Feature: Add option to execute vyper cli via `python -m vyper <args>`

### DIFF
--- a/vyper/__main__.py
+++ b/vyper/__main__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+import sys
+from vyper.cli import (
+    vyper_compile,
+    vyper_lll,
+    vyper_serve
+)
+
+if __name__ == "__main__":
+
+    allowed_subcommands = {
+        "--vyper-compile": vyper_compile,
+        "--vyper-lll": vyper_lll,
+        "--vyper-serve": vyper_serve
+    }
+
+    if not len(sys.argv) > 1 or sys.argv[1] not in allowed_subcommands.keys():
+        # default (no args, no switch in first arg): run vyper_compile
+        vyper_compile._parse_cli_args()
+    else:
+        # pop switch and forward args to subcommand
+        allowed_subcommands.get(sys.argv.pop(1), vyper_compile)._parse_cli_args()

--- a/vyper/__main__.py
+++ b/vyper/__main__.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 import sys
+
 from vyper.cli import (
     vyper_compile,
     vyper_lll,
-    vyper_serve
+    vyper_serve,
 )
 
 if __name__ == "__main__":
 
-    allowed_subcommands = {
-        "--vyper-compile": vyper_compile,
-        "--vyper-lll": vyper_lll,
-        "--vyper-serve": vyper_serve
-    }
+    allowed_subcommands = ("--vyper-compile", "--vyper-lll", "--vyper-serve")
 
-    if not len(sys.argv) > 1 or sys.argv[1] not in allowed_subcommands.keys():
+    if not len(sys.argv) > 1 or sys.argv[1] not in allowed_subcommands:
         # default (no args, no switch in first arg): run vyper_compile
         vyper_compile._parse_cli_args()
     else:
         # pop switch and forward args to subcommand
-        allowed_subcommands.get(sys.argv.pop(1), vyper_compile)._parse_cli_args()
+        subcommand = sys.argv.pop(1)
+        if subcommand == "--vyper-serve":
+            vyper_serve._parse_cli_args()
+        elif subcommand == "--vyper-lll":
+            vyper_lll._parse_cli_args()
+        else:
+            vyper_compile._parse_cli_args()


### PR DESCRIPTION
### What I did
In order to not have to rely on shell scripts to be deployed with `setup.py` and be able to call vyper from various non-venv python installations, this PR adds the option to execute the vyper module and sub-functionality directly via `python -m vyper [--vyper-compile | --vyper-lll | --vyper-serve] <args>`.

- `python -m vyper <args>` - by default calls `vyper_compile(args)`
- `python -m vyper --vyper-compile <args>` - calls `vyper_compile(args)`
- `python -m vyper --vyper-lll <args>` - calls `vyper_lll(args)`
- `python -m vyper --vyper-serve <args>` - calls `vyper_serve(args)`

### How I did it

- added `__main__.py` with minimal dispatching code. No existing code modified :)

### How to verify it

- run `python -m vyper <args>`. see section **"What I did"** for a complete list of dispatched commands.

```console
~/w/p/vyper ❯❯❯ python3 -m vyper --help       
usage: __main__.py [-h] [--version] [--show-gas-estimates] [-f FORMAT]
                   [--traceback-limit TRACEBACK_LIMIT] [-p ROOT_FOLDER]
                   input_files [input_files ...]

Vyper programming language for Ethereum

positional arguments:
  input_files           Vyper sourcecode to compile

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --show-gas-estimates  Show gas estimates in ir output mode.
  -f FORMAT             Format to print, one or more of:
                        bytecode (default) - Deployable bytecode
                        bytecode_runtime   - Bytecode at runtime
                        abi                - ABI in JSON format
                        abi_python         - ABI in python format
                        ast                - AST in JSON format
                        source_map         - Vyper source map
                        method_identifiers - Dictionary of method signature to method identifier.
                        combined_json      - All of the above format options combined as single JSON output.
                        interface          - Print Vyper interface of a contract
                        external_interface - Print the External interface of a contract, used for outside contract calls.
                        opcodes            - List of opcodes as a string
                        opcodes_runtime    - List of runtime opcodes as a string
                        ir                 - Print Intermediate Representation in LLL
  --traceback-limit TRACEBACK_LIMIT
                        Set the traceback limit for error messages reported by the compiler
  -p ROOT_FOLDER        Set the root path for contract imports


~/w/p/vyper ❯❯❯ python3 -m vyper --vyper-lll --help 

usage: __main__.py [-h] [--version] [-f FORMAT] [--show-gas-estimates]
                   input_file

Vyper LLL for Ethereum

positional arguments:
  input_file            Vyper sourcecode to compile

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -f FORMAT             Format to print csv list of ir,opt_ir,asm,bytecode
  --show-gas-estimates  Show gas estimates in ir output mode.
```

### Description for the changelog

- Added option to execute `vyper` commands via `python -m vyper [--vyper-compile | --vyper-lll | --vyper-serve] <args>`.

### Cute Animal Picture

![cute-fox](https://i.pinimg.com/originals/bc/26/9d/bc269df2e321384595987bf372f50731.jpg)
