### PR TITLE
Add link to Gitcoin Grant for Github Sponsors Button

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://gitcoin.co/grants/128/vyper-smart-contract-language-dev-fund


### PR DESCRIPTION
### What I did
Added a link for using [GitHub Sponsors](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository). Needs to be enabled in settings though.

### Cute Animal Picture
![gimme the money or your bacon is mine](https://i.pinimg.com/originals/fd/87/7c/fd877c65685c274f57ed3e5ee90be535.gif)
