### PR TITLE
Check calldatasize before loading func selector

### DIFF
--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -45,6 +45,8 @@ if not hasattr(ast, 'AnnAssign'):
 # Header code
 STORE_CALLDATA: List[Any] = \
         ['seq',
+            # check that calldatasize is at least 4, otherwise
+            # calldataload will load zeros (cf. yellow paper).
             ['if', ['lt', 'calldatasize', 4],
                 ['goto', 'fallback']],
             ['mstore', 28, ['calldataload', 0]]]

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -43,7 +43,11 @@ if not hasattr(ast, 'AnnAssign'):
     raise Exception("Requires python 3.6 or higher for annotation support")
 
 # Header code
-STORE_CALLDATA: List[Any] = ['seq', ['mstore', 28, ['calldataload', 0]]]
+STORE_CALLDATA: List[Any] = \
+        ['seq',
+            ['if', ['lt', 'calldatasize', 4],
+                ['goto', 'fallback']],
+            ['mstore', 28, ['calldataload', 0]]]
 # Store limit constants at fixed addresses in memory.
 LIMIT_MEMORY_SET: List[Any] = [
     ['mstore', pos, limit_size]
@@ -55,13 +59,6 @@ FUNC_INIT_LLL = LLLnode.from_list(
 INIT_FUNC_INIT_LLL = LLLnode.from_list(
     ['seq'] + LIMIT_MEMORY_SET, typ=None
 )
-
-
-# Header code
-INITIALIZER_LIST = ['seq', ['mstore', 28, ['calldataload', 0]]]
-# Store limit constants at fixed addresses in memory.
-INITIALIZER_LIST += [['mstore', pos, limit_size] for pos, limit_size in LOADED_LIMIT_MAP.items()]
-INITIALIZER_LLL = LLLnode.from_list(INITIALIZER_LIST, typ=None)
 
 
 def parse_events(sigs, global_ctx):
@@ -142,9 +139,10 @@ def parse_other_functions(o,
             origcode,
             global_ctx,
         )
-        sub.append(default_func)
+        fallback = default_func
     else:
-        sub.append(LLLnode.from_list(['revert', 0, 0], typ=None, annotation='Default function'))
+        fallback = LLLnode.from_list(['revert', 0, 0], typ=None, annotation='Default function')
+    sub.append(['seq_unchecked', ['label', 'fallback'], fallback])
     if runtime_only:
         return sub
     else:


### PR DESCRIPTION
### What I did
Fix #1603 

### How I did it
Implemented the solution from https://github.com/ethereum/vyper/issues/1603#issuecomment-529238275

### How to verify it
Check tests, also look at IR of following code:
```python

@public
@payable
def blockHashAskewLimitary(v: uint256): # function selector: 0x00000000
  send(msg.sender, self.balance)

@public
def __default__() -> uint256:
  return 1`
```

### Description for the changelog
Fix edge case in function selector with 0 calldata

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://oceana.org/sites/default/files/styles/lightbox_full/public/blue_whale_0.jpg?itok=ot2r7OSJ)
