### PR TITLE
Force parse_body to be zerovalent

### DIFF
--- a/tests/parser/features/iteration/test_repeater.py
+++ b/tests/parser/features/iteration/test_repeater.py
@@ -84,3 +84,20 @@ def sum(frm: int128, to: int128) -> int128:
     assert c.sum(70, 131) == 6100
 
     print('Passed more complex repeater with offset test')
+
+
+def test_loop_call_priv(get_contract_with_gas_estimation):
+    code = """
+@private
+def _bar() -> bool:
+    return True
+
+@public
+def foo() -> bool:
+    for i in range(3):
+        self._bar()
+    return True
+    """
+
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() is True

--- a/tests/parser/features/test_conditionals.py
+++ b/tests/parser/features/test_conditionals.py
@@ -15,3 +15,29 @@ def foo(i: bool) -> int128:
     assert c.foo(False) == 7
 
     print('Passed conditional return tests')
+
+
+def test_single_branch_underflow_public(get_contract_with_gas_estimation):
+    code = """
+@public
+def doit():
+    if False:
+        raw_call(msg.sender, b"", outsize=0, value=0, gas=msg.gas)
+    """
+    c = get_contract_with_gas_estimation(code)
+    c.doit()
+
+
+def test_single_branch_underflow_private(get_contract_with_gas_estimation):
+    code = """
+@private
+def priv() -> uint256:
+    return 1
+
+@public
+def dont_doit():
+    if False:
+        self.priv()
+    """
+    c = get_contract_with_gas_estimation(code)
+    c.dont_doit()

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -244,7 +244,7 @@ def optimize(node: LLLnode) -> LLLnode:
         for arg in argz:
             if arg.value == "seq":
                 o.extend(arg.args)
-            elif arg.value != "pass":
+            else:
                 o.append(arg)
         return LLLnode(
             node.value,

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -334,7 +334,7 @@ class Stmt(object):
         if self.stmt.orelse:
             block_scope_id = id(self.stmt.orelse)
             with self.context.make_blockscope(block_scope_id):
-                add_on = [['seq', parse_body(self.stmt.orelse, self.context)]]
+                add_on = [parse_body(self.stmt.orelse, self.context)]
         else:
             add_on = []
 
@@ -345,7 +345,7 @@ class Stmt(object):
             if not self.is_bool_expr(test_expr):
                 raise TypeMismatchException('Only boolean expressions allowed', self.stmt.test)
             body = ['if', test_expr,
-                    ['seq', parse_body(self.stmt.body, self.context)]] + add_on
+                    parse_body(self.stmt.body, self.context)] + add_on
             o = LLLnode.from_list(
                 body,
                 typ=None, pos=getpos(self.stmt)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -1012,8 +1012,10 @@ def parse_stmt(stmt, context):
 def parse_body(code, context):
     if not isinstance(code, list):
         return parse_stmt(code, context)
-    o = []
+
+    o = ['seq']
     for stmt in code:
         lll = parse_stmt(stmt, context)
         o.append(lll)
-    return LLLnode.from_list(['seq'] + o, pos=getpos(code[0]) if code else None)
+    o.append('pass')  # force zerovalent, even last statement
+    return LLLnode.from_list(o, pos=getpos(code[0]) if code else None)


### PR DESCRIPTION
### What I did
Fix #1511 and #1620 

### How I did it
Seq will issue a pop after every univalent statement but the last one.
However, if and for statements should have zerovalent bodies. This PR
forces even the last statement to get a pop if it is univalent.

### How to verify it
See new tests

### Description for the changelog
Fix stack valency issues in if and for statements.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://2.bp.blogspot.com/-Y1LypviOwgI/UA2BDmumqkI/AAAAAAAABI8/_wsHkIV5hYM/s1600/Happy+Puppy+10.jpg)
