### PR TITLE
Remove Abstract as redundent from VIP template

### DIFF
--- a/.github/ISSUE_TEMPLATE/vip.md
+++ b/.github/ISSUE_TEMPLATE/vip.md
@@ -5,9 +5,6 @@ about: This is the suggested template for new VIPs.
 ## Simple Summary
 "If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the VIP.
 
-## Abstract
-A short description of the technical issue being addressed.
-
 ## Motivation
 The motivation is critical for VIPs that add or change Vyper's functionality. It should clearly explain why the existing Vyper functionality is inadequate to address the problem that the VIP solves as well as how the VIP is in line with Vyper's goals and design philosophy.
 


### PR DESCRIPTION
### What I did
Everytime I enter a new VIP I think why "Simple Summary" and "Abstract" should both be in the template. I can't think of a good reason! So maybe let's remove it?

### Cute Animal Picture
![giraffes](https://i.dailymail.co.uk/1s/2019/04/05/13/11901926-6890597-image-a-90_1554466860012.jpg)
