### PR TITLE
Fix incorrect compile_to_assembly call args

### DIFF
--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -163,3 +163,37 @@ def test():
     c2 = get_contract(code, *[c1.address])
     # static call prohibits state change
     assert_tx_failed(lambda: c2.test())
+
+
+def test_assert_in_for_loop(get_contract, assert_tx_failed):
+    code = """
+@public
+def test(x: uint256[3]) -> bool:
+    for i in range(3):
+        assert x[i] < 5
+    return True
+    """
+
+    c = get_contract(code)
+
+    c.test([1, 2, 3])
+    assert_tx_failed(lambda: c.test([5, 1, 3]))
+    assert_tx_failed(lambda: c.test([1, 5, 3]))
+    assert_tx_failed(lambda: c.test([1, 3, 5]))
+
+
+def test_assert_with_reason_in_for_loop(get_contract, assert_tx_failed):
+    code = """
+@public
+def test(x: uint256[3]) -> bool:
+    for i in range(3):
+        assert x[i] < 5, "because reasons"
+    return True
+    """
+
+    c = get_contract(code)
+
+    c.test([1, 2, 3])
+    assert_tx_failed(lambda: c.test([5, 1, 3]))
+    assert_tx_failed(lambda: c.test([1, 5, 3]))
+    assert_tx_failed(lambda: c.test([1, 3, 5]))

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -1,5 +1,8 @@
 import functools
 
+from vyper.exceptions import (
+    CompilerPanic,
+)
 from vyper.parser.parser import (
     LLLnode,
 )
@@ -88,11 +91,13 @@ def apply_line_numbers(func):
 def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=None, height=0):
     if withargs is None:
         withargs = {}
-    assert isinstance(withargs, dict)
+    if not isinstance(withargs, dict):
+        raise CompilerPanic(f"Incorrect type for withargs: {type(withargs)}")
 
     if existing_labels is None:
         existing_labels = set()
-    assert isinstance(existing_labels, set)
+    if not isinstance(existing_labels, set):
+        raise CompilerPanic(f"Incorrect type for existing_labels: {type(existing_labels)}")
 
     # Opcodes
     if isinstance(code.value, str) and code.value.upper() in opcodes:

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -136,7 +136,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
                 ['codecopy', MemoryPositions.FREE_VAR_SPACE, code.args[0], 32],
                 ['mload', MemoryPositions.FREE_VAR_SPACE]
             ]
-        ), withargs, break_dest, height)
+        ), withargs, existing_labels, break_dest, height)
     # If statements (2 arguments, ie. if x: y)
     elif code.value in ('if', 'if_unchecked') and len(code.args) == 2:
         o = []
@@ -270,9 +270,9 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
         o.extend(get_revert())
         return o
     elif code.value == 'assert_reason':
-        o = compile_to_assembly(code.args[0], withargs, break_dest, height)
-        mem_start = compile_to_assembly(code.args[1], withargs, break_dest, height)
-        mem_len = compile_to_assembly(code.args[2], withargs, break_dest, height)
+        o = compile_to_assembly(code.args[0], withargs, existing_labels, break_dest, height)
+        mem_start = compile_to_assembly(code.args[1], withargs, existing_labels, break_dest, height)
+        mem_len = compile_to_assembly(code.args[2], withargs, existing_labels, break_dest, height)
         o.extend(get_revert(mem_start, mem_len))
         return o
     # Unsigned/signed clamp, check less-than


### PR DESCRIPTION
### The Issue
As discovered by @michwill and reported on Gitter, the following code was not compiling due to an assertion error:
```python
@public    
def g():
    ok: bool = False
    for i in range(5):
        assert ok, "Reasons"
```
The issue was in `vyper/compile_lll.py` - several calls to `compile_to_assembly` were not including the `existing_labels` argument:

https://github.com/ethereum/vyper/blob/089d0c4046a5e71412b46205788a89e76d7646ea/vyper/compile_lll.py#L273-L275

### What I did
Added `existing_labels` as an argument in `compile_to_assembly` calls where it was missing.

### How to verify it
See the new test cases in `tests/parser/features/test_assert.py`.  I also added checks for proper behavior of the iterated assertions.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/65383871-c7740300-dd4d-11e9-9196-9adc95bb3342.png)
