### PR TITLE
upgraded to mostly f-strings

### DIFF
--- a/scripts/fixed_address_creator.py
+++ b/scripts/fixed_address_creator.py
@@ -78,10 +78,10 @@ g4 = t.s.head_state.receipts[-1].gas_used \
     - t.s.head_state.receipts[-2].gas_used \
     - t.s.last_tx.intrinsic_gas_used
 
-print("500 bytes increment: %d" % (g2 - g1))
-print("500 bytes increment: %d" % (g4 - g3))
-print("25 items increment: %d" % (g3 - g1))
-print("25 items increment: %d" % (g4 - g2))
+print(f"500 bytes increment: {(g2 - g1)}")
+print(f"500 bytes increment: {(g4 - g3)}")
+print(f"25 items increment: {(g3 - g1)}")
+print(f"25 items increment: {(g4 - g2)}")
 
 # Create transaction
 t = transactions.Transaction(0, 30 * 10**9, 2999999, '', 0, rlp_decoder_bytes)
@@ -92,13 +92,6 @@ t.s = 79
 
 print("RLP decoder")
 print("Instructions for launching:")
-print('First send {} wei to {}'.format(
-    t.startgas * t.gasprice,
-    utils.checksum_encode(t.sender),
-))
-print('Publish this tx to create the contract: 0x{}'.format(
-    utils.encode_hex(rlp.encode(t)),
-))
-print('This is the contract address: {}'.format(
-    utils.checksum_encode(utils.mk_contract_address(t.sender, 0)),
-))
+print(f'First send {t.startgas * t.gasprice} wei to {utils.checksum_encode(t.sender)}')
+print(f'Publish this tx to create the contract: 0x{utils.encode_hex(rlp.encode(t))}')
+print(f'This is the contract address: {utils.checksum_encode(utils.mk_contract_address(t.sender, 0))}')  # noqa: E501

--- a/scripts/fixed_address_creator.py
+++ b/scripts/fixed_address_creator.py
@@ -94,4 +94,5 @@ print("RLP decoder")
 print("Instructions for launching:")
 print(f'First send {t.startgas * t.gasprice} wei to {utils.checksum_encode(t.sender)}')
 print(f'Publish this tx to create the contract: 0x{utils.encode_hex(rlp.encode(t))}')
-print(f'This is the contract address: {utils.checksum_encode(utils.mk_contract_address(t.sender, 0))}')  # noqa: E501
+print('This is the contract address: '
+      f'{utils.checksum_encode(utils.mk_contract_address(t.sender, 0))}')

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -47,9 +47,9 @@ class VyperMethod:
             modifier, modifier_dict = kwargs.popitem()
             if modifier not in self.ALLOWED_MODIFIERS:
                 raise TypeError(
-                    "The only allowed keyword arguments are: %s" % self.ALLOWED_MODIFIERS)
+                    f"The only allowed keyword arguments are: {self.ALLOWED_MODIFIERS}")
         else:
-            raise TypeError("Use up to one keyword argument, one of: %s" % self.ALLOWED_MODIFIERS)
+            raise TypeError(f"Use up to one keyword argument, one of: {self.ALLOWED_MODIFIERS}")
         return getattr(self._function(*args), modifier)(modifier_dict)
 
 

--- a/tests/cli/vyper_compile/test_import_paths.py
+++ b/tests/cli/vyper_compile/test_import_paths.py
@@ -121,8 +121,8 @@ META_IMPORT_STMT = [
 @pytest.mark.parametrize('import_stmt', META_IMPORT_STMT)
 def test_import_self_interface(import_stmt, tmp_path):
     # a contract can access it's derived interface by importing itself
-    code = """
-{}
+    code = f"""
+{import_stmt}
 
 @public
 def know_thyself(a: address) -> uint256:
@@ -131,7 +131,7 @@ def know_thyself(a: address) -> uint256:
 @public
 def be_known() -> uint256:
     return 42
-    """.format(import_stmt)
+    """
 
     tmp_path.joinpath('contracts').mkdir()
 
@@ -157,8 +157,8 @@ DERIVED_IMPORT_STMT_FOO = [
 @pytest.mark.parametrize('import_stmt_foo', DERIVED_IMPORT_STMT_FOO)
 def test_derived_interface_imports(import_stmt_baz, import_stmt_foo, tmp_path):
     # contracts-as-interfaces should be able to contain import statements
-    baz_code = """
-{}
+    baz_code = f"""
+{import_stmt_baz}
 
 @public
 def foo(a: address) -> uint256:
@@ -167,7 +167,7 @@ def foo(a: address) -> uint256:
 @public
 def bar(_foo: address, _bar: address) -> uint256:
     return Foo(_foo).bar(_bar)
-    """.format(import_stmt_baz)
+    """
 
     with tmp_path.joinpath('Foo.vy').open('w') as fp:
         fp.write(FOO_CODE.format(import_stmt_foo))

--- a/tests/compiler/test_pre_parser.py
+++ b/tests/compiler/test_pre_parser.py
@@ -61,13 +61,13 @@ def foo(contract_address: address) -> int128:
 
 def test_version_pragma(get_contract):
     from vyper import __version__
-    code = """
-# @version {}
+    code = f"""
+# @version {__version__}
 
 @public
 def test():
     pass
-    """.format(__version__)
+    """
     assert get_contract(code)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,11 +105,9 @@ def check_gas_on_chain(w3, tester, code, func=None, res=None):
     # Computed upper bound on the gas consumption should
     # be greater than or equal to the amount of gas used
     if gas_estimate < gas_actual:
-        raise Exception("Gas upper bound fail: bound %d actual %d" % (gas_estimate, gas_actual))
+        raise Exception(f"Gas upper bound fail: bound {gas_estimate} actual {gas_actual}")
 
-    print('Function name: {} - Gas estimate {}, Actual: {}'.format(
-        func, gas_estimate, gas_actual)
-    )
+    print(f'Function name: {func} - Gas estimate {gas_estimate}, Actual: {gas_actual}')
 
 
 def gas_estimation_decorator(w3, tester, fn, source_code, func):

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -64,7 +64,7 @@ def create_and_return_forwarder(inp: address) -> address:
 
     print('Passed forwarder test')
     # TODO: This one is special
-    # print('Gas consumed: %d' % (chain.head_state.receipts[-1].gas_used - chain.head_state.receipts[-2].gas_used - chain.last_tx.intrinsic_gas_used))  # noqa: E501
+    # print(f'Gas consumed: {(chain.head_state.receipts[-1].gas_used - chain.head_state.receipts[-2].gas_used - chain.last_tx.intrinsic_gas_used)}')  # noqa: E501
 
 
 def test_multiple_levels2(assert_tx_failed, get_contract_with_gas_estimation):

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -163,15 +163,15 @@ def is_owner() -> bool:
 
 def test_constant_bytes(get_contract):
     test_str = b"Alabama, Arkansas. I do love my ma and pa"
-    code = """
-X: constant(bytes[100]) = b"{}"
+    code = f"""
+X: constant(bytes[100]) = b"{test_str.decode()}"
 
 @public
 def test() -> bytes[100]:
     y: bytes[100] = X
 
     return y
-    """.format(test_str.decode())
+    """
 
     c = get_contract(code)
 

--- a/tests/parser/types/test_bytes_literal.py
+++ b/tests/parser/types/test_bytes_literal.py
@@ -45,7 +45,7 @@ moo: bytes[100]
 @public
 def foo(s: int128, L: int128) -> bytes[100]:
         x: int128 = 27
-        r: bytes[100] = slice(b"%s", start=s, len=L)
+        r: bytes[100] = slice(b"{0}", start=s, len=L)
         y: int128 = 37
         if x * y == 999:
             return r
@@ -53,7 +53,7 @@ def foo(s: int128, L: int128) -> bytes[100]:
 
 @public
 def bar(s: int128, L: int128) -> bytes[100]:
-        self.moo = b"%s"
+        self.moo = b"{0}"
         x: int128 = 27
         r: bytes[100] = slice(self.moo, start=s, len=L)
         y: int128  = 37
@@ -64,12 +64,12 @@ def bar(s: int128, L: int128) -> bytes[100]:
 @public
 def baz(s: int128, L: int128) -> bytes[100]:
         x: int128 = 27
-        self.moo = slice(b"%s", start=s, len=L)
+        self.moo = slice(b"{0}", start=s, len=L)
         y: int128 = 37
         if x * y == 999:
             return self.moo
         return b"3434346667777"
-        """ % (("c" * i), ("c" * i), ("c" * i))
+        """.format(("c" * i))
 
         c = get_contract_with_gas_estimation(kode)
         for e in range(63, 64, 65):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,22 +75,14 @@ class ParserException(Exception):
 
         if self.lineno and hasattr(self, 'source_code'):
 
-            output = 'line %d: %s\n%s' % (
-                self.lineno,
-                output,
-                self.source_code[self.lineno - 1]
-            )
+            output = f'line {self.lineno}: {output}\n{self.source_code[self.lineno -1]}'
 
             if self.col_offset:
                 col = '-' * self.col_offset + '^'
                 output += '\n' + col
 
         elif self.lineno is not None and self.col_offset is not None:
-            output = 'line %d:%d %s' % (
-                self.lineno,
-                self.col_offset,
-                output
-            )
+            output = f'line {self.lineno}:{self.col_offset} {output}'
 
         return output
 """[1:-1]
@@ -156,21 +148,17 @@ def test_annotate_source_code_marks_positions_in_source_code():
 
     annotation = annotate_source_code(
         TEST_SOURCE_CODE,
-        44,
+        36,
         col_offset=8,
-        context_lines=8,
+        context_lines=4,
         line_numbers=True,
     )
     assert annotation == r"""
-     36
-     37         elif self.lineno is not None and self.col_offset is not None:
-     38             output = 'line %d:%d %s' % (
-     39                 self.lineno,
-     40                 self.col_offset,
-     41                 output
-     42             )
-     43
----> 44         return output
+     32
+     33         elif self.lineno is not None and self.col_offset is not None:
+     34             output = f'line {self.lineno}:{self.col_offset} {output}'
+     35
+---> 36         return output
 ----------------^
 """[1:-1]
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -73,7 +73,7 @@ def _parse_args(argv):
     parser.add_argument(
         '--version',
         action='version',
-        version='{0}+commit.{1}'.format(vyper.__version__, vyper.__commit__),
+        version=f'{vyper.__version__}+commit.{vyper.__commit__}',
     )
     parser.add_argument(
         '--show-gas-estimates',

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -63,7 +63,7 @@ def _parse_args(argv):
     parser.add_argument(
         '--version',
         action='version',
-        version='{0}+commit.{1}'.format(vyper.__version__, vyper.__commit__),
+        version=f'{vyper.__version__}+commit.{vyper.__commit__}',
     )
     parser.add_argument(
         '-o',

--- a/vyper/cli/vyper_lll.py
+++ b/vyper/cli/vyper_lll.py
@@ -28,7 +28,7 @@ def _parse_args(argv):
     parser.add_argument(
         '--version',
         action='version',
-        version='{0}'.format(vyper.__version__),
+        version=f'{vyper.__version__}',
     )
     parser.add_argument(
         '-f',

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -28,7 +28,7 @@ def _parse_args(argv):
     parser = argparse.ArgumentParser(
         description='Serve Vyper compiler as an HTTP Service'
     )
-    parser.add_argument('--version', action='version', version='{0}'.format(vyper.__version__))
+    parser.add_argument('--version', action='version', version=f'{vyper.__version__}')
     parser.add_argument(
         '-b',
         help='Address to bind JSON server on, default: localhost:8000',
@@ -66,7 +66,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_cors_all()
             self.end_headers()
-            self.wfile.write('Vyper Compiler. Version: {} \n'.format(vyper.__version__).encode())
+            self.wfile.write('Vyper Compiler. Version: {vyper.__version__).encode()} \n')
         else:
             self.send_404()
 
@@ -134,5 +134,5 @@ class VyperHTTPServer(ThreadingMixIn, HTTPServer):
 def runserver(host='', port=8000):
     server_address = (host, int(port))
     httpd = VyperHTTPServer(server_address, VyperRequestHandler)
-    print('Listening on http://{0}:{1}'.format(host, port))
+    print(f'Listening on http://{host}:{port}')
     httpd.serve_forever()

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -66,7 +66,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_cors_all()
             self.end_headers()
-            self.wfile.write('Vyper Compiler. Version: {vyper.__version__).encode()} \n')
+            self.wfile.write('Vyper Compiler. Version: {(vyper.__version__).encode()} \n')
         else:
             self.send_404()
 

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -66,7 +66,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_cors_all()
             self.end_headers()
-            self.wfile.write('Vyper Compiler. Version: {(vyper.__version__).encode()}\n')
+            self.wfile.write('Vyper Compiler. Version: ' + (vyper.__version__).encode() + '\n')
         else:
             self.send_404()
 

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -66,7 +66,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_cors_all()
             self.end_headers()
-            self.wfile.write('Vyper Compiler. Version: {(vyper.__version__).encode()} \n')
+            self.wfile.write('Vyper Compiler. Version: {(vyper.__version__).encode()}\n')
         else:
             self.send_404()
 

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -104,9 +104,9 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
     # Numbers
     elif isinstance(code.value, int):
         if code.value <= -2**255:
-            raise Exception("Value too low: %d" % code.value)
+            raise Exception(f"Value too low: {code.value}")
         elif code.value >= 2**256:
-            raise Exception("Value too high: %d" % code.value)
+            raise Exception(f"Value too high: {code.value}")
         bytez = num_to_bytearray(code.value % 2**256) or [0]
         return ['PUSH' + str(len(bytez))] + bytez
     # Variables connected to with statements
@@ -293,7 +293,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
                 )
             else:
                 raise Exception(
-                    "Invalid %r with values %r and %r" % (code.value, code.args[0], code.args[1])
+                    f"Invalid {code.value} with values {code.args[0]} and {code.args[1]}"
                 )
         o = compile_to_assembly(code.args[0], withargs, existing_labels, break_dest, height)
         o.extend(compile_to_assembly(
@@ -432,7 +432,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
         label_name = str(code.args[0])
 
         if label_name in existing_labels:
-            raise Exception('Label with name %s already exists!', label_name)
+            raise Exception(f'Label with name {label_name} already exists!')
         else:
             existing_labels.add(label_name)
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -73,7 +73,7 @@ def get_keyword(expr, keyword):
             return kw.value
     # This should never happen, as kwargs['value'] will KeyError first.
     # Leaving exception for other use cases.
-    raise Exception("Keyword %s not found" % keyword)  # pragma: no cover
+    raise Exception(f"Keyword {keyword} not found")  # pragma: no cover
 
 # like `assert foo`, but doesn't check constancy.
 # currently no option for reason string (easy to add, just need to refactor
@@ -417,7 +417,7 @@ def sha256(expr, args, kwargs, context):
         )
     else:
         # This should never happen, but just left here for future compiler-writers.
-        raise Exception("Unsupported location: %s" % sub.location)  # pragma: no test
+        raise Exception(f"Unsupported location: {sub.location}")  # pragma: no test
 
 
 @signature('str_literal', 'name_literal')
@@ -594,10 +594,8 @@ def as_wei_value(expr, args, kwargs, context):
             break
     else:
         raise InvalidLiteralException(
-            "Invalid denomination: %s, valid denominations are: %s" % (
-                args[1],
-                ",".join(x[0].decode() for x in names_denom)
-            ),
+            f"""Invalid denomination: {args[1]}, valid denominations are:
+            {','.join(x[0].decode() for x in names_denom)}""",
             expr.args[1]
         )
     # Compute the amount of wei and return that value
@@ -608,7 +606,7 @@ def as_wei_value(expr, args, kwargs, context):
             expr_args_0 = context.constants._constants_ast[expr.args[0].id]
         numstring, num, den = get_number_as_fraction(expr_args_0, context)
         if denomination % den:
-            raise InvalidLiteralException("Too many decimal places: %s" % numstring, expr.args[0])
+            raise InvalidLiteralException(f"Too many decimal places: {numstring}", expr.args[0])
         sub = num * denomination // den
     elif args[0].typ.is_literal:
         if args[0].value <= 0:
@@ -653,7 +651,7 @@ def raw_call(expr, args, kwargs, context):
         )
     if context.is_constant():
         raise ConstancyViolationException(
-            "Cannot make calls from %s" % context.pp_constancy(),
+            f"Cannot make calls from {context.pp_constancy()}",
             expr,
         )
     if value != zero_value:
@@ -727,7 +725,7 @@ def send(expr, args, kwargs, context):
     to, value = args
     if context.is_constant():
         raise ConstancyViolationException(
-            "Cannot send ether inside %s!" % context.pp_constancy(),
+            f"Cannot send ether inside {context.pp_constancy()}!",
             expr,
         )
     enforce_units(value.typ, expr.args[1], BaseType('uint256', {'wei': 1}))
@@ -742,7 +740,7 @@ def send(expr, args, kwargs, context):
 def selfdestruct(expr, args, kwargs, context):
     if context.is_constant():
         raise ConstancyViolationException(
-            "Cannot %s inside %s!" % (expr.func.id, context.pp_constancy()),
+            f"Cannot {expr.func.id} inside {context.pp_constancy()}!",
             expr.func,
         )
     return LLLnode.from_list(['selfdestruct', args[0]], typ=None, pos=getpos(expr))
@@ -776,7 +774,7 @@ def _RLPlist(expr, args, kwargs, context):
             if not isinstance(subtyp, BaseType):
                 raise TypeMismatchException("RLP lists only accept BaseTypes and byte arrays", arg)
             if not is_base_type(subtyp, ('int128', 'uint256', 'bytes32', 'address', 'bool')):
-                raise TypeMismatchException("Unsupported base type: %s" % subtyp.typ, arg)
+                raise TypeMismatchException(f"Unsupported base type: {subtyp.typ}", arg)
         _format.append(subtyp)
     output_type = TupleType(_format)
     output_placeholder_type = ByteArrayType(
@@ -885,7 +883,7 @@ def _RLPlist(expr, args, kwargs, context):
                 ],
                 typ,
                 location='memory',
-                annotation='getting and checking %s' % typ.typ,
+                annotation=f'getting and checking {typ.typ}',
             )
             decoder.append(byte_array_to_num(bytez, expr, typ.typ))
         # Decoder for bools
@@ -1125,7 +1123,7 @@ def create_forwarder_to(expr, args, kwargs, context):
                       BaseType('uint256', {'wei': 1}))
     if context.is_constant():
         raise ConstancyViolationException(
-            "Cannot make calls from %s" % context.pp_constancy(),
+            f"Cannot make calls from {context.pp_constancy()}",
             expr,
         )
     placeholder = context.new_placeholder(ByteArrayType(96))
@@ -1186,7 +1184,7 @@ def minmax(expr, args, kwargs, context, is_min):
         otyp.is_literal = False
     else:
         raise TypeMismatchException(
-            "Minmax types incompatible: %s %s" % (left.typ.typ, right.typ.typ)
+            f"Minmax types incompatible: {left.typ.typ} {right.typ.typ}"
         )
     return LLLnode.from_list(
         ['with', '_l', left, ['with', '_r', right, o]],

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -594,8 +594,8 @@ def as_wei_value(expr, args, kwargs, context):
             break
     else:
         raise InvalidLiteralException(
-            f"""Invalid denomination: {args[1]}, valid denominations are:
-            {','.join(x[0].decode() for x in names_denom)}""",
+            f"Invalid denomination: {args[1]}, valid denominations are: "
+            f"{','.join(x[0].decode() for x in names_denom)}",
             expr.args[1]
         )
     # Compute the amount of wei and return that value

--- a/vyper/functions/signatures.py
+++ b/vyper/functions/signatures.py
@@ -120,7 +120,8 @@ def signature(*argz, **kwargz):
             function_name = element.func.id
             if len(element.args) > len(argz):
                 raise StructureException(
-                    f"Expected {len(argz)} arguments for {function_name}, got {len(element.args)}",  # noqa: E501
+                    f"Expected {len(argz)} arguments for {function_name}, "
+                    f"got {len(element.args)}",
                     element
                 )
             subs = []

--- a/vyper/parser/arg_clamps.py
+++ b/vyper/parser/arg_clamps.py
@@ -71,7 +71,7 @@ def make_arg_clamper(datapos, mempos, typ, is_init=False):
 
             # for i in range(typ.count):
             mem_to = subtype_size * 32 * (typ.count - 1)
-            loop_label = "_check_list_loop_%s" % str(uuid.uuid4())
+            loop_label = f"_check_list_loop_{str(uuid.uuid4())}"
 
             # use LOOP_FREE_INDEX to store i
             offset = 288

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -73,10 +73,10 @@ class Constants(object):
 
         if fail:
             raise TypeMismatchException(
-                'Invalid value for constant type, expected %r got %r instead' % (
-                    annotation_type,
-                    expr.typ,
-                ),
+                f"""
+                Invalid value for constant type, expected {annotation_type} got
+                {expr.typ} instead'
+                """,
                 const.value,
             )
 
@@ -133,7 +133,7 @@ class Constants(object):
                 return expr
             else:
                 raise VariableDeclarationException(
-                    "ByteArray: Can not be used outside of a function context: %s" % const_name
+                    f"ByteArray: Can not be used outside of a function context: {const_name}"
                 )
 
         # Other types are already unwrapped, no need

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -73,10 +73,8 @@ class Constants(object):
 
         if fail:
             raise TypeMismatchException(
-                f"""
-                Invalid value for constant type, expected {annotation_type} got
-                {expr.typ} instead'
-                """,
+                f"Invalid value for constant type, expected {annotation_type} got "
+                f"{expr.typ} instead",
                 const.value,
             )
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -141,7 +141,7 @@ class Context:
             )
             # Local context duplicate context check.
             if any((name in self.vars, name in self.globals, name in self.constants)):
-                raise VariableDeclarationException("Duplicate variable name: %s" % name, name)
+                raise VariableDeclarationException(f"Duplicate variable name: {name}", name)
         return True
 
     # TODO location info for errors
@@ -179,4 +179,4 @@ class Context:
             return 'a range expression'
         elif self.constancy == Constancy.Constant:
             return 'a constant function'
-        raise ValueError('Compiler error: unknown constancy in pp_constancy: %r' % self.constancy)
+        raise ValueError(f'Compiler error: unknown constancy in pp_constancy: {self.constancy}')

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -43,7 +43,7 @@ def pack_logging_topics(event_id, args, expected_topics, context, pos):
         if isinstance(arg_type, ByteArrayLike) and isinstance(expected_type, ByteArrayLike):
             if arg_type.maxlen > expected_type.maxlen:
                 raise TypeMismatchException(
-                    "Topic input bytes are too big: %r %r" % (arg_type, expected_type), code_pos
+                    f"Topic input bytes are too big: {arg_type} {expected_type}", code_pos
                 )
             if isinstance(arg, ast.Str):
                 bytez, bytez_length = string_to_bytes(arg.s)
@@ -130,7 +130,7 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder,
         def check_list_type_match(provided):  # Check list types match.
             if provided != typ:
                 raise TypeMismatchException(
-                    "Log list type '%s' does not match provided, expected '%s'" % (provided, typ)
+                    f"Log list type '{provided}' does not match provided, expected '{typ}'"
                 )
 
         # NOTE: Below code could be refactored into iterators/getter functions for each type of
@@ -220,11 +220,11 @@ def pack_logging_data(expected_data, args, context, pos):
             if isinstance(arg, ast.Str):
                 if len(arg.s) > typ.maxlen:
                     raise TypeMismatchException(
-                        "Data input bytes are to big: %r %r" % (len(arg.s), typ), pos
+                        f"Data input bytes are to big: {len(arg.s)} {typ}", pos
                     )
 
             tmp_variable = context.new_variable(
-                '_log_pack_var_%i_%i' % (arg.lineno, arg.col_offset),
+                f'_log_pack_var_{arg.lineno}_{arg.col_offset}',
                 source_lll.typ,
             )
             tmp_variable_node = LLLnode.from_list(
@@ -232,7 +232,7 @@ def pack_logging_data(expected_data, args, context, pos):
                 typ=source_lll.typ,
                 pos=getpos(arg),
                 location="memory",
-                annotation='log_prealloacted %r' % source_lll.typ,
+                annotation=f'log_prealloacted {source_lll.typ}',
             )
             # Store len.
             # holder.append(['mstore', len_placeholder, ['mload', unwrap_location(source_lll)]])

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -186,7 +186,7 @@ class Expr(object):
                 pos=getpos(self.expr),
             )
         else:
-             raise InvalidLiteralException(
+            raise InvalidLiteralException(
                 f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
                 "incl 0x) or 66 (bytes32 incl 0x)",
             self.expr

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -146,10 +146,11 @@ class Expr(object):
                 else total_bits + 8 - (total_bits % 8)  # ceil8 to get byte length.
             )
             if len(orignum[2:]) != total_bits:  # Support only full formed bit definitions.
-                raise InvalidLiteralException((
+                raise InvalidLiteralException(
                     f"Bit notation requires a multiple of 8 bits / 1 byte. "
-                    f"{total_bits - len(orignum[2:])} bit(s) are missing."
-                ), self.expr)
+                    f"{total_bits - len(orignum[2:])} bit(s) are missing.",
+                self.expr,
+            )
             byte_len = int(total_bits / 8)
             placeholder = self.context.new_placeholder(ByteArrayType(byte_len))
             seq = []
@@ -172,7 +173,7 @@ class Expr(object):
                     "Address checksum mismatch. If you are sure this is the "
                     f"right address, the correct checksummed form is: {checksum_encode(orignum)}",
                     self.expr
-                    )
+                )
             return LLLnode.from_list(
                 self.expr.n,
                 typ=BaseType('address', is_literal=True),
@@ -187,8 +188,9 @@ class Expr(object):
         else:
             raise InvalidLiteralException((
                 f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
-                "incl 0x) or 66 (bytes32 incl 0x)"
-            ), self.expr)
+                "incl 0x) or 66 (bytes32 incl 0x)",
+            self.expr
+        )
 
     # String literals
     def string(self):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -186,7 +186,7 @@ class Expr(object):
                 pos=getpos(self.expr),
             )
         else:
-            raise InvalidLiteralException((
+             raise InvalidLiteralException(
                 f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
                 "incl 0x) or 66 (bytes32 incl 0x)",
             self.expr

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -149,8 +149,8 @@ class Expr(object):
                 raise InvalidLiteralException(
                     f"Bit notation requires a multiple of 8 bits / 1 byte. "
                     f"{total_bits - len(orignum[2:])} bit(s) are missing.",
-                self.expr,
-            )
+                    self.expr,
+                )
             byte_len = int(total_bits / 8)
             placeholder = self.context.new_placeholder(ByteArrayType(byte_len))
             seq = []
@@ -189,8 +189,8 @@ class Expr(object):
             raise InvalidLiteralException(
                 f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
                 "incl 0x) or 66 (bytes32 incl 0x)",
-            self.expr
-        )
+                self.expr
+            )
 
     # String literals
     def string(self):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -147,9 +147,9 @@ class Expr(object):
             )
             if len(orignum[2:]) != total_bits:  # Support only full formed bit definitions.
                 raise InvalidLiteralException((
-                    "Bit notation requires a multiple of 8 bits / 1 byte. {} "
-                    "bit(s) are missing."
-                ).format(total_bits - len(orignum[2:])), self.expr)
+                    f"""Bit notation requires a multiple of 8 bits / 1 byte.
+                    {total_bits - len(orignum[2:])} bit(s) are missing."""
+                ), self.expr)
             byte_len = int(total_bits / 8)
             placeholder = self.context.new_placeholder(ByteArrayType(byte_len))
             seq = []
@@ -164,12 +164,12 @@ class Expr(object):
                 typ=ByteArrayType(byte_len),
                 location='memory',
                 pos=getpos(self.expr),
-                annotation='Create ByteArray (Binary literal): %s' % str_val,
+                annotation=f'Create ByteArray (Binary literal): {str_val}',
             )
         elif len(orignum) == 42:
             if checksum_encode(orignum) != orignum:
-                raise InvalidLiteralException("""Address checksum mismatch. If you are sure this is the
-right address, the correct checksummed form is: %s""" % checksum_encode(orignum), self.expr)
+                raise InvalidLiteralException(f"""Address checksum mismatch. If you are sure this is the
+right address, the correct checksummed form is: {checksum_encode(orignum)}""", self.expr)
             return LLLnode.from_list(
                 self.expr.n,
                 typ=BaseType('address', is_literal=True),
@@ -183,9 +183,9 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             )
         else:
             raise InvalidLiteralException((
-                "Cannot read 0x value with length %d. Expecting 42 (address "
+                f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
                 "incl 0x) or 66 (bytes32 incl 0x)"
-            ) % len(orignum), self.expr)
+            ), self.expr)
 
     # String literals
     def string(self):
@@ -213,7 +213,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             typ=btype,
             location='memory',
             pos=getpos(self.expr),
-            annotation='Create %r: %s' % (btype, bytez),
+            annotation=f'Create {btype}: {bytez}',
         )
 
     # True, False, None constants
@@ -233,7 +233,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
         elif self.expr.value is None:
             return LLLnode.from_list(None, typ=NullType(), pos=getpos(self.expr))
         else:
-            raise Exception("Unknown name constant: %r" % self.expr.value.value)
+            raise Exception(f"Unknown name constant: {self.expr.value.value}")
 
     # Variable names
     def variables(self):
@@ -260,7 +260,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
         elif self.context.constants.ast_is_constant(self.expr):
             return self.context.constants.get_constant(self.expr.id, self.context)
         else:
-            raise VariableDeclarationException("Undeclared variable: " + self.expr.id, self.expr)
+            raise VariableDeclarationException(f"Undeclared variable: {self.expr.id}", self.expr)
 
     # x.y or x[5]
     def attribute(self):
@@ -376,9 +376,8 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             attrs = list(sub.typ.members.keys())
             if self.expr.attr not in attrs:
                 raise TypeMismatchException(
-                    "Member %s not found. Only the following available: %s" % (
-                        self.expr.attr, " ".join(attrs)
-                    ),
+                    f"""Member {self.expr.attr} not found. Only the following available:
+                    {' '.join(attrs)}""",
                     self.expr,
                 )
             return add_variable_offset(sub, self.expr.attr, pos=getpos(self.expr))
@@ -426,7 +425,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
 
         if not is_numeric_type(left.typ) or not is_numeric_type(right.typ):
             raise TypeMismatchException(
-                "Unsupported types for arithmetic op: %r %r" % (left.typ, right.typ),
+                f"Unsupported types for arithmetic op: {left.typ} {right.typ}",
                 self.expr,
             )
 
@@ -451,7 +450,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                 val = left.value ** right.value
             else:
                 raise ParserException(
-                    'Unsupported literal operator: %s' % str(type(self.expr.op)),
+                    f'Unsupported literal operator: {str(type(self.expr.op))}',
                     self.expr,
                 )
 
@@ -485,7 +484,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
         # Only allow explicit conversions to occur.
         if left.typ.typ != right.typ.typ:
             raise TypeMismatchException(
-                "Cannot implicitly convert {} to {}.".format(left.typ.typ, right.typ.typ),
+                f"Cannot implicitly convert {left.typ.typ} to {right.typ.typ}.",
                 self.expr,
             )
 
@@ -493,7 +492,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
         if isinstance(self.expr.op, (ast.Add, ast.Sub)):
             if left.typ.unit != right.typ.unit and left.typ.unit != {} and right.typ.unit != {}:
                 raise TypeMismatchException(
-                    "Unit mismatch: %r %r" % (left.typ.unit, right.typ.unit),
+                    f"Unit mismatch: {left.typ.unit} {right.typ.unit}",
                     self.expr,
                 )
             if left.typ.positional and right.typ.positional and isinstance(self.expr.op, ast.Add):
@@ -528,7 +527,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                     pos=getpos(self.expr),
                 )
             else:
-                raise Exception("Unsupported Operation '%r(%r, %r)'" % (op, ltyp, rtyp))
+                raise Exception(f"Unsupported Operation '{op}({ltyp}, {rtyp})'")
         elif isinstance(self.expr.op, ast.Mult):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot multiply positional values!", self.expr)
@@ -566,7 +565,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                     ],
                 ], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             else:
-                raise Exception("Unsupported Operation 'mul(%r, %r)'" % (ltyp, rtyp))
+                raise Exception(f"Unsupported Operation 'mul({ltyp}, {rtyp})'")
         elif isinstance(self.expr.op, ast.Div):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot divide positional values!", self.expr)
@@ -595,7 +594,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                     ]
                 ], typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             else:
-                raise Exception("Unsupported Operation 'div(%r, %r)'" % (ltyp, rtyp))
+                raise Exception(f"Unsupported Operation 'div({ltyp}, {rtyp})'")
         elif isinstance(self.expr.op, ast.Mod):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException(
@@ -618,7 +617,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                     pos=getpos(self.expr),
                 )
             else:
-                raise Exception("Unsupported Operation 'mod(%r, %r)'" % (ltyp, rtyp))
+                raise Exception(f"Unsupported Operation 'mod({ltyp}, {rtyp})'")
         elif isinstance(self.expr.op, ast.Pow):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException(
@@ -660,7 +659,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             else:
                 raise TypeMismatchException('Only whole number exponents are supported', self.expr)
         else:
-            raise ParserException("Unsupported binary operator: %r" % self.expr.op, self.expr)
+            raise ParserException(f"Unsupported binary operator: {self.expr.op}", self.expr)
 
         p = ['seq']
 
@@ -689,7 +688,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             p.append(o)
             return LLLnode.from_list(p, typ=o.typ, pos=getpos(self.expr))
         else:
-            raise Exception("%r %r" % (o, o.typ))
+            raise Exception(f"{o} {o.typ}")
 
     def build_in_comparator(self):
         left = Expr(self.expr.left, self.context).lll_node
@@ -697,7 +696,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
 
         if left.typ != right.typ.subtype:
             raise TypeMismatchException(
-                "%s cannot be in a list of %s" % (left.typ, right.typ.subtype),
+                f"{left.typ} cannot be in a list of {right.typ.subtype}",
             )
 
         result_placeholder = self.context.new_placeholder(BaseType('bool'))
@@ -886,10 +885,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             op = self._signed_to_unsigned_comparision_op(op)
         elif (left_type in ('decimal', 'int128') or right_type in ('decimal', 'int128')) and left_type != right_type:  # noqa: E501
             raise TypeMismatchException(
-                'Implicit conversion from {} to {} disallowed, please convert.'.format(
-                    left_type,
-                    right_type,
-                ),
+                f'Implicit conversion from {left_type} to {right_type} disallowed, please convert.',
                 self.expr,
             )
 
@@ -897,7 +893,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
             return LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
         else:
             raise TypeMismatchException(
-                "Unsupported types for comparison: %r %r" % (left_type, right_type),
+                f"Unsupported types for comparison: {left_type} {right_type}",
                 self.expr,
             )
 
@@ -958,13 +954,13 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                 return LLLnode.from_list(["iszero", operand], typ='bool', pos=getpos(self.expr))
             else:
                 raise TypeMismatchException(
-                    "Only bool is supported for not operation, %r supplied." % operand.typ,
+                    f"Only bool is supported for not operation, {operand.typ} supplied.",
                     self.expr,
                 )
         elif isinstance(self.expr.op, ast.USub):
             if not is_numeric_type(operand.typ):
                 raise TypeMismatchException(
-                    "Unsupported type for negation: %r" % operand.typ,
+                    f"Unsupported type for negation: {operand.typ}",
                     operand,
                 )
 
@@ -1029,9 +1025,9 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
                         self.expr,
                     )
             else:
-                err_msg = "Not a top-level function: {}".format(function_name)
+                err_msg = f"Not a top-level function: {function_name}"
                 if function_name in [x.split('(')[0] for x, _ in self.context.sigs['self'].items()]:
-                    err_msg += ". Did you mean self.{}?".format(function_name)
+                    err_msg += f". Did you mean self.{function_name}?"
                 raise StructureException(err_msg, self.expr)
         elif isinstance(self.expr.func, ast.Attribute) and isinstance(self.expr.func.value, ast.Name) and self.expr.func.value.id == "self":  # noqa: E501
             return self_call.make_call(self.expr, self.context)
@@ -1085,7 +1081,7 @@ right address, the correct checksummed form is: %s""" % checksum_encode(orignum)
         for key, value in zip(expr.keys, expr.values):
             if not isinstance(key, ast.Name):
                 raise TypeMismatchException(
-                    "Invalid member variable for struct: %r" % getattr(key, 'id', ''),
+                    f"Invalid member variable for struct: {getattr(key, 'id', '')}",
                     key,
                 )
             check_valid_varname(

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -147,8 +147,8 @@ class Expr(object):
             )
             if len(orignum[2:]) != total_bits:  # Support only full formed bit definitions.
                 raise InvalidLiteralException((
-                    f"""Bit notation requires a multiple of 8 bits / 1 byte.
-                    {total_bits - len(orignum[2:])} bit(s) are missing."""
+                    f"Bit notation requires a multiple of 8 bits / 1 byte. "
+                    f"{total_bits - len(orignum[2:])} bit(s) are missing."
                 ), self.expr)
             byte_len = int(total_bits / 8)
             placeholder = self.context.new_placeholder(ByteArrayType(byte_len))
@@ -168,8 +168,11 @@ class Expr(object):
             )
         elif len(orignum) == 42:
             if checksum_encode(orignum) != orignum:
-                raise InvalidLiteralException(f"""Address checksum mismatch. If you are sure this is the
-right address, the correct checksummed form is: {checksum_encode(orignum)}""", self.expr)
+                raise InvalidLiteralException(
+                    "Address checksum mismatch. If you are sure this is the "
+                    f"right address, the correct checksummed form is: {checksum_encode(orignum)}",
+                    self.expr
+                    )
             return LLLnode.from_list(
                 self.expr.n,
                 typ=BaseType('address', is_literal=True),
@@ -376,8 +379,8 @@ right address, the correct checksummed form is: {checksum_encode(orignum)}""", s
             attrs = list(sub.typ.members.keys())
             if self.expr.attr not in attrs:
                 raise TypeMismatchException(
-                    f"""Member {self.expr.attr} not found. Only the following available:
-                    {' '.join(attrs)}""",
+                    f"Member {self.expr.attr} not found. Only the following available: "
+                    f"{' '.join(attrs)}",
                     self.expr,
                 )
             return add_variable_offset(sub, self.expr.attr, pos=getpos(self.expr))

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -55,10 +55,10 @@ def external_contract_call(node,
     if method_name not in context.sigs[contract_name]:
         raise FunctionDeclarationException(
             (
-                "Function not declared yet: %s (reminder: "
+                f"Function not declared yet: {method_name} (reminder: "
                 "function must be declared in the correct contract)"
-                " The available methods are: %s"
-            ) % (method_name, ",".join(context.sigs[contract_name].keys())),
+                f"The available methods are: {','.join(context.sigs[contract_name].keys())}"
+            ),
             node.func
         )
     sig = context.sigs[contract_name][method_name]
@@ -76,10 +76,8 @@ def external_contract_call(node,
     ]
     if context.is_constant() and not sig.const:
         raise ConstancyViolationException(
-            "May not call non-constant function '%s' within %s." % (
-                method_name,
-                context.pp_constancy(),
-            ) +
+            f"May not call non-constant function '{method_name}' within {context.pp_constancy()}."
+            +
             " For asserting the result of modifiable contract calls, try assert_modifiable.",
             node
         )
@@ -119,7 +117,7 @@ def get_external_contract_call_output(sig, context):
     elif isinstance(sig.output_type, ListType):
         returner = [0, output_placeholder]
     else:
-        raise TypeMismatchException("Invalid output type: %s" % sig.output_type)
+        raise TypeMismatchException(f"Invalid output type: {sig.output_type}")
     return output_placeholder, output_size, returner
 
 

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -77,7 +77,6 @@ def external_contract_call(node,
     if context.is_constant() and not sig.const:
         raise ConstancyViolationException(
             f"May not call non-constant function '{method_name}' within {context.pp_constancy()}."
-            +
             " For asserting the result of modifiable contract calls, try assert_modifiable.",
             node
         )

--- a/vyper/parser/function_definitions/parse_private_function.py
+++ b/vyper/parser/function_definitions/parse_private_function.py
@@ -93,7 +93,7 @@ def parse_private_function(code: ast.FunctionDef,
     # Allocate variable space.
     context.memory_allocator.increase_memory(sig.max_copy_size)
 
-    _post_callback_ptr = "{}_{}_post_callback_ptr".format(sig.name, sig.method_id)
+    _post_callback_ptr = f"{sig.name}_{sig.method_id}_post_callback_ptr"
     context.callback_ptr = context.new_placeholder(typ=BaseType('uint256'))
     clampers.append(
         LLLnode.from_list(
@@ -143,7 +143,7 @@ def parse_private_function(code: ast.FunctionDef,
         unpackers: List[Any] = []
         for idx, var_name in enumerate(dyn_variable_names):
             var = context.vars[var_name]
-            ident = "_load_args_%d_dynarg%d" % (sig.method_id, idx)
+            ident = f"_load_args_{sig.method_id}_dynarg{idx}"
             o = make_unpacker(ident=ident, i_placeholder=i_placeholder, begin_pos=var.pos)
             unpackers.append(o)
 
@@ -222,7 +222,7 @@ def parse_private_function(code: ast.FunctionDef,
                 if dynamics:
                     i_placeholder = context.new_placeholder(typ=BaseType('uint256'))
                     for idx, var_pos in enumerate(dynamics):
-                        ident = 'unpack_default_sig_dyn_%d_arg%d' % (default_sig.method_id, idx)
+                        ident = f'unpack_default_sig_dyn_{default_sig.method_id}_arg{idx}'
                         default_copiers.append(make_unpacker(
                             ident=ident,
                             i_placeholder=i_placeholder,

--- a/vyper/parser/function_definitions/parse_public_function.py
+++ b/vyper/parser/function_definitions/parse_public_function.py
@@ -177,7 +177,7 @@ def parse_public_function(code: ast.FunctionDef,
     else:
         # Function with default parameters.
         if sig.total_default_args > 0:
-            function_routine = "{}_{}".format(sig.name, sig.method_id)
+            function_routine = f"{sig.name}_{sig.method_id}"
             default_sigs = sig_utils.generate_default_arg_sigs(
                 code, context.sigs, context.global_ctx
             )

--- a/vyper/parser/function_definitions/utils.py
+++ b/vyper/parser/function_definitions/utils.py
@@ -4,13 +4,13 @@ from vyper.parser.lll_node import (
 
 
 def get_sig_statements(sig, pos):
-    method_id_node = LLLnode.from_list(sig.method_id, pos=pos, annotation='%s' % sig.sig)
+    method_id_node = LLLnode.from_list(sig.method_id, pos=pos, annotation=f'{sig.sig}')
 
     if sig.private:
         sig_compare = 0
         private_label = LLLnode.from_list(
-            ['label', 'priv_{}'.format(sig.method_id)],
-            pos=pos, annotation='%s' % sig.sig
+            ['label', f'priv_{sig.method_id}'],
+            pos=pos, annotation=f'{sig.sig}'
         )
     else:
         sig_compare = ['eq', ['mload', 0], method_id_node]

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -84,7 +84,7 @@ class GlobalContext:
                 elif item.class_type == 'contract':
                     if item.name in global_ctx._contracts or item.name in global_ctx._interfaces:
                         raise StructureException(
-                            "Contract '{}' is already defined".format(item.name),
+                            f"Contract '{item.name}' is already defined",
                             item,
                         )
                     global_ctx._contracts[item.name] = GlobalContext.make_contract(item.body)
@@ -105,7 +105,7 @@ class GlobalContext:
                     interface_name = item.annotation.id
                     if interface_name not in global_ctx._interfaces:
                         raise StructureException(
-                            'Unknown interface specified: {}'.format(interface_name), item
+                            f'Unknown interface specified: {interface_name}', item
                         )
                     global_ctx._implemented_interfaces.add(interface_name)
                 else:
@@ -114,7 +114,7 @@ class GlobalContext:
             elif isinstance(item, ast.FunctionDef):
                 if item.name in global_ctx._globals:
                     raise FunctionDeclarationException(
-                        "Function name shadowing a variable name: %s" % item.name
+                        f"Function name shadowing a variable name: {item.name}"
                     )
                 global_ctx._defs.append(item)
             elif isinstance(item, ast.ImportFrom):
@@ -124,11 +124,11 @@ class GlobalContext:
                         interface_name = item_alias.name
                         if interface_name in global_ctx._interfaces:
                             raise StructureException(
-                                'Duplicate import of {}'.format(interface_name), item
+                                f'Duplicate import of {interface_name}', item
                             )
                         if interface_name not in built_in_interfaces:
                             raise StructureException(
-                                'Built-In interface {} does not exist.'.format(interface_name), item
+                                f'Built-In interface {interface_name} does not exist.', item
                             )
                         global_ctx._interfaces[interface_name] = built_in_interfaces[interface_name].copy()  # noqa: E501
                 else:
@@ -137,11 +137,11 @@ class GlobalContext:
 
                         if interface_name in global_ctx._interfaces:
                             raise StructureException(
-                                'Duplicate import of {}'.format(interface_name), item
+                                f'Duplicate import of {interface_name}', item
                             )
                         if interface_name not in interface_codes:
                             raise StructureException(
-                                'Unknown interface {}'.format(interface_name), item
+                                f'Unknown interface {interface_name}', item
                             )
                         global_ctx._interfaces[interface_name] = extract_sigs(interface_codes[interface_name])  # noqa: E501
             elif isinstance(item, ast.Import):
@@ -154,11 +154,11 @@ class GlobalContext:
                     interface_name = item_alias.asname
                     if interface_name in global_ctx._interfaces:
                         raise StructureException(
-                            'Duplicate import of {}'.format(interface_name), item
+                            f'Duplicate import of {interface_name}', item
                         )
                     if interface_name not in interface_codes:
                         raise StructureException(
-                            'Unknown interface {}'.format(interface_name), item
+                            f'Unknown interface {interface_name}', item
                         )
                     global_ctx._interfaces[interface_name] = extract_sigs(interface_codes[interface_name])  # noqa: E501
             else:
@@ -210,8 +210,8 @@ class GlobalContext:
             for funname, head, tail, base in cls._mk_getter_helper(typ.subtype, depth + 1):
                 o.append((
                     funname,
-                    ("arg%d: int128, " % depth) + head,
-                    ("[arg%d]" % depth) + tail,
+                    (f"arg{depth}: int128, ") + head,
+                    (f"[arg{depth}]") + tail,
                     base,
                 ))
             return o
@@ -222,8 +222,8 @@ class GlobalContext:
             for funname, head, tail, base in cls._mk_getter_helper(typ.valuetype, depth + 1):
                 o.append((
                     funname,
-                    ("arg%d: %r, " % (depth, typ.keytype)) + head,
-                    ("[arg%d]" % depth) + tail,
+                    (f"arg{depth}: {typ.keytype}, ") + head,
+                    (f"[arg{depth}]") + tail,
                     base,
                 ))
             return o
@@ -244,9 +244,7 @@ class GlobalContext:
     def mk_getter(cls, varname, typ):
         funs = cls._mk_getter_helper(typ)
         return [
-            """@public\n@constant\ndef %s%s(%s) -> %s: return self.%s%s""" % (
-                varname, funname, head.rstrip(', '), base, varname, tail
-            ) for (funname, head, tail, base) in funs
+            f"@public\n@constant\ndef {varname}{funname}({head.rstrip(', ')}) -> {base}: return self.{varname}{tail}" for (funname, head, tail, base) in funs  # noqa: E501
         ]
 
     # Parser for a single line
@@ -265,7 +263,7 @@ class GlobalContext:
                 # Check well-formedness of member names
                 if not isinstance(member_name, ast.Name):
                     raise InvalidTypeException(
-                        "Invalid member name for struct %r, needs to be a valid name. " % name,
+                        f"Invalid member name for struct {name}, needs to be a valid name. ",
                         item
                     )
                 check_valid_varname(
@@ -330,7 +328,7 @@ class GlobalContext:
             attributes[item.func.id] = True
             # Raise for multiple args
             if len(item.args) != 1:
-                raise StructureException("%s expects one arg (the type)" % item.func.id)
+                raise StructureException(f"{item.func.id} expects one arg (the type)")
             return self.get_item_name_and_attributes(item.args[0], attributes)
         return None, attributes
 
@@ -339,7 +337,7 @@ class GlobalContext:
         check_valid_varname(name, self._custom_units, self._structs, self._constants, item)
         if name in self._globals:
             raise VariableDeclarationException(
-                'Invalid name "%s", previously defined as global.' % name, item
+                f'Invalid name "{name}", previously defined as global.', item
             )
         return True
 
@@ -370,9 +368,7 @@ class GlobalContext:
 
         if len(self._globals) > NONRENTRANT_STORAGE_OFFSET:
             raise ParserException(
-                "Too many globals defined, only {} globals are allowed".format(
-                    NONRENTRANT_STORAGE_OFFSET
-                ),
+                f"Too many globals defined, only {NONRENTRANT_STORAGE_OFFSET} globals are allowed",
                 item,
             )
 
@@ -389,7 +385,7 @@ class GlobalContext:
         if not (self.get_call_func_name(item) == "event"):
             item_name, item_attributes = self.get_item_name_and_attributes(item, item_attributes)
             if not all([attr in valid_global_keywords for attr in item_attributes.keys()]):
-                raise StructureException('Invalid global keyword used: %s' % item_attributes, item)
+                raise StructureException(f'Invalid global keyword used: {item_attributes}', item)
 
         if item.value is not None:
             raise StructureException('May not assign value whilst defining type', item)

--- a/vyper/parser/keccak256_helper.py
+++ b/vyper/parser/keccak256_helper.py
@@ -49,7 +49,7 @@ def keccak256_helper(expr, args, kwargs, context):
         lengetter = LLLnode.from_list(['sload', ['sha3_32', '_sub']], typ=BaseType('int128'))
     else:
         # This should never happen, but just left here for future compiler-writers.
-        raise Exception("Unsupported location: %s" % sub.location)  # pragma: no test
+        raise Exception(f"Unsupported location: {sub.location}")  # pragma: no test
     placeholder = context.new_placeholder(sub.typ)
     placeholder_node = LLLnode.from_list(placeholder, typ=sub.typ, location='memory')
     copier = make_byte_array_copier(

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -136,10 +136,10 @@ class LLLnode:
                 if len(self.args) == 2:
                     self.gas = self.args[0].gas + self.args[1].gas + 17
                 if not self.args[0].valency:
-                    raise CompilerPanic((
+                    raise CompilerPanic(
                         "Can't have a zerovalent argument as a test to an if "
                         f"statement! {self.args[0]}"
-                    ))
+                    )
                 if len(self.args) not in (2, 3):
                     raise CompilerPanic("If can only have 2 or 3 arguments")
                 self.valency = self.args[1].valency

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -93,7 +93,7 @@ class LLLnode:
                 self.valency = outs
                 if len(self.args) != ins:
                     raise CompilerPanic(
-                        "Number of arguments mismatched: %r %r" % (self.value, self.args)
+                        f"Number of arguments mismatched: {self.value} {self.args}"
                     )
                 # We add 2 per stack height at push time and take it back
                 # at pop time; this makes `break` easier to handle
@@ -106,7 +106,7 @@ class LLLnode:
                     if arg.valency == 0 and arg.value not in zero_valency_whitelist:
                         raise CompilerPanic(
                             "Can't have a zerovalent argument to an opcode or a pseudo-opcode! "
-                            "%r: %r. Please file a bug report." % (arg.value, arg)
+                            f"{arg.value}: {arg}. Please file a bug report."
                         )
                     self.gas += arg.gas
                 # Dynamic gas cost: 8 gas for each byte of logging data
@@ -138,8 +138,8 @@ class LLLnode:
                 if not self.args[0].valency:
                     raise CompilerPanic((
                         "Can't have a zerovalent argument as a test to an if "
-                        "statement! %r"
-                    ) % self.args[0])
+                        f"statement! {self.args[0]}"
+                    ))
                 if len(self.args) not in (2, 3):
                     raise CompilerPanic("If can only have 2 or 3 arguments")
                 self.valency = self.args[1].valency
@@ -152,8 +152,8 @@ class LLLnode:
                 if not self.args[1].valency:
                     raise CompilerPanic((
                         "Second argument to with statement (initial value) "
-                        "cannot be zerovalent: %r"
-                    ) % self.args[1])
+                        f"cannot be zerovalent: {self.args[1]}"
+                    ))
                 self.valency = self.args[2].valency
                 self.gas = sum([arg.gas for arg in self.args]) + 5
             # Repeat statements: repeat <index_memloc> <startval> <rounds> <body>
@@ -167,23 +167,23 @@ class LLLnode:
                 if is_invalid_repeat_count:
                     raise CompilerPanic((
                         "Number of times repeated must be a constant nonzero "
-                        "positive integer: %r"
-                    ) % self.args[2])
+                        f"positive integer: {self.args[2]}"
+                    ))
                 if not self.args[0].valency:
                     raise CompilerPanic((
                         "First argument to repeat (memory location) cannot be "
-                        "zerovalent: %r"
-                    ) % self.args[0])
+                        f"zerovalent: {self.args[0]}"
+                    ))
                 if not self.args[1].valency:
                     raise CompilerPanic((
                         "Second argument to repeat (start value) cannot be "
-                        "zerovalent: %r"
-                    ) % self.args[1])
+                        f"zerovalent: {self.args[1]}"
+                    ))
                 if self.args[3].valency:
                     raise CompilerPanic((
                         "Third argument to repeat (clause to be repeated) must "
-                        "be zerovalent: %r"
-                    ) % self.args[3])
+                        f"be zerovalent: {self.args[3]}"
+                    ))
                 self.valency = 0
                 if self.args[1].value in ('calldataload', 'mload') or self.args[1].value == 'sload':
                     rounds = self.args[2].value
@@ -199,7 +199,7 @@ class LLLnode:
                 for arg in self.args:
                     if not arg.valency:
                         raise CompilerPanic(
-                            "Multi expects all children to not be zerovalent: %r" % arg
+                            f"Multi expects all children to not be zerovalent: {arg}"
                         )
                 self.valency = sum([arg.valency for arg in self.args])
                 self.gas = sum([arg.gas for arg in self.args])
@@ -219,7 +219,7 @@ class LLLnode:
             self.valency = 1
             self.gas = 5
         else:
-            raise CompilerPanic("Invalid value for LLL AST node: %r" % self.value)
+            raise CompilerPanic(f"Invalid value for LLL AST node: {self.value}")
         assert isinstance(self.args, list)
 
         if valency is not None:
@@ -268,7 +268,7 @@ class LLLnode:
         if not len(self.args):
 
             if self.annotation:
-                return '%r ' % self.repr_value + OKLIGHTBLUE + '<%s>' % self.annotation + ENDC
+                return f'{self.repr_value} ' + OKLIGHTBLUE + f'<{self.annotation}>' + ENDC
             else:
                 return str(self.repr_value)
         # x = repr(self.to_list())
@@ -276,7 +276,7 @@ class LLLnode:
         #     return x
         o = ''
         if self.annotation:
-            o += '/* %s */ \n' % self.annotation
+            o += f'/* {self.annotation} */ \n'
         if self.repr_show_gas and self.gas:
             o += OKBLUE + "{" + ENDC + str(self.gas) + OKBLUE + "} " + ENDC  # add gas for info.
         o += '[' + self._colorise_keywords(self.repr_value)
@@ -288,7 +288,7 @@ class LLLnode:
             o += ',\n  '
             arg_lineno = arg.pos[0] if arg.pos else None
             if arg_lineno is not None and arg_lineno != prev_lineno and self.value in ('seq', 'if'):
-                o += '# Line %d\n  ' % (arg_lineno)
+                o += f'# Line {(arg_lineno)}\n  '
                 prev_lineno = arg_lineno
                 annotated = True
             arg_repr = arg.repr()

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -77,8 +77,8 @@ def parse_external_contracts(external_contracts, global_ctx):
         contract = {}
         if len(set(_defnames)) < len(_contract_defs):
             raise FunctionDeclarationException(
-                f"""Duplicate function name:
-                {[name for name in _defnames if _defnames.count(name) > 1][0]}"""
+                "Duplicate function name: "
+                f"{[name for name in _defnames if _defnames.count(name) > 1][0]}"
             )
 
         for _def in _contract_defs:
@@ -158,8 +158,8 @@ def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None):
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
         raise FunctionDeclarationException(
-            f"""Duplicate function name:
-            {[name for name in _names_def if _names_def.count(name) > 1][0]}"""
+            "Duplicate function name: "
+            f"{[name for name in _names_def if _names_def.count(name) > 1][0]}"
         )
     _names_events = [_event.target.id for _event in global_ctx._events]
     # Checks for duplicate event names

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -77,9 +77,8 @@ def parse_external_contracts(external_contracts, global_ctx):
         contract = {}
         if len(set(_defnames)) < len(_contract_defs):
             raise FunctionDeclarationException(
-                "Duplicate function name: %s" % (
-                    [name for name in _defnames if _defnames.count(name) > 1][0]
-                )
+                f"""Duplicate function name:
+                {[name for name in _defnames if _defnames.count(name) > 1][0]}"""
             )
 
         for _def in _contract_defs:
@@ -159,17 +158,15 @@ def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None):
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
         raise FunctionDeclarationException(
-            "Duplicate function name: %s" % (
-                [name for name in _names_def if _names_def.count(name) > 1][0]
-            )
+            f"""Duplicate function name:
+            {[name for name in _names_def if _names_def.count(name) > 1][0]}"""
         )
     _names_events = [_event.target.id for _event in global_ctx._events]
     # Checks for duplicate event names
     if len(set(_names_events)) < len(_names_events):
         raise EventDeclarationException(
-            "Duplicate event name: %s" % (
-                [name for name in _names_events if _names_events.count(name) > 1][0]
-            )
+            f"""Duplicate event name:
+            {[name for name in _names_events if _names_events.count(name) > 1][0]}"""
         )
     # Initialization function
     initfunc = [_def for _def in global_ctx._defs if is_initializer(_def)]

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -93,7 +93,7 @@ def make_byte_array_copier(destination, source, pos=None):
         raise TypeMismatchException(
             f"Cannot cast from greater max-length {source.typ.maxlen} to shorter "
             f"max-length {destination.typ.maxlen}"
-            )
+        )
     # Special case: memory to memory
     if source.location == "memory" and destination.location == "memory":
         gas_calculation = GAS_IDENTITY + GAS_IDENTITYWORD * (ceil32(source.typ.maxlen) // 32)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -91,8 +91,8 @@ def make_byte_array_copier(destination, source, pos=None):
         raise TypeMismatchException(f"Can only set a {btype} to another {btype}", pos)
     if isinstance(source.typ, ByteArrayLike) and source.typ.maxlen > destination.typ.maxlen:
         raise TypeMismatchException(
-            f"""Cannot cast from greater max-length {source.typ.maxlen} to shorter
-            max-length {destination.typ.maxlen}"""
+            f"Cannot cast from greater max-length {source.typ.maxlen} to shorter "
+            f"max-length {destination.typ.maxlen}"
             )
     # Special case: memory to memory
     if source.location == "memory" and destination.location == "memory":
@@ -304,8 +304,8 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
         if isinstance(key.typ, ByteArrayLike):
             if not isinstance(typ.keytype, ByteArrayLike) or (typ.keytype.maxlen < key.typ.maxlen):
                 raise TypeMismatchException(
-                    f'''Mapping keys of bytes cannot be cast, use exact same bytes type of:
-                    {str(typ.keytype)}''',
+                    "Mapping keys of bytes cannot be cast, use exact same bytes type of: "
+                    f"{str(typ.keytype)}",
                     pos,
                 )
             subtype = typ.valuetype
@@ -646,8 +646,8 @@ def make_setter(left, right, location, pos, in_function_call=False):
             else:
                 if len(left.typ.members) != len(right.typ.members):
                     raise TypeMismatchException(
-                        f"""Tuple lengths don't match,
-                        {len(left.typ.members)} vs {len(right.typ.members)}""",
+                        "Tuple lengths don't match, "
+                        f"{len(left.typ.members)} vs {len(right.typ.members)}",
                         pos,
                     )
 

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -57,10 +57,7 @@ def make_call(stmt_expr, context):
 
     if context.is_constant() and not sig.const:
         raise ConstancyViolationException(
-            "May not call non-constant function '%s' within %s." % (
-                method_name,
-                context.pp_constancy(),
-            ),
+            f"May not call non-constant function '{method_name}' within {context.pp_constancy()}.",
             getpos(stmt_expr)
         )
 
@@ -111,7 +108,7 @@ def call_self_private(stmt_expr, context, sig):
         mem_from, mem_to = var_slots[0][0], var_slots[-1][0] + var_slots[-1][1] * 32
 
         i_placeholder = context.new_placeholder(BaseType('uint256'))
-        local_save_ident = "_%d_%d" % (stmt_expr.lineno, stmt_expr.col_offset)
+        local_save_ident = f"_{stmt_expr.lineno}_{stmt_expr.col_offset}"
         push_loop_label = 'save_locals_start' + local_save_ident
         pop_loop_label = 'restore_locals_start' + local_save_ident
 
@@ -156,7 +153,7 @@ def call_self_private(stmt_expr, context, sig):
                     for arg in expr_args])
 
         if needs_dyn_section:
-            ident = 'push_args_%d_%d_%d' % (sig.method_id, stmt_expr.lineno, stmt_expr.col_offset)
+            ident = f'push_args_{sig.method_id}_{stmt_expr.lineno}_{stmt_expr.col_offset}'
             start_label = ident + '_start'
             end_label = ident + '_end'
             i_placeholder = context.new_placeholder(BaseType('uint256'))
@@ -207,7 +204,7 @@ def call_self_private(stmt_expr, context, sig):
     # Jump to function label.
     jump_to_func = [
         ['add', ['pc'], 6],  # set callback pointer.
-        ['goto', 'priv_{}'.format(sig.method_id)],
+        ['goto', f'priv_{sig.method_id}'],
         ['jumpdest'],
     ]
 
@@ -247,7 +244,7 @@ def call_self_private(stmt_expr, context, sig):
             # append dynamic unpacker.
             dyn_idx = 0
             for in_memory_offset, _out_type in dynamic_offsets:
-                ident = "%d_%d_arg_%d" % (stmt_expr.lineno, stmt_expr.col_offset, dyn_idx)
+                ident = f"{stmt_expr.lineno}_{stmt_expr.col_offset}_arg_{dyn_idx}"
                 dyn_idx += 1
                 start_label = 'dyn_unpack_start_' + ident
                 end_label = 'dyn_unpack_end_' + ident
@@ -294,7 +291,7 @@ def call_self_private(stmt_expr, context, sig):
         typ=sig.output_type,
         location='memory',
         pos=getpos(stmt_expr),
-        annotation='Internal Call: %s' % method_name,
+        annotation=f'Internal Call: {method_name}',
         add_gas_estimate=sig.gas
     )
     o.gas += sig.gas

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -88,7 +88,7 @@ class Stmt(object):
         if stmt_type in self.stmt_table:
             self.lll_node = self.stmt_table[stmt_type]()
         else:
-            raise StructureException("Unsupported statement type: %s" % type(stmt), stmt)
+            raise StructureException(f"Unsupported statement type: {type(stmt)}", stmt)
 
     def expr(self):
         return Stmt(self.stmt.value, self.context).lll_node
@@ -100,7 +100,7 @@ class Stmt(object):
         if self.stmt.id == "vdb":
             return LLLnode('debugger', typ=None, pos=getpos(self.stmt))
         else:
-            raise StructureException("Unsupported statement type: %s" % type(self.stmt), self.stmt)
+            raise StructureException(f"Unsupported statement type: {type(self.stmt)}", self.stmt)
 
     def parse_raise(self):
         if self.stmt.exc is None:
@@ -111,7 +111,7 @@ class Stmt(object):
         if isinstance(self.stmt.annotation, ast.Call):  # unit style: num(wei)
             if self.stmt.annotation.func.id != sub.typ.typ and not sub.typ.is_literal:
                 raise TypeMismatchException(
-                    'Invalid type, expected: %s' % self.stmt.annotation.func.id, self.stmt
+                    f'Invalid type, expected: {self.stmt.annotation.func.id}', self.stmt
                 )
         elif isinstance(self.stmt.annotation, ast.Name) and self.stmt.annotation.id == 'bytes32':
             if isinstance(sub.typ, ByteArrayLike):
@@ -129,14 +129,14 @@ class Stmt(object):
         elif isinstance(self.stmt.annotation, ast.Subscript):
             if not isinstance(sub.typ, (ListType, ByteArrayLike)):  # check list assign.
                 raise TypeMismatchException(
-                    'Invalid type, expected: %s' % self.stmt.annotation.value.id, self.stmt
+                    f'Invalid type, expected: {self.stmt.annotation.value.id}', self.stmt
                 )
         elif isinstance(sub.typ, StructType):
             # This needs to get more sophisticated in the presence of
             # foreign structs.
             if not sub.typ.name == self.stmt.annotation.id:
                 raise TypeMismatchException(
-                    "Invalid type, expected %s" % self.stmt.annotation.id, self.stmt
+                    f"Invalid type, expected {self.stmt.annotation.id}", self.stmt
                 )
         # Check that the integer literal, can be assigned to uint256 if necessary.
         elif (self.stmt.annotation.id, sub.typ.typ) == ('uint256', 'int128') and sub.typ.is_literal:
@@ -146,7 +146,7 @@ class Stmt(object):
                 )
         elif self.stmt.annotation.id != sub.typ.typ and not sub.typ.unit:
             raise TypeMismatchException(
-                'Invalid type %s, expected: %s' % (sub.typ.typ, self.stmt.annotation.id),
+                f'Invalid type {sub.typ.typ}, expected: {self.stmt.annotation.id}',
                 self.stmt,
             )
         else:
@@ -158,8 +158,8 @@ class Stmt(object):
         if lhs_var_name in rhs_names:
             raise VariableDeclarationException((
                 'Invalid variable assignment, same variable not allowed on '
-                'LHS and RHS: %s'
-            ) % lhs_var_name)
+                f'LHS and RHS: {lhs_var_name}'
+            ))
         else:
             return True
 
@@ -197,7 +197,7 @@ class Stmt(object):
             )
             if isinstance(self.stmt.target, ast.Attribute):
                 raise TypeMismatchException(
-                    'May not set type for field %r' % self.stmt.target.attr,
+                    f'May not set type for field {self.stmt.target.attr}',
                     self.stmt,
                 )
             varname = self.stmt.target.id
@@ -247,11 +247,8 @@ class Stmt(object):
         if isinstance(target_typ, BaseType) and isinstance(assign_typ, BaseType):
             if not assign_typ.is_literal and assign_typ.typ != target_typ.typ:
                 raise TypeMismatchException(
-                    'Invalid type {}, expected: {}'.format(
-                        assign_typ.typ,
-                        target_typ.typ,
-                        self.stmt,
-                    )
+                    f'Invalid type {assign_typ.typ}, expected: {target_typ.typ}',
+                    self.stmt
                 )
 
     def assign(self):
@@ -386,29 +383,24 @@ class Stmt(object):
                     return stmt_dispatch_table[self.stmt.func.id](self.stmt, self.context)
             elif self.stmt.func.id in dispatch_table:
                 raise StructureException(
-                    "Function {} can not be called without being used.".format(
-                        self.stmt.func.id
-                    ),
+                    f"Function {self.stmt.func.id} can not be called without being used.",
                     self.stmt,
                 )
             else:
                 raise StructureException(
-                    "Unknown function: '{}'.".format(self.stmt.func.id),
+                    f"Unknown function: '{self.stmt.func.id}'.",
                     self.stmt,
                 )
         elif is_self_function:
             return self_call.make_call(self.stmt, self.context)
         elif is_log_call:
             if self.stmt.func.attr not in self.context.sigs['self']:
-                raise EventDeclarationException("Event not declared yet: %s" % self.stmt.func.attr)
+                raise EventDeclarationException(f"Event not declared yet: {self.stmt.func.attr}")
             event = self.context.sigs['self'][self.stmt.func.attr]
             if len(event.indexed_list) != len(self.stmt.args):
                 raise EventDeclarationException(
-                    "%s received %s arguments but expected %s" % (
-                        event.name,
-                        len(self.stmt.args),
-                        len(event.indexed_list)
-                    )
+                    f"""{event.name} received {len(self.stmt.args)} arguments but
+                    expected {len(event.indexed_list)}"""
                 )
             expected_topics, topics = [], []
             expected_data, data = [], []
@@ -574,10 +566,7 @@ class Stmt(object):
                         (
                             "Two-arg for statements of the form `for i in "
                             "range(x, x + y): ...` must have x identical in both "
-                            "places: %r %r"
-                        ) % (
-                            ast_to_dict(arg0),
-                            ast_to_dict(arg1.left)
+                            f"places: {ast_to_dict(arg0)} {ast_to_dict(arg1.left)}"
                         ),
                         self.stmt.iter,
                     )
@@ -792,18 +781,13 @@ class Stmt(object):
 
             if not isinstance(self.context.return_type, BaseType):
                 raise TypeMismatchException(
-                    "Return type units mismatch %r %r" % (
-                        sub.typ,
-                        self.context.return_type,
-                    ),
+                    f"Return type units mismatch {sub.typ} {self.context.return_type}",
                     self.stmt.value
                 )
             elif self.context.return_type != sub.typ and not sub.typ.is_literal:
                 raise TypeMismatchException(
-                    "Trying to return base type %r, output expecting %r" % (
-                        sub.typ,
-                        self.context.return_type,
-                    ),
+                    f"""Trying to return base type {sub.typ}, output expecting
+                    {self.context.return_type}""",
                     self.stmt.value,
                 )
             elif sub.typ.is_literal and (self.context.return_type.typ == sub.typ or 'int' in self.context.return_type.typ and 'int' in sub.typ.typ):  # noqa: E501
@@ -832,25 +816,21 @@ class Stmt(object):
                 )
             else:
                 raise TypeMismatchException(
-                    "Unsupported type conversion: %r to %r" % (sub.typ, self.context.return_type),
+                    f"Unsupported type conversion: {sub.typ} to {self.context.return_type}",
                     self.stmt.value,
                 )
         # Returning a byte array
         elif isinstance(sub.typ, ByteArrayLike):
             if not sub.typ.eq_base(self.context.return_type):
                 raise TypeMismatchException(
-                    "Trying to return base type %r, output expecting %r" % (
-                        sub.typ,
-                        self.context.return_type,
-                    ),
+                    f"""Trying to return base type {sub.typ}, output expecting
+                    {self.context.return_type}""",
                     self.stmt.value,
                 )
             if sub.typ.maxlen > self.context.return_type.maxlen:
                 raise TypeMismatchException(
-                    "Cannot cast from greater max-length %d to shorter max-length %d" % (
-                        sub.typ.maxlen,
-                        self.context.return_type.maxlen,
-                    ),
+                    f"""Cannot cast from greater max-length {sub.typ.maxlen} to shorter
+                    max-length {self.context.return_type.maxlen}""",
                     self.stmt.value,
                 )
 
@@ -879,7 +859,7 @@ class Stmt(object):
                     )
                 ], typ=None, pos=getpos(self.stmt), valency=0)
             else:
-                raise Exception("Invalid location: %s" % sub.location)
+                raise Exception(f"Invalid location: {sub.location}")
 
         elif isinstance(sub.typ, ListType):
             sub_base_type = re.split(r'\(|\[', str(sub.typ.subtype))[0]
@@ -887,9 +867,8 @@ class Stmt(object):
             loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))
             if sub_base_type != ret_base_type:
                 raise TypeMismatchException(
-                    "List return type %r does not match specified return type, expecting %r" % (
-                        sub_base_type, ret_base_type
-                    ),
+                    f"""List return type {sub_base_type} does not match specified
+                    return type, expecting {ret_base_type}""",
                     self.stmt
                 )
             elif sub.location == "memory" and sub.value != "multi":
@@ -929,10 +908,7 @@ class Stmt(object):
             retty = self.context.return_type
             if not isinstance(retty, StructType) or retty.name != sub.typ.name:
                 raise TypeMismatchException(
-                    "Trying to return %r, output expecting %r" % (
-                        sub.typ,
-                        self.context.return_type,
-                    ),
+                    f"Trying to return {sub.typ}, output expecting {self.context.return_type}",
                     self.stmt.value,
                 )
             return gen_tuple_return(self.stmt, self.context, sub)
@@ -941,10 +917,8 @@ class Stmt(object):
         elif isinstance(sub.typ, TupleType):
             if not isinstance(self.context.return_type, TupleType):
                 raise TypeMismatchException(
-                    "Trying to return tuple type %r, output expecting %r" % (
-                        sub.typ,
-                        self.context.return_type,
-                    ),
+                    f"""Trying to return tuple type {sub.typ}, output expecting
+                    {self.context.return_type}""",
                     self.stmt.value,
                 )
 
@@ -957,15 +931,14 @@ class Stmt(object):
                 sub_type = s_member if isinstance(s_member, NodeType) else s_member.typ
                 if type(sub_type) is not type(ret_x):
                     raise StructureException(
-                        "Tuple return type does not match annotated return. {} != {}".format(
-                            type(sub_type), type(ret_x)
-                        ),
+                        f"""Tuple return type does not match annotated return.
+                        {type(sub_type)} != {type(ret_x)}""",
                         self.stmt
                     )
             return gen_tuple_return(self.stmt, self.context, sub)
 
         else:
-            raise TypeMismatchException("Can't return type %r" % sub.typ, self.stmt)
+            raise TypeMismatchException(f"Can't return type {sub.typ}", self.stmt)
 
     def parse_delete(self):
         raise StructureException(
@@ -978,7 +951,7 @@ class Stmt(object):
         if isinstance(target, ast.Subscript) and self.context.in_for_loop:
             raise_exception = False
             if isinstance(target.value, ast.Attribute):
-                list_name = "%s.%s" % (target.value.value.id, target.value.attr)
+                list_name = f"{target.value.value.id}.{target.value.attr}"
                 if list_name in self.context.in_for_loop:
                     raise_exception = True
 
@@ -989,13 +962,13 @@ class Stmt(object):
 
             if raise_exception:
                 raise StructureException(
-                    "Altering list '%s' which is being iterated!" % list_name,
+                    f"Altering list '{list_name}' which is being iterated!",
                     self.stmt,
                 )
 
         if isinstance(target, ast.Name) and target.id in self.context.forvars:
             raise StructureException(
-                "Altering iterator '%s' which is in use!" % target.id,
+                f"Altering iterator '{target.id}' which is in use!",
                 self.stmt,
             )
         if isinstance(target, ast.Tuple):
@@ -1003,15 +976,12 @@ class Stmt(object):
         target = Expr.parse_variable_location(target, self.context)
         if target.location == 'storage' and self.context.is_constant():
             raise ConstancyViolationException(
-                "Cannot modify storage inside %s: %s" % (
-                    self.context.pp_constancy(),
-                    target.annotation,
-                ),
+                f"Cannot modify storage inside {self.context.pp_constancy()}: {target.annotation}",
                 self.stmt,
             )
         if not target.mutable:
             raise ConstancyViolationException(
-                "Cannot modify function argument: %s" % target.annotation,
+                f"Cannot modify function argument: {target.annotation}",
                 self.stmt,
             )
         return target

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -399,8 +399,8 @@ class Stmt(object):
             event = self.context.sigs['self'][self.stmt.func.attr]
             if len(event.indexed_list) != len(self.stmt.args):
                 raise EventDeclarationException(
-                    f"""{event.name} received {len(self.stmt.args)} arguments but
-                    expected {len(event.indexed_list)}"""
+                    f"{event.name} received {len(self.stmt.args)} arguments but "
+                    f"expected {len(event.indexed_list)}"
                 )
             expected_topics, topics = [], []
             expected_data, data = [], []
@@ -786,8 +786,8 @@ class Stmt(object):
                 )
             elif self.context.return_type != sub.typ and not sub.typ.is_literal:
                 raise TypeMismatchException(
-                    f"""Trying to return base type {sub.typ}, output expecting
-                    {self.context.return_type}""",
+                    f"Trying to return base type {sub.typ}, output expecting "
+                    f"{self.context.return_type}",
                     self.stmt.value,
                 )
             elif sub.typ.is_literal and (self.context.return_type.typ == sub.typ or 'int' in self.context.return_type.typ and 'int' in sub.typ.typ):  # noqa: E501
@@ -823,14 +823,14 @@ class Stmt(object):
         elif isinstance(sub.typ, ByteArrayLike):
             if not sub.typ.eq_base(self.context.return_type):
                 raise TypeMismatchException(
-                    f"""Trying to return base type {sub.typ}, output expecting
-                    {self.context.return_type}""",
+                    f"Trying to return base type {sub.typ}, output expecting "
+                    f"{self.context.return_type}",
                     self.stmt.value,
                 )
             if sub.typ.maxlen > self.context.return_type.maxlen:
                 raise TypeMismatchException(
-                    f"""Cannot cast from greater max-length {sub.typ.maxlen} to shorter
-                    max-length {self.context.return_type.maxlen}""",
+                    f"Cannot cast from greater max-length {sub.typ.maxlen} to shorter "
+                    f"max-length {self.context.return_type.maxlen}",
                     self.stmt.value,
                 )
 
@@ -867,8 +867,8 @@ class Stmt(object):
             loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))
             if sub_base_type != ret_base_type:
                 raise TypeMismatchException(
-                    f"""List return type {sub_base_type} does not match specified
-                    return type, expecting {ret_base_type}""",
+                    f"List return type {sub_base_type} does not match specified "
+                    f"return type, expecting {ret_base_type}",
                     self.stmt
                 )
             elif sub.location == "memory" and sub.value != "multi":
@@ -917,8 +917,8 @@ class Stmt(object):
         elif isinstance(sub.typ, TupleType):
             if not isinstance(self.context.return_type, TupleType):
                 raise TypeMismatchException(
-                    f"""Trying to return tuple type {sub.typ}, output expecting
-                    {self.context.return_type}""",
+                    f"Trying to return tuple type {sub.typ}, output expecting "
+                    f"{self.context.return_type}",
                     self.stmt.value,
                 )
 
@@ -931,8 +931,8 @@ class Stmt(object):
                 sub_type = s_member if isinstance(s_member, NodeType) else s_member.typ
                 if type(sub_type) is not type(ret_x):
                     raise StructureException(
-                        f"""Tuple return type does not match annotated return.
-                        {type(sub_type)} != {type(ret_x)}""",
+                        "Tuple return type does not match annotated return. "
+                        f"{type(sub_type)} != {type(ret_x)}",
                         self.stmt
                     )
             return gen_tuple_return(self.stmt, self.context, sub)

--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -77,7 +77,7 @@ class EventSignature:
                     raise EventDeclarationException("Indexed arguments are limited to 32 bytes")
                 if topics_count > 4:
                     raise EventDeclarationException(
-                        "Maximum of 3 topics {} given".format(topics_count - 1),
+                        f"Maximum of 3 topics {topics_count - 1} given",
                         arg,
                     )
                 if not isinstance(arg, str):

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -254,15 +254,15 @@ class FunctionSignature:
 
         if public and private:
             raise StructureException(
-                "Cannot use public and private decorators on the same function: {}".format(name)
+                f"Cannot use public and private decorators on the same function: {name}"
             )
         if payable and const:
             raise StructureException(
-                "Function {} cannot be both constant and payable.".format(name)
+                f"Function {name} cannot be both constant and payable."
             )
         if payable and private:
             raise StructureException(
-                "Function {} cannot be both private and payable.".format(name)
+                f"Function {name} cannot be both private and payable."
             )
         if (not public and not private) and not contract_def:
             raise StructureException(
@@ -291,7 +291,7 @@ class FunctionSignature:
             )
         else:
             raise InvalidTypeException(
-                "Output type invalid or unsupported: %r" % parse_type(code.returns, None),
+                f"Output type invalid or unsupported: {parse_type(code.returns, None)}",
                 code.returns,
             )
         # Output type must be canonicalizable
@@ -429,7 +429,7 @@ class FunctionSignature:
         if method_name not in method_names_dict:
             raise FunctionDeclarationException(
                 "Function not declared yet (reminder: functions cannot "
-                "call functions later in code than themselves): %s" % method_name
+                f"call functions later in code than themselves): {method_name}"
             )
 
         if method_names_dict[method_name] == 1:
@@ -454,7 +454,7 @@ class FunctionSignature:
             if len(ssig) == 0:
                 raise FunctionDeclarationException(
                     "Function not declared yet (reminder: functions cannot "
-                    "call functions later in code than themselves): %s" % method_name
+                    f"call functions later in code than themselves): {method_name}"
                 )
             return ssig[0]
 

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -167,7 +167,10 @@ def extract_interface_str(code, contract_name, interface_codes=None):
             out += "\n# Functions\n"
         if not func.private and func.name != '__init__':
             args = ", ".join([arg.name + ": " + str(arg.typ) for arg in func.args])
-            out += f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n    pass\n"  # noqa: E501
+            out += (
+                    f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n"
+                    "    pass\n"
+                    )
     out += "\n"
 
     return out

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -151,8 +151,8 @@ def extract_interface_str(code, contract_name, interface_codes=None):
     for idx, event in enumerate(events):
         if idx == 0:
             out += "# Events\n\n"
-event_args_str = ', '.join([arg.name + ': ' + str(arg.typ) for arg in event.args])
-out += f"{event.name}: event({{{event_args_str}}})\n"
+        event_args_str = ', '.join([arg.name + ': ' + str(arg.typ) for arg in event.args])
+        out += f"{event.name}: event({{{event_args_str}}})\n"
 
     # Print functions.
     def render_decorator(sig):

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -151,7 +151,8 @@ def extract_interface_str(code, contract_name, interface_codes=None):
     for idx, event in enumerate(events):
         if idx == 0:
             out += "# Events\n\n"
-        out += f"{event.name}: event({{{', '.join([arg.name + ': ' + str(arg.typ) for arg in event.args])}}})\n"  # noqa: E501
+event_args_str = ', '.join([arg.name + ': ' + str(arg.typ) for arg in event.args])
+out += f"{event.name}: event({{{event_args_str}}})\n"
 
     # Print functions.
     def render_decorator(sig):

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -167,9 +167,11 @@ def extract_interface_str(code, contract_name, interface_codes=None):
             out += "\n# Functions\n"
         if not func.private and func.name != '__init__':
             args = ", ".join([arg.name + ": " + str(arg.typ) for arg in func.args])
-            out += (
-                    f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n"
-                    "    pass\n"
+            out += f"""
+{render_decorator(func)}
+def {func.name}({args}){render_return(func)}:
+    pass
+"""
                     )
     out += "\n"
 

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -169,11 +169,10 @@ def extract_interface_str(code, contract_name, interface_codes=None):
         if not func.private and func.name != '__init__':
             args = ", ".join([arg.name + ": " + str(arg.typ) for arg in func.args])
             out += f"""
-{render_decorator(func)}
-def {func.name}({args}){render_return(func)}:
-    pass
-"""
-                    )
+                {render_decorator(func)}
+                def {func.name}({args}){render_return(func)}:
+                    pass
+                """
     out += "\n"
 
     return out

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -168,7 +168,7 @@ def extract_interface_str(code, contract_name, interface_codes=None):
             out += "\n# Functions\n"
         if not func.private and func.name != '__init__':
             args = ", ".join([arg.name + ": " + str(arg.typ) for arg in func.args])
-            out += f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n    pass\n"
+            out += f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n    pass\n"  # noqa: E501
     out += "\n"
 
     return out

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -168,11 +168,7 @@ def extract_interface_str(code, contract_name, interface_codes=None):
             out += "\n# Functions\n"
         if not func.private and func.name != '__init__':
             args = ", ".join([arg.name + ": " + str(arg.typ) for arg in func.args])
-            out += f"""
-                {render_decorator(func)}
-                def {func.name}({args}){render_return(func)}:
-                    pass
-                """
+            out += f"{render_decorator(func)}def {func.name}({args}){render_return(func)}:\n    pass\n"
     out += "\n"
 
     return out

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -344,7 +344,7 @@ def to_bytes32(expr, args, kwargs, context):
     if input_type == 'bytes':
         if _len > 32:
             raise TypeMismatchException(
-                f"Unable to convert bytes[{len}] to bytes32, max length is too "
+                f"Unable to convert bytes[{_len}] to bytes32, max length is too "
                 "large."
             )
 

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -343,10 +343,10 @@ def to_bytes32(expr, args, kwargs, context):
 
     if input_type == 'bytes':
         if _len > 32:
-            raise TypeMismatchException((
+            raise TypeMismatchException(
                 f"Unable to convert bytes[{len}] to bytes32, max length is too "
                 "large."
-            ))
+            )
 
         if in_arg.location == "memory":
             return LLLnode.from_list(

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -36,9 +36,7 @@ def to_bool(expr, args, kwargs, context):
     if input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                "Cannot convert bytes array of max length {} to bool".format(
-                    in_arg.value,
-                ),
+                f"Cannot convert bytes array of max length {in_arg.value} to bool",
                 expr,
             )
         else:
@@ -67,7 +65,7 @@ def to_int128(expr, args, kwargs, context):
     if input_type == 'num_literal':
         if isinstance(in_arg, int):
             if not SizeLimits.in_bounds('int128', in_arg):
-                raise InvalidLiteralException("Number out of range: {}".format(in_arg))
+                raise InvalidLiteralException(f"Number out of range: {in_arg}")
             return LLLnode.from_list(
                 in_arg,
                 typ=BaseType('int128', _unit),
@@ -75,19 +73,19 @@ def to_int128(expr, args, kwargs, context):
             )
         elif isinstance(in_arg, float):
             if not SizeLimits.in_bounds('int128', math.trunc(in_arg)):
-                raise InvalidLiteralException("Number out of range: {}".format(math.trunc(in_arg)))
+                raise InvalidLiteralException(f"Number out of range: {math.trunc(in_arg)}")
             return LLLnode.from_list(
                 math.trunc(in_arg),
                 typ=BaseType('int128', _unit),
                 pos=getpos(expr)
             )
         else:
-            raise InvalidLiteralException("Unknown numeric literal type: {}".fornat(in_arg))
+            raise InvalidLiteralException(f"Unknown numeric literal type: {in_arg}")
 
     elif input_type == 'bytes32':
         if in_arg.typ.is_literal:
             if not SizeLimits.in_bounds('int128', in_arg.value):
-                raise InvalidLiteralException("Number out of range: {}".format(in_arg.value), expr)
+                raise InvalidLiteralException(f"Number out of range: {in_arg.value}", expr)
             else:
                 return LLLnode.from_list(
                     in_arg,
@@ -124,7 +122,7 @@ def to_int128(expr, args, kwargs, context):
     elif input_type in ('string', 'bytes'):
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                "Cannot convert bytes array of max length {} to int128".format(in_arg.value),
+                f"Cannot convert bytes array of max length {in_arg.value} to int128",
                 expr,
             )
         return byte_array_to_num(in_arg, expr, 'int128')
@@ -132,7 +130,7 @@ def to_int128(expr, args, kwargs, context):
     elif input_type == 'uint256':
         if in_arg.typ.is_literal:
             if not SizeLimits.in_bounds('int128', in_arg.value):
-                raise InvalidLiteralException("Number out of range: {}".format(in_arg.value), expr)
+                raise InvalidLiteralException(f"Number out of range: {in_arg.value}", expr)
             else:
                 return LLLnode.from_list(
                     in_arg,
@@ -167,7 +165,7 @@ def to_int128(expr, args, kwargs, context):
         )
 
     else:
-        raise InvalidLiteralException("Invalid input for int128: %r" % in_arg, expr)
+        raise InvalidLiteralException(f"Invalid input for int128: {in_arg}", expr)
 
 
 @signature(('num_literal', 'int128', 'bytes32', 'bytes', 'address', 'bool', 'decimal'), '*')
@@ -179,7 +177,7 @@ def to_uint256(expr, args, kwargs, context):
     if input_type == 'num_literal':
         if isinstance(in_arg, int):
             if not SizeLimits.in_bounds('uint256', in_arg):
-                raise InvalidLiteralException("Number out of range: {}".format(in_arg))
+                raise InvalidLiteralException(f"Number out of range: {in_arg}")
             return LLLnode.from_list(
                 in_arg,
                 typ=BaseType('uint256', _unit),
@@ -187,7 +185,7 @@ def to_uint256(expr, args, kwargs, context):
             )
         elif isinstance(in_arg, float):
             if not SizeLimits.in_bounds('uint256', math.trunc(in_arg)):
-                raise InvalidLiteralException("Number out of range: {}".format(math.trunc(in_arg)))
+                raise InvalidLiteralException(f"Number out of range: {math.trunc(in_arg)}")
             return LLLnode.from_list(
                 math.trunc(in_arg),
                 typ=BaseType('uint256', _unit),
@@ -228,13 +226,13 @@ def to_uint256(expr, args, kwargs, context):
     elif isinstance(in_arg, LLLnode) and input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise InvalidLiteralException(
-                "Cannot convert bytes array of max length {} to uint256".format(in_arg.value),
+                f"Cannot convert bytes array of max length {in_arg.value} to uint256",
                 expr,
             )
         return byte_array_to_num(in_arg, expr, 'uint256')
 
     else:
-        raise InvalidLiteralException("Invalid input for uint256: %r" % in_arg, expr)
+        raise InvalidLiteralException(f"Invalid input for uint256: {in_arg}", expr)
 
 
 @signature(('bool', 'int128', 'uint256', 'bytes32', 'bytes', 'address'), '*')
@@ -245,7 +243,7 @@ def to_decimal(expr, args, kwargs, context):
     if input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                "Cannot convert bytes array of max length {} to decimal".format(in_arg.value),
+                f"Cannot convert bytes array of max length {in_arg.value} to decimal",
                 expr,
             )
         num = byte_array_to_num(in_arg, expr, 'int128')
@@ -263,7 +261,7 @@ def to_decimal(expr, args, kwargs, context):
             if in_arg.typ.is_literal:
                 if not SizeLimits.in_bounds('int128', (in_arg.value * DECIMAL_DIVISOR)):
                     raise InvalidLiteralException(
-                        "Number out of range: {}".format(in_arg.value),
+                        f"Number out of range: {in_arg.value}",
                         expr,
                     )
                 else:
@@ -306,7 +304,7 @@ def to_decimal(expr, args, kwargs, context):
             if in_arg.typ.is_literal:
                 if not SizeLimits.in_bounds('int128', (in_arg.value * DECIMAL_DIVISOR)):
                     raise InvalidLiteralException(
-                        "Number out of range: {}".format(in_arg.value),
+                        f"Number out of range: {in_arg.value}",
                         expr,
                     )
                 else:
@@ -335,7 +333,7 @@ def to_decimal(expr, args, kwargs, context):
             )
 
         else:
-            raise InvalidLiteralException("Invalid input for decimal: %r" % in_arg, expr)
+            raise InvalidLiteralException(f"Invalid input for decimal: {in_arg}", expr)
 
 
 @signature(('int128', 'uint256', 'address', 'bytes', 'bool', 'decimal'), '*')
@@ -346,9 +344,9 @@ def to_bytes32(expr, args, kwargs, context):
     if input_type == 'bytes':
         if _len > 32:
             raise TypeMismatchException((
-                "Unable to convert bytes[{}] to bytes32, max length is too "
+                f"Unable to convert bytes[{len}] to bytes32, max length is too "
                 "large."
-            ).format(len))
+            ))
 
         if in_arg.location == "memory":
             return LLLnode.from_list(
@@ -436,7 +434,7 @@ def convert(expr, context):
     if output_type in conversion_table:
         return conversion_table[output_type](expr, context)
     else:
-        raise ParserException("Conversion to {} is invalid.".format(output_type), expr)
+        raise ParserException(f"Conversion to {output_type} is invalid.", expr)
 
 
 conversion_table = {

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -149,13 +149,13 @@ class ByteArrayLike(NodeType):
 
 class StringType(ByteArrayLike):
     def __repr__(self):
-        return 'string[%d]' % self.maxlen
+        return f'string[{self.maxlen}]'
 
 
 # Data structure for a byte array
 class ByteArrayType(ByteArrayLike):
     def __repr__(self):
-        return 'bytes[%d]' % self.maxlen
+        return f'bytes[{self.maxlen}]'
 
 
 # Data structure for a list with some fixed length
@@ -246,22 +246,20 @@ def canonicalize_type(t, is_indexed=False):
         # Check to see if maxlen is small enough for events
         byte_type = 'string' if isinstance(t, StringType) else 'bytes'
         if is_indexed:
-            return '{}{}'.format(byte_type, t.maxlen)
+            return f'{byte_type}{t.maxlen}'
         else:
-            return '{}'.format(byte_type)
+            return f'{byte_type}'
 
     if isinstance(t, ListType):
         if not isinstance(t.subtype, (ListType, BaseType)):
             raise Exception("List of byte arrays not allowed")
-        return canonicalize_type(t.subtype) + "[%d]" % t.count
+        return canonicalize_type(t.subtype) + f"[{t.count}]"
 
     if isinstance(t, TupleLike):
-        return "({})".format(
-            ",".join(canonicalize_type(x) for x in t.tuple_members())
-        )
+        return f"({','.join(canonicalize_type(x) for x in t.tuple_members())})"
 
     if not isinstance(t, BaseType):
-        raise Exception("Cannot canonicalize non-base type: %r" % t)
+        raise Exception(f"Cannot canonicalize non-base type: {t}")
 
     t = t.typ
     if t in ('int128', 'uint256', 'bool', 'address', 'bytes32'):
@@ -312,7 +310,7 @@ def make_struct_type(name, location, members, custom_units, custom_structs, cons
     for key, value in members:
         if not isinstance(key, ast.Name):
             raise InvalidTypeException(
-                "Invalid member variable for struct %r, expected a name." % key.id,
+                f"Invalid member variable for struct {key.id}, expected a name.",
                 key,
             )
         check_valid_varname(
@@ -497,7 +495,7 @@ def get_size_of_type(typ):
     elif isinstance(typ, TupleLike):
         return sum([get_size_of_type(v) for v in typ.tuple_members()])
     else:
-        raise Exception("Can not get size of type, Unexpected type: %r" % repr(typ))
+        raise Exception(f"Can not get size of type, Unexpected type: {repr(typ)}")
 
 
 # amount of space a type takes in the static section of its ABI encoding
@@ -513,7 +511,7 @@ def get_static_size_of_type(typ):
     elif isinstance(typ, TupleLike):
         return sum([get_size_of_type(v) for v in typ.tuple_members()])
     else:
-        raise Exception("Can not get size of type, Unexpected type: %r" % repr(typ))
+        raise Exception(f"Can not get size of type, Unexpected type: {repr(typ)}")
 
 
 # could be rewritten as get_static_size_of_type == get_size_of_type?
@@ -527,7 +525,7 @@ def has_dynamic_data(typ):
     elif isinstance(typ, TupleLike):
         return any([has_dynamic_data(v) for v in typ.tuple_members()])
     else:
-        raise Exception("Unexpected type: %r" % repr(typ))
+        raise Exception(f"Unexpected type: {repr(typ)}")
 
 
 def get_type(input):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -35,7 +35,7 @@ def string_to_bytes(str):
     bytez = b''
     for c in str:
         if ord(c) >= 256:
-            raise InvalidLiteralException("Cannot insert special character %r into byte array" % c)
+            raise InvalidLiteralException(f"Cannot insert special character {c} into byte array")
         bytez += bytes([ord(c)])
     bytez_length = len(bytez)
     return bytez, bytez_length
@@ -120,7 +120,7 @@ class SizeLimits:
         elif type_str == 'int128':
             return cls.MINNUM <= value <= cls.MAXNUM
         else:
-            raise Exception('Unknown type "%s" supplied.' % type_str)
+            raise Exception(f'Unknown type "{type_str}" supplied.')
 
 
 # Map representing all limits loaded into a contract as part of the initializer
@@ -221,25 +221,25 @@ def is_varname_valid(varname, custom_units, custom_structs, constants):
     if custom_units is None:
         custom_units = set()
     if varname_lower in {cu.lower() for cu in custom_units}:
-        return False, "%s is a unit name." % varname
+        return False, f"{varname} is a unit name."
 
     # struct names are case sensitive.
     if varname in custom_structs:
-        return False, "Duplicate name: %s, previously defined as a struct." % varname
+        return False, f"Duplicate name: {varname}, previously defined as a struct."
     if varname in constants:
-        return False, "Duplicate name: %s, previously defined as a constant." % varname
+        return False, f"Duplicate name: {varname}, previously defined as a constant."
     if varname_lower in base_types:
-        return False, "%s name is a base type." % varname
+        return False, f"{varname} name is a base type."
     if varname_lower in valid_units:
-        return False, "%s is a built in unit type." % varname
+        return False, f"{varname} is a built in unit type."
     if varname_lower in reserved_words:
-        return False, "%s is a a reserved keyword." % varname
+        return False, f"{varname} is a a reserved keyword."
     if varname_upper in opcodes:
-        return False, "%s is a reserved keyword (EVM opcode)." % varname
+        return False, f"{varname} is a reserved keyword (EVM opcode)."
     if varname_lower in built_in_functions:
-        return False, "%s is a built in function." % varname
+        return False, f"{varname} is a built in function."
     if not re.match('^[_a-zA-Z][a-zA-Z0-9_]*$', varname):
-        return False, "%s contains invalid character(s)." % varname
+        return False, f"{varname} contains invalid character(s)."
 
     return True, ""
 


### PR DESCRIPTION
### What I did

Updated most instances of string formatting to use f-strings: Fixes #1567 

### How I did it

Took out all instances of `%`-type formatting. `.format()` was left in cases where using f-strings would've only complicated things further (byte strings, generated strings)

### How to verify it

`git grep -n '%[a-z]' -- './*.py'` verifies there are no instances of formatting using `%` (this regex searches for any % that has a lowercase letter after it).
`git grep -n '.format(' -- './*.py'` will turn up plenty of instances where `.format()` is used, but they adhere to the above conditions.

Lastly, the tests pass, meaning that all the strings in the repo are behaving like they should.

### Description for the changelog

Upgraded to mostly f-strings

### Cute Animal Picture

![](https://pixfeeds.com/images/12/369302/1200-465108856-porcupine-puffer-fish.jpg)
