### PR TITLE
Zero pad from calldata

### DIFF
--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -108,7 +108,6 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
             typ=typ, location='memory', annotation="pack_args_by_32:dest_placeholder")
         copier = make_byte_array_copier(dest_placeholder, source_lll, pos=pos)
         holder.append(copier)
-        item_maxlen = source_lll.typ.maxlen
         # Add zero padding.
         holder.append(zero_pad(dest_placeholder))
 

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -72,7 +72,7 @@ def pack_logging_topics(event_id, args, expected_topics, context, pos):
 
 
 def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
-        dynamic_offset_counter=None, datamem_start=None, pos=None):
+                    dynamic_offset_counter=None, datamem_start=None, pos=None):
     """
     Copy necessary variables to pre-allocated memory section.
 

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -72,7 +72,7 @@ def pack_logging_topics(event_id, args, expected_topics, context, pos):
 
 
 def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
-                    dynamic_offset_counter=None, datamem_start=None, zero_pad_i=None, pos=None):
+        dynamic_offset_counter=None, datamem_start=None, pos=None):
     """
     Copy necessary variables to pre-allocated memory section.
 
@@ -111,7 +111,7 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
         item_maxlen = source_lll.typ.maxlen
         # Add zero padding.
         holder.append(
-            zero_pad(dest_placeholder, item_maxlen, zero_pad_i=zero_pad_i)
+            zero_pad(dest_placeholder, maxlen)
         )
 
         # Increment offset counter.
@@ -246,13 +246,10 @@ def pack_logging_data(expected_data, args, context, pos):
 
     requires_dynamic_offset = any([isinstance(data.typ, ByteArrayLike) for data in expected_data])
     if requires_dynamic_offset:
-        # Iterator used to zero pad memory.
-        zero_pad_i = context.new_placeholder(BaseType('uint256'))
         dynamic_offset_counter = context.new_placeholder(BaseType(32))
         dynamic_placeholder = context.new_placeholder(BaseType(32))
     else:
         dynamic_offset_counter = None
-        zero_pad_i = None
 
     # Create placeholder for static args. Note: order of new_*() is important.
     placeholder_map = {}
@@ -276,7 +273,6 @@ def pack_logging_data(expected_data, args, context, pos):
                 typ,
                 context,
                 placeholder,
-                zero_pad_i=zero_pad_i,
                 pos=pos,
             )
 
@@ -308,7 +304,6 @@ def pack_logging_data(expected_data, args, context, pos):
                 placeholder=placeholder_map[i],
                 datamem_start=datamem_start,
                 dynamic_offset_counter=dynamic_offset_counter,
-                zero_pad_i=zero_pad_i,
                 pos=pos
             )
 

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -111,7 +111,7 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
         item_maxlen = source_lll.typ.maxlen
         # Add zero padding.
         holder.append(
-            zero_pad(dest_placeholder, maxlen)
+            zero_pad(dest_placeholder, item_maxlen)
         )
 
         # Increment offset counter.

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -110,9 +110,7 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
         holder.append(copier)
         item_maxlen = source_lll.typ.maxlen
         # Add zero padding.
-        holder.append(
-            zero_pad(dest_placeholder, item_maxlen)
-        )
+        holder.append(zero_pad(dest_placeholder))
 
         # Increment offset counter.
         increment_counter = LLLnode.from_list([

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -124,7 +124,8 @@ class LLLnode:
                     if isinstance(self.args[2].value, int):
                         size = self.args[2].value
                     elif isinstance(self.args[2], LLLnode) and len(self.args[2].args) > 0:
-                        size = self.args[2].args / [-1].value
+                        #size = self.args[2].args / [-1].value
+                        size = 32 # WIP FIXME
                     self.gas += ceil32(size) // 32 * 3
                 # Gas limits in call
                 if self.value.upper() == 'CALL' and isinstance(self.args[0].value, int):

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -123,9 +123,6 @@ class LLLnode:
                     size = 34000
                     if isinstance(self.args[2].value, int):
                         size = self.args[2].value
-                    elif isinstance(self.args[2], LLLnode) and len(self.args[2].args) > 0:
-                        #size = self.args[2].args / [-1].value
-                        size = 32 # WIP FIXME
                     self.gas += ceil32(size) // 32 * 3
                 # Gas limits in call
                 if self.value.upper() == 'CALL' and isinstance(self.args[0].value, int):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -891,7 +891,7 @@ def annotate_ast(
 
 # zero pad a bytearray according to the ABI spec. The last word
 # of the byte array needs to be right-padded with zeroes.
-def zero_pad(bytez_placeholder, maxlen, context=None, zero_pad_i=None):
+def zero_pad(bytez_placeholder, maxlen):
     zero_padder = LLLnode.from_list(['pass'])
     if maxlen > 0:
         # calldatacopy from past-the-end gives zero bytes.
@@ -987,7 +987,7 @@ def gen_tuple_return(stmt, context, sub):
                 'add',
                 mem_pos,
                 ['mload', mem_pos + i * 32]
-            ], maxlen=x.maxlen, context=context)
+            ], maxlen=x.maxlen)
         return LLLnode.from_list(['seq'] + [sub] + [zero_padder] + [
             make_return_stmt(stmt, context, mem_pos, mem_size)
         ], typ=sub.typ, pos=getpos(stmt), valency=0)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -893,6 +893,7 @@ def annotate_ast(
 # of the byte array needs to be right-padded with zeroes.
 def zero_pad(bytez_placeholder):
     # calldatacopy from past-the-end gives zero bytes.
+    # cf. YP H.2 (ops section) with CALLDATACOPY spec.
     len_ = ['mload', bytez_placeholder]
     dst = ['add', ['add', bytez_placeholder, 32], 'len']
     # the runtime length of the data rounded up to nearest 32

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -892,26 +892,23 @@ def annotate_ast(
 # zero pad a bytearray according to the ABI spec. The last word
 # of the byte array needs to be right-padded with zeroes.
 def zero_pad(bytez_placeholder):
-    zero_padder = LLLnode.from_list(['pass'])
-    if maxlen > 0:
-        # calldatacopy from past-the-end gives zero bytes.
-        len_ = ['mload', bytez_placeholder]
-        dst = ['add', ['add', bytez_placeholder, 32], 'len']
-        # the runtime length of the data rounded up to nearest 32
-        # from spec:
-        #   the actual value of X as a byte sequence,
-        #   followed by the *minimum* number of zero-bytes
-        #   such that len(enc(X)) is a multiple of 32.
-        num_zero_bytes = ['sub', ['ceil32', 'len'], 'len']
-        zero_padder = LLLnode.from_list(
-                ['with', 'len', len_,
-                    ['with', 'dst', dst,
-                        # calldatacopy mempos calldatapos len
-                        ['calldatacopy', 'dst', 'calldatasize', num_zero_bytes]
-                        ]],
-                    annotation="Zero pad",
-                    )
-    return zero_padder
+    # calldatacopy from past-the-end gives zero bytes.
+    len_ = ['mload', bytez_placeholder]
+    dst = ['add', ['add', bytez_placeholder, 32], 'len']
+    # the runtime length of the data rounded up to nearest 32
+    # from spec:
+    #   the actual value of X as a byte sequence,
+    #   followed by the *minimum* number of zero-bytes
+    #   such that len(enc(X)) is a multiple of 32.
+    num_zero_bytes = ['sub', ['ceil32', 'len'], 'len']
+    return LLLnode.from_list(
+            ['with', 'len', len_,
+                ['with', 'dst', dst,
+                    # calldatacopy mempos calldatapos len
+                    ['calldatacopy', 'dst', 'calldatasize', num_zero_bytes]
+                    ]],
+                annotation="Zero pad",
+                )
 
 
 # Generate return code for stmt

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -905,10 +905,9 @@ def zero_pad(bytez_placeholder):
             ['with', 'len', len_,
                 ['with', 'dst', dst,
                     # calldatacopy mempos calldatapos len
-                    ['calldatacopy', 'dst', 'calldatasize', num_zero_bytes]
-                    ]],
-                annotation="Zero pad",
-                )
+                    ['calldatacopy', 'dst', 'calldatasize', num_zero_bytes]]],
+            annotation="Zero pad",
+            )
 
 
 # Generate return code for stmt

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -852,7 +852,7 @@ class Stmt(object):
                         sub,
                         pos=getpos(self.stmt)
                     ),
-                    zero_pad(bytez_placeholder, sub.typ.maxlen, self.context),
+                    zero_pad(bytez_placeholder, sub.typ.maxlen),
                     ['mstore', len_placeholder, 32],
                     make_return_stmt(
                         self.stmt,

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -852,7 +852,7 @@ class Stmt(object):
                         sub,
                         pos=getpos(self.stmt)
                     ),
-                    zero_pad(bytez_placeholder, sub.typ.maxlen),
+                    zero_pad(bytez_placeholder),
                     ['mstore', len_placeholder, 32],
                     make_return_stmt(
                         self.stmt,


### PR DESCRIPTION
### What I did
Increase clarity and efficiency of zero-padder. Currently overlaps with #1611 - fixes #1599, #1610. See the discussion in those issues as well as https://github.com/ethereum/vyper/issues/1603#issuecomment-529239131.

### How I did it
CALLDATACOPY writes zero bytes into memory when the location in calldata is >= calldatasize.

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.pets4homes.co.uk/images/breeds/5/large/8124642d1eda160c9d25e7316fc2eae2.jpg)
