### PR TITLE
Reserved keywords fix

### DIFF
--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -113,15 +113,6 @@ def zoo() -> uint256:
     assert c.zoo() == 2**256 - 1
 
 
-def test_reserved_keyword(get_contract, assert_compile_failed):
-    code = """
-@public
-def test():
-    ZERO_ADDRESS: address
-    """
-    assert_compile_failed(lambda: get_contract(code))
-
-
 def test_custom_constants(get_contract):
     code = """
 X_VALUE: constant(uint256) = 33

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -192,7 +192,7 @@ reserved_words = {
     # units
     'units',
     # sentinal constant values
-    'zero_address', 'empty_bytes32' 'max_int128', 'min_int128', 'max_decimal',
+    'zero_address', 'empty_bytes32', 'max_int128', 'min_int128', 'max_decimal',
     'min_decimal', 'max_uint256', 'zero_wei',
 }
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -170,11 +170,12 @@ reserved_words = {
     # control flow
     'if', 'for', 'while', 'until', 'pass',
     'def',
-    # EVM operations and transaction properties
+    # EVM operations
     'push', 'dup', 'swap', 'send', 'call',
     'selfdestruct', 'assert', 'stop', 'throw',
     'raise', 'init', '_init_', '___init___', '____init____',
-    'msg',
+    # environment variables
+    'block', 'msg', 'tx',
     # boolean literals
     'true', 'false',
     # more control flow and special operations
@@ -192,7 +193,7 @@ reserved_words = {
     'units',
     # sentinal constant values
     'zero_address', 'empty_bytes32' 'max_int128', 'min_int128', 'max_decimal',
-    'min_decimal', 'max_uint256',
+    'min_decimal', 'max_uint256', 'zero_wei',
 }
 
 # Otherwise reserved words that are whitelisted for function declarations


### PR DESCRIPTION
### What I did
Fix #1697  and related bugs

### How I did it
Add `zero_wei` to list of reserved words (also `tx`, `block`, and a missing comma between `empty_bytes32` and `max_int128`)

### How to verify it
Run the tests, I added parametrized cases to check builtin constants when assigned in memory, storage, and function signatures.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/68607323-cf3c6200-04c9-11ea-8853-ca3337bcd6b8.png)
