### PR TITLE
Add support for Python3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
 
 workflows:
   version: 2
@@ -62,3 +68,4 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37}-core
+    py{36,37,38}-core
     lint
 
 [flake8]
@@ -37,6 +37,7 @@ commands =
 basepython =
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 extras =
     test
 whitelist_externals = make

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -117,7 +117,7 @@ class keyword(VyperNode):
 
 
 class Str(VyperNode):
-    __slots__ = ('s', )
+    __slots__ = ('s', 'value')
 
 
 class Compare(VyperNode):
@@ -125,7 +125,7 @@ class Compare(VyperNode):
 
 
 class Num(VyperNode):
-    __slots__ = ('n', )
+    __slots__ = ('n', 'value')
 
 
 class NameConstant(VyperNode):

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -117,7 +117,7 @@ class keyword(VyperNode):
 
 
 class Str(VyperNode):
-    __slots__ = ('s', 'value')
+    __slots__ = ('s', )
 
 
 class Compare(VyperNode):
@@ -125,7 +125,7 @@ class Compare(VyperNode):
 
 
 class Num(VyperNode):
-    __slots__ = ('n', 'value')
+    __slots__ = ('n', )
 
 
 class NameConstant(VyperNode):
@@ -258,6 +258,7 @@ class Assert(VyperNode):
 
 class For(VyperNode):
     __slots__ = ('iter', 'target', 'body')
+    only_empty_fields = ('orelse', )
 
 
 class AugAssign(VyperNode):

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -76,18 +76,16 @@ def parse_python_ast(source_code: str,
     if isinstance(node, list):
         return _build_vyper_ast_list(source_code, node, source_id)
     elif isinstance(node, python_ast.AST):
-        # necessary for python3.8 compatibility
-        if isinstance(node, python_ast.Num):
-            class_name = "Num"
-        elif isinstance(node, python_ast.Str):
-            class_name = "Str"
-        elif isinstance(node, python_ast.Bytes):
-            class_name = "Bytes"
-        elif isinstance(node, python_ast.NameConstant):
-            class_name = "NameConstant"
-        else:
-            class_name = node.__class__.__name__
-
+        class_name = node.__class__.__name__
+        if isinstance(node, python_ast.Constant):
+            if isinstance(node.value, (int, float)):
+                class_name = "Num"
+            elif isinstance(node.value, str):
+                class_name = "Str"
+            elif isinstance(node.value, bytes):
+                class_name = "Bytes"
+            elif node.value is None or isinstance(node.value, bool):
+                class_name = "NameConstant"
         if not hasattr(vyper_ast, class_name):
             raise SyntaxException(
                 f'Invalid syntax (unsupported "{class_name}" Python AST node).', node

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -87,7 +87,19 @@ def parse_python_ast(source_code: str,
     if isinstance(node, list):
         return _build_vyper_ast_list(source_code, node, source_id)
     elif isinstance(node, python_ast.AST):
-        class_name = node.__class__.__name__
+        if isinstance(node, python_ast.Num):
+            class_name = "Num"
+            node._fields += ('n',)
+        elif isinstance(node, python_ast.Str):
+            class_name = "Str"
+            node._fields += ('s',)
+        elif isinstance(node, python_ast.Bytes):
+            class_name = "Bytes"
+            node._fields += ('s',)
+        elif isinstance(node, python_ast.NameConstant):
+            class_name = "NameConstant"
+        else:
+            class_name = node.__class__.__name__
         if hasattr(vyper_ast, class_name):
             vyper_class = getattr(vyper_ast, class_name)
             init_kwargs = _build_vyper_ast_init_kwargs(

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -80,14 +80,14 @@ def parse_python_ast(source_code: str,
 
     class_name = node.__class__.__name__
     if isinstance(node, python_ast.Constant):
-        if isinstance(node.value, (int, float)):
+        if node.value is None or isinstance(node.value, bool):
+            class_name = "NameConstant"
+        elif isinstance(node.value, (int, float)):
             class_name = "Num"
         elif isinstance(node.value, str):
             class_name = "Str"
         elif isinstance(node.value, bytes):
             class_name = "Bytes"
-        elif node.value is None or isinstance(node.value, bool):
-            class_name = "NameConstant"
     if not hasattr(vyper_ast, class_name):
         raise SyntaxException(f'Invalid syntax (unsupported "{class_name}" Python AST node).', node)
 


### PR DESCRIPTION
### What I did
Add support for Python 3.8

### How I did it
* Replace `Constant` python AST type with deprecated type names when generating Vyper AST nodes.
* Add python3.8 build to CI

### How to verify it
Run the tests

### Description for the changelog
* support for Python3.8

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/68153278-3bb7de00-ff6b-11e9-8c3a-f7c81d3200a9.png)
