### PR TITLE
Fix off-by-one in list type checking

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -1,5 +1,6 @@
 from vyper.exceptions import (
     ArrayIndexException,
+    TypeMismatchException,
 )
 
 
@@ -233,7 +234,7 @@ def bounds_check_int128(ix: int128) -> uint256:
     assert_tx_failed(lambda: c.bounds_check_int128(-1))
 
 
-def test_compile_time_bounds_check(get_contract_with_gas_estimation, assert_compile_failed):
+def test_list_check_heterogeneous_types(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @public
 def fail() -> uint256:
@@ -253,4 +254,17 @@ def fail() -> uint256:
     assert_compile_failed(
             lambda: get_contract_with_gas_estimation(code),
             ArrayIndexException
+            )
+
+
+def test_compile_time_bounds_check(get_contract_with_gas_estimation, assert_compile_failed):
+    code = """
+@public
+def parse_list_fail():
+    xs: uint256[3] = [2**255, 1, 3]
+    pass
+    """
+    assert_compile_failed(
+            lambda: get_contract_with_gas_estimation(code),
+            TypeMismatchException
             )

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -1078,7 +1078,7 @@ class Expr(object):
                 out_type = current_lll_node.typ
 
             current_type = get_out_type(current_lll_node)
-            if len(o) > 1 and previous_type != current_type:
+            if len(o) > 0 and previous_type != current_type:
                 raise TypeMismatchException("Lists may only contain one type", self.expr)
             else:
                 o.append(current_lll_node)


### PR DESCRIPTION
### What I did
Fix off-by-one in list type checking

### How I did it
The loop wanted to check if there were any elements in the output list yet, but the check should have been `>= 1` instead of `> 1`

### How to verify it

### Description for the changelog
Fix off-by-one in check for homogeneous list element types.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.bing.com/th?id=AMMS_430ac30e3d6e7b0b9bc830a3c5901bcc&pid=Api&w=530&h=412&rs=1)
