### PR TITLE
Make scientific notation an invalid literal declaration

### DIFF
--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -120,7 +120,12 @@ def overflow() -> uint256:
 def overflow2() -> uint256:
     a: uint256 = 2**256
     return a
+    """,
     """
+@public
+def scientific_notation() -> decimal:
+    return 2e-8  # not valid decimal literal
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -60,7 +60,7 @@ def test(VAL: uint256):
 
 
 @pytest.mark.parametrize('bad_code', fail_list)
-def test_as_wei_fail(bad_code):
+def test_constants_fail(bad_code):
     if isinstance(bad_code, tuple):
         with raises(bad_code[1]):
             compiler.compile_code(bad_code[0])
@@ -143,5 +143,5 @@ ZERO_LIST: constant(int128[8]) = [0, 0, 0, 0, 0, 0, 0, 0]
 
 
 @pytest.mark.parametrize('good_code', valid_list)
-def test_as_wei_success(good_code):
+def test_constant_success(good_code):
     assert compiler.compile_code(good_code) is not None

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -8,6 +8,7 @@ from vyper import (
 )
 from vyper.exceptions import (
     FunctionDeclarationException,
+    InvalidLiteralException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
@@ -55,7 +56,10 @@ VAL: constant(bytes[4]) = b"t"
 @public
 def test(VAL: uint256):
     pass
-    """, FunctionDeclarationException)
+    """, FunctionDeclarationException),
+    ("""
+VAL: constant(decimal) = 2e-8
+    """, InvalidLiteralException),
 ]
 
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -55,6 +55,8 @@ def get_number_as_fraction(expr, context):
     t = 0
     while t < len(context_slice) and context_slice[t] in '0123456789.':
         t += 1
+    if t < len(context_slice) and context_slice[t] == 'e':
+        raise InvalidLiteralException("Literals in scientific notation not accepted.")
     top = int(context_slice[:t].replace('.', ''))
     bottom = 1 if '.' not in context_slice[:t] else 10**(t - context_slice[:t].index('.') - 1)
 


### PR DESCRIPTION
fixes: #1680

### What I did
Raise `InvalidLiteralException` when scientific notation is used for a literal value (either for a constant, or in a method)

### How I did it
WIP

### How to verify it
Well, tests fail...

### Description for the changelog
Added additional verification of literals to ensure scientific notation was not used (as Python interprets as a float)

### Cute Animal Picture
![cute birds](https://i.ytimg.com/vi/RmZaR5kMpGk/maxresdefault.jpg)
