### PR TITLE
Only rewrite bytes32 when they are literals

### DIFF
--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,3 +1,7 @@
+from vyper.exceptions import (
+    TypeMismatchException,
+)
+
 
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
     test_bytes = """
@@ -268,3 +272,13 @@ def get_count() -> bytes[24]:
     assert c.get_count() == b'\xf0\xf0\xf0\x00\x00\x00\x00\x00'
     c.set_count(0x0101010101010101, transact={})
     assert c.get_count() == b'\x01\x01\x01\x01\x01\x01\x01\x01'
+
+
+def test_bytes_to_bytes32_assigment(get_contract, assert_compile_failed):
+    code = """
+@public
+def assign():
+    xs: bytes[32] = b'abcdef'
+    y: bytes32 = xs
+    """
+    assert_compile_failed(lambda: get_contract(code), TypeMismatchException)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -206,13 +206,15 @@ class Expr(object):
     # String literals
     def string(self):
         bytez, bytez_length = string_to_bytes(self.expr.s)
-        return self._make_bytelike(StringType(bytez_length), bytez, bytez_length)
+        typ = StringType(bytez_length, is_literal=True)
+        return self._make_bytelike(typ, bytez, bytez_length)
 
     # Byte literals
     def bytes(self):
         bytez = self.expr.s
         bytez_length = len(self.expr.s)
-        return self._make_bytelike(ByteArrayType(bytez_length), bytez, bytez_length)
+        typ = ByteArrayType(bytez_length, is_literal=True)
+        return self._make_bytelike(typ, bytez, bytez_length)
 
     def _make_bytelike(self, btype, bytez, bytez_length):
         placeholder = self.context.new_placeholder(btype)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -225,7 +225,7 @@ class Stmt(object):
                 and sub.typ.maxlen == 32
                 and isinstance(typ, BaseType)
                 and typ.typ == 'bytes32'
-                and typ.is_literal
+                and sub.typ.is_literal
             )
 
             # If bytes[32] to bytes32 assignment rewrite sub as bytes32.

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -220,12 +220,16 @@ class Stmt(object):
                     self.stmt
                 )
 
-            is_valid_bytes32_assign = (
-                isinstance(sub.typ, ByteArrayType) and sub.typ.maxlen == 32
-            ) and isinstance(typ, BaseType) and typ.typ == 'bytes32'
+            is_literal_bytes32_assign = (
+                isinstance(sub.typ, ByteArrayType)
+                and sub.typ.maxlen == 32
+                and isinstance(typ, BaseType)
+                and typ.typ == 'bytes32'
+                and typ.is_literal
+            )
 
             # If bytes[32] to bytes32 assignment rewrite sub as bytes32.
-            if is_valid_bytes32_assign:
+            if is_literal_bytes32_assign:
                 sub = LLLnode(
                     bytes_to_int(self.stmt.value.s),
                     typ=BaseType('bytes32'),

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -137,8 +137,9 @@ class ContractType(BaseType):
 
 
 class ByteArrayLike(NodeType):
-    def __init__(self, maxlen):
+    def __init__(self, maxlen, is_literal=False):
         self.maxlen = maxlen
+        self.is_literal = is_literal
 
     def eq(self, other):
         return self.maxlen == other.maxlen


### PR DESCRIPTION
### What I did
Fix https://github.com/ethereum/vyper/issues/1717

### How I did it
There is a rewrite rule but was only intended for literals.

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/02/Sea_Otter_%28Enhydra_lutris%29_%2825169790524%29_crop.jpg)
