### PR TITLE
Avoid overflow on sqrt of Decimal upper bound

### DIFF
--- a/tests/parser/types/numbers/test_sqrt.py
+++ b/tests/parser/types/numbers/test_sqrt.py
@@ -142,6 +142,13 @@ def test(a: decimal) -> decimal:
     return c
 
 
+@pytest.mark.parametrize('value', [Decimal(0), Decimal(SizeLimits.MAXNUM)])
+def test_sqrt_bounds(sqrt_contract, value):
+    vyper_sqrt = sqrt_contract.test(value)
+    actual_sqrt = decimal_sqrt(value)
+    assert vyper_sqrt == actual_sqrt
+
+
 @hypothesis.given(
     value=hypothesis.strategies.decimals(
         min_value=Decimal(0),

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1210,7 +1210,7 @@ z: decimal = 0.0
 if x == 0.0:
     z = 0.0
 else:
-    z = (x + 1.0) / 2.0
+    z = x / 2.0 + 0.5
     y: decimal = x
 
     for i in range(256):


### PR DESCRIPTION
### What I did
* Fixed an overflow when attempting to calculate the sqrt of `2**127`

### How I did it
`vyper/functions/functions.py` line 1213, divide before adding.

### How to verify it
Run the tests. I've added a new test case to specifically check the upper and lower bounds, as this was discovered by fuzzing.

### Description for the changelog
* Bugfix: sqrt overflow on upper bound of Decimal

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/68180385-8bbd9180-ffb9-11e9-96f8-66aa71792da5.png)
