### PR TITLE
Improved decimal precision error messages

### DIFF
--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -606,7 +606,12 @@ def as_wei_value(expr, args, kwargs, context):
             expr_args_0 = context.constants._constants_ast[expr.args[0].id]
         numstring, num, den = get_number_as_fraction(expr_args_0, context)
         if denomination % den:
-            raise InvalidLiteralException(f"Too many decimal places: {numstring}", expr.args[0])
+            max_len = len(str(denomination))-1
+            raise InvalidLiteralException(
+                f"Wei value of denomination '{args[1].decode()}' "
+                f"has maximum {max_len} decimal places",
+                expr.args[0]
+            )
         sub = num * denomination // den
     elif args[0].typ.is_literal:
         if args[0].value <= 0:

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -129,7 +129,10 @@ class Expr(object):
             if not (SizeLimits.MINNUM * den < num < SizeLimits.MAXNUM * den):
                 raise InvalidLiteralException("Number out of range: " + numstring, self.expr)
             if DECIMAL_DIVISOR % den:
-                raise InvalidLiteralException("Too many decimal places: " + numstring, self.expr)
+                raise InvalidLiteralException(
+                    "Type 'decimal' has maximum 10 decimal places",
+                    self.expr
+                )
             return LLLnode.from_list(
                 num * DECIMAL_DIVISOR // den,
                 typ=BaseType('decimal', unit=None, is_literal=True),


### PR DESCRIPTION
### What I did
* Modified the error messages raised on incorrect decimal precision to include the maximum allowable number of decimals
* Renamed some variables in `as_wei_value` to make the code more readable

### How to verify it
Check the diff, run the tests

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/65684913-573de800-e093-11e9-9e8b-3a07456f0694.png)
