### PR TITLE
Fix termination condition in zero_pad

### DIFF
--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -108,9 +108,10 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
             typ=typ, location='memory', annotation="pack_args_by_32:dest_placeholder")
         copier = make_byte_array_copier(dest_placeholder, source_lll, pos=pos)
         holder.append(copier)
+        item_maxlen = source_lll.typ.maxlen
         # Add zero padding.
         holder.append(
-            zero_pad(dest_placeholder, maxlen, zero_pad_i=zero_pad_i)
+            zero_pad(dest_placeholder, item_maxlen, zero_pad_i=zero_pad_i)
         )
 
         # Increment offset counter.

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -899,6 +899,8 @@ def annotate_ast(
     RewriteUnarySubVisitor().visit(parsed_ast)
 
 
+# zero pad a bytearray according to the ABI spec. The last word
+# of the byte array needs to be right-padded with zeroes.
 def zero_pad(bytez_placeholder, maxlen, context=None, zero_pad_i=None):
     zero_padder = LLLnode.from_list(['pass'])
     if maxlen > 0:

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -909,7 +909,7 @@ def zero_pad(bytez_placeholder, maxlen, context=None, zero_pad_i=None):
             'repeat', zero_pad_i, ['mload', bytez_placeholder], ceil32(maxlen), [
                 'seq',
                 # stay within allocated bounds
-                ['if', ['gt', ['mload', zero_pad_i], ceil32(maxlen)], 'break'],
+                ['if', ['ge', ['mload', zero_pad_i], ceil32(maxlen)], 'break'],
                 ['mstore8', ['add', ['add', 32, bytez_placeholder], ['mload', zero_pad_i]], 0]
             ]],
             annotation="Zero pad",


### PR DESCRIPTION
### What I did
Fix #1599, #1610 

### How I did it
See mentioned issues for discussion

### How to verify it

### Description for the changelog
Fix zero padding conditions in ABI encoder

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://i.huffpost.com/gen/1526799/images/o-CUTE-SEAL-facebook.jpg)
