### PR TITLE
Add documentation for environment variables

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Vyper'
-copyright = '2017, Vitalik Buterin'
-author = 'Vitalik Buterin'
+copyright = '2017-2019 CC-BY-4.0 Vyper Team'
+author = 'Vyper Team (originally created by Vitalik Buterin)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -152,7 +152,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'Vyper.tex', 'Vyper Documentation',
-     'Vitalik Buterin', 'manual'),
+     'Vyper Team (originally created by Vitalik Buterin)', 'manual'),
 ]
 
 

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -1,0 +1,75 @@
+.. index:: type
+
+.. _types:
+
+Constants and Environment Variables
+***********************************
+
+Built In Constants
+==================
+
+Vyper has a few convenience constants builtin.
+
+================= =========== ==============================================
+Name              Type        Value
+================= =========== ==============================================
+``ZERO_ADDRESS``  ``address`` ``0x0000000000000000000000000000000000000000``
+``EMPTY_BYTES32`` ``bytes32`` ``0x0000000000000000000000000000000000000000000000000000000000000000``
+``MAX_INT128``    ``int128``  ``2**127 - 1``
+``MIN_INT128``    ``int128``  ``-2**127``
+``MAX_DECIMAL``   ``decimal`` ``(2**127 - 1)``
+``MIN_DECIMAL``   ``decimal`` ``(-2**127)``
+``MAX_UINT256``   ``uint256`` ``2**256 - 1``
+================= =========== ==============================================
+
+Custom Constants
+================
+
+Custom constants can be defined at a global level in Vyper. To define a constant make use of the ``constant`` keyword.
+
+**Example:**
+::
+
+  TOTAL_SUPPLY: constant(uint256) = 10000000
+  total_supply: public(uint256)
+
+  @public
+  def __init__():
+      self.total_supply = TOTAL_SUPPLY
+
+**Advanced Example:**
+::
+
+  units: {
+      share: "Share unit"
+  }
+
+  MAX_SHARES: constant(uint256(share)) = 1000
+  SHARE_PRICE: constant(uint256(wei/share)) = 5
+
+  @public
+  def market_cap() -> uint256(wei):
+      return MAX_SHARES * SHARE_PRICE
+
+Environment Variables
+=====================
+
+Environment variables always exist in the namespace and are used to provide information about the blockchain or current transaction.
+
+.. note::
+
+    ``msg.sender`` and ``msg.value`` can only be accessed from public functions. If you require these values within a private function they must be passed as parameters.
+
+==================== ================ =============================================
+Name                 Type             Value
+==================== ================ =============================================
+``block.coinbase``   ``address``      Current block miner’s address
+``block.difficulty`` ``uint256``      Current block difficulty
+``block.number``     ``uint256``      Current block number
+``block.prevhash``   ``bytes32``      Equivalent to ``blockhash(block.number - 1)``
+``block.timestamp``  ``uint256``      Current block epoch timestamp
+``msg.gas``          ``uint256``      Remaining gas
+``msg.sender``       ``address``      Sender of the message (current call)
+``msg.value``        ``uint256(wei)`` Number of wei sent with the message
+``tx.origin``        ``address``      Sender of the transaction (full call chain)
+==================== ================ =============================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Glossary
     structure-of-a-contract.rst
     built-in-functions.rst
     types.rst
+    constants-and-vars.rst
     logging.rst
     compiling-a-contract.rst
     deploying-contracts.rst

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -50,7 +50,7 @@ Operator              Description
 ====================  ===================
 
 The operators ``or`` and ``and`` do not apply short-circuiting rules, i.e. both
-`x` and `y` will always be evaluated.
+``x`` and ``y`` will always be evaluated.
 
 .. index:: ! int128, ! int, ! integer
 
@@ -483,52 +483,6 @@ Here ``_KeyType`` can be any base or bytes type. Mappings, contract or structs a
 
 .. index:: !initial
 
-Built In Constants
-******************
-
-Vyper has a few convenience constants builtin.
-
-======= ============= ==========================================
-Type    Name          Value
-======= ============= ==========================================
-address ZERO_ADDRESS  0x0000000000000000000000000000000000000000
-bytes32 EMPTY_BYTES32 0x0000000000000000000000000000000000000000000000000000000000000000
-int128  MAX_INT128    2**127 - 1
-int128  MIN_INT128    -2**127
-decimal MAX_DECIMAL   (2**127 - 1)
-decimal MIN_DECIMAL   (-2**127)
-uint256 MAX_UINT256   2**256 - 1
-======= ============= ==========================================
-
-Custom Constants
-****************
-
-Custom constants can be defined at a global level in Vyper. To define a constant make use of the `constant` keyword.
-
-**Example:**
-::
-
-  TOTAL_SUPPLY: constant(uint256) = 10000000
-  total_supply: public(uint256)
-
-  @public
-  def __init__():
-      self.total_supply = TOTAL_SUPPLY
-
-**Advanced Example:**
-::
-
-  units: {
-      share: "Share unit"
-  }
-
-  MAX_SHARES: constant(uint256(share)) = 1000
-  SHARE_PRICE: constant(uint256(wei/share)) = 5
-
-  @public
-  def market_cap() -> uint256(wei):
-      return MAX_SHARES * SHARE_PRICE
-
 Initial Values
 **************
 
@@ -578,7 +532,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - Additional Notes
    * - ``bool``
      - ``bool``
-     - `—`
+     - ``—``
      - Do not allow converting to/from the same type
    * - ``bool``
      - ``decimal``


### PR DESCRIPTION
### What I did
Added documentation for environment variables.

### How I did it
Split the "Types" section into two pages, the new one is called "Constants and Environment Variables".  Moved the information on constants to this new page, then added docs for environment variables.

### How to verify it
Read the docs.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/64805157-fc9c8a80-d5c2-11e9-9d56-4514a6b87c62.png)
