### PR TITLE
WIP Fix exponent overflow

### DIFF
--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -200,17 +200,20 @@ def market_cap() -> uint256(wei):
 
 
 def test_constant_folds(search_for_sublist):
-    code = """
+    some_prime = 10013677
+    code = f"""
 SOME_CONSTANT: constant(uint256) = 11 + 1
-
+SOME_PRIME: constant(uint256) = {some_prime}
 
 @public
-def test(some_dynamic_var: uint256) -> uint256:
-    return some_dynamic_var  +  2**SOME_CONSTANT
+def test() -> uint256:
+    # calculate some constant which is really unlikely to be randomly
+    # in bytecode
+    return 2**SOME_CONSTANT * SOME_PRIME
     """
 
     lll = compile_code(code, ['ir'])['ir']
-    assert search_for_sublist(lll, ['add', ['calldataload', [4]], [4096]])
+    assert search_for_sublist(lll, ['mstore', [0], [2**12 * some_prime]])
 
 
 def test_constant_lists(get_contract):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -512,15 +512,14 @@ class Expr(object):
             if ltyp == 'uint256' and isinstance(self.expr.op, ast.Add):
                 # safeadd
                 arith = ['seq',
-                        # Checks that: a + b >= a
-                        ['assert', ['ge', ['add', 'l', 'r'], 'l']],
-                        ['add', 'l', 'r']]
+                         ['assert', ['ge', ['add', 'l', 'r'], 'l']],
+                         ['add', 'l', 'r']]
 
             elif ltyp == 'uint256' and isinstance(self.expr.op, ast.Sub):
+                # safesub
                 arith = ['seq',
-                        # Checks that: a >= b
-                        ['assert', ['ge', 'l', 'r']],
-                        ['sub', 'l', 'r']]
+                         ['assert', ['ge', 'l', 'r']],
+                         ['sub', 'l', 'r']]
 
             elif ltyp == rtyp:
                 arith = [op, 'l', 'r']
@@ -536,13 +535,12 @@ class Expr(object):
 
             if ltyp == rtyp == 'uint256':
                 arith = ['with', 'ans', ['mul', 'l', 'r'],
-                        ['seq',
-                            ['assert',
-                                ['or',
-                                    ['eq', ['div', 'ans', 'l'], 'r'],
-                                ['iszero', 'l']]
-                                ],
-                            'ans']]
+                         ['seq',
+                             ['assert',
+                                 ['or',
+                                     ['eq', ['div', 'ans', 'l'], 'r'],
+                                     ['iszero', 'l']]],
+                             'ans']]
 
             elif ltyp == rtyp == 'int128':
                 # TODO should this be 'smul' (note edge cases in YP for smul)
@@ -550,13 +548,12 @@ class Expr(object):
 
             elif ltyp == rtyp == 'decimal':
                 arith = ['with', 'ans', ['mul', 'l', 'r'],
-                        ['seq',
-                            ['assert',
-                                ['or',
-                                    ['eq', ['sdiv', 'ans', 'l'], 'r'],
-                                    ['iszero', 'l']]
-                                ],
-                            ['sdiv', 'ans', DECIMAL_DIVISOR]]]
+                         ['seq',
+                             ['assert',
+                                 ['or',
+                                     ['eq', ['sdiv', 'ans', 'l'], 'r'],
+                                     ['iszero', 'l']]],
+                             ['sdiv', 'ans', DECIMAL_DIVISOR]]]
             else:
                 raise Exception(f"Unsupported Operation 'mul({ltyp}, {rtyp})'")
 
@@ -573,9 +570,9 @@ class Expr(object):
 
             elif ltyp == rtyp == 'decimal':
                 arith = ['sdiv',
-                        # TODO check overflow cases
-                        ['mul', 'l', DECIMAL_DIVISOR],
-                        ['clamp_nonzero', 'r']]
+                         # TODO check overflow cases
+                         ['mul', 'l', DECIMAL_DIVISOR],
+                         ['clamp_nonzero', 'r']]
 
             else:
                 raise Exception(f"Unsupported Operation 'div({ltyp}, {rtyp})'")
@@ -622,15 +619,13 @@ class Expr(object):
 
             if ltyp == rtyp == 'uint256':
                 arith = ['seq',
-                        ['assert',
-                            ['or',
-                                # r == 1 | iszero(r)
-                                # could be simplified to ~(r & 1)
-                                ['or', ['eq', 'r', 1], ['iszero', 'r']],
-                                ['lt', 'l', ['exp', 'l', 'r']]
-                                ]
-                            ],
-                        ['exp', 'l', 'r']]
+                         ['assert',
+                             ['or',
+                                 # r == 1 | iszero(r)
+                                 # could be simplified to ~(r & 1)
+                                 ['or', ['eq', 'r', 1], ['iszero', 'r']],
+                                 ['lt', 'l', ['exp', 'l', 'r']]]],
+                         ['exp', 'l', 'r']]
             elif ltyp == rtyp == 'int128':
                 arith = ['exp', 'l', 'r']
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -523,11 +523,11 @@ class Expr(object):
 
             op = 'add' if isinstance(self.expr.op, ast.Add) else 'sub'
             if ltyp == 'uint256' and isinstance(self.expr.op, ast.Add):
-                o = LLLnode.from_list([
-                    'seq',
+                o = LLLnode.from_list(['with', 'l', left, ['with', 'r', right,
+                    ['seq',
                     # Checks that: a + b >= a
-                    ['assert', ['ge', ['add', left, right], left]],
-                    ['add', left, right],
+                    ['assert', ['ge', ['add', 'l', 'r'], 'l']],
+                    ['add', 'l', 'r']]]
                 ], typ=BaseType('uint256', new_unit, new_positional), pos=getpos(self.expr))
             elif ltyp == 'uint256' and isinstance(self.expr.op, ast.Sub):
                 o = LLLnode.from_list([


### PR DESCRIPTION
### What I did
(WIP because it depends on another PR)
Fix exponent overflow

### How I did it
In general there is no good way without an inverse operation (i.e.
logarithm) to check that the exp operation has not overflowed. Luckily
the EVM charges an extra G_expbyte for every overflow encountered in the
exponentiation, so we can profile the gas used to detect the overflow.

### How to verify it
WIP tests

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
