### PR TITLE
Add support raw_log data of bytes32.

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -248,9 +248,10 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
     Provides low level access to the ``LOG`` opcodes, emitting a log without having to specify an ABI type.
 
     * ``topics``: List of ``bytes32`` log topics
-    * ``data``: Unindexed event data to include in the log
+    * ``data``: Unindexed event data to include in the log, bytes or bytes32
 
-    This method provides low-level access to the ``LOG`` opcodes (``0xA0``..``0xA4``). The length of ``topics`` determines which opcode will be used.
+    This method provides low-level access to the ``LOG`` opcodes (``0xA0``..``0xA4``). The length of ``topics`` determines which opcode will be used. ``topics`` is a list of bytes32 topics that will be indexed. The remaining unindexed parameters can be placed in the ``data`` parameter.
+
 
 .. py:function:: create_forwarder_to(target: address, value: uint256(wei) = 0) -> address
 

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -6,7 +6,9 @@ from vyper.exceptions import (
     EventDeclarationException,
     TypeMismatchException,
 )
-from vyper.utils import keccak256
+from vyper.utils import (
+    keccak256,
+)
 
 
 def test_empty_event_logging(w3, tester, keccak, get_contract_with_gas_estimation):

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -6,6 +6,7 @@ from vyper.exceptions import (
     EventDeclarationException,
     TypeMismatchException,
 )
+from vyper.utils import keccak256
 
 
 def test_empty_event_logging(w3, tester, keccak, get_contract_with_gas_estimation):
@@ -748,6 +749,29 @@ def ioo(inp: bytes[100]):
     assert w3.toText(logs[0]['data']) == 'moo4'
 
     print("Passed raw log tests")
+
+
+def test_raw_call_bytes32_data(w3, tester, get_contract_with_gas_estimation):
+    code = """
+b: uint256
+
+@public
+def foo():
+    a: uint256 = 1234
+    self.b = 4321
+    raw_log([], convert(a, bytes32))
+    raw_log([], convert(self.b, bytes32))
+    raw_log([], convert(b"testmessage", bytes32))
+    raw_log([], keccak256(b""))
+    """
+    c = get_contract_with_gas_estimation(code)
+    tx_hash = c.foo(transact={})
+    receipt = tester.get_transaction_receipt(tx_hash.hex())
+    logs = receipt['logs']
+    assert logs[0]['data'] == w3.toHex((1234).to_bytes(32, 'big'))
+    assert logs[1]['data'] == w3.toHex((4321).to_bytes(32, 'big'))
+    assert logs[2]['data'] == w3.toHex(b"testmessage").ljust(32*2 + 2, '0')
+    assert logs[3]['data'] == w3.toHex(keccak256(b""))
 
 
 def test_variable_list_packing(get_logs, get_contract_with_gas_estimation):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -981,8 +981,7 @@ def raw_log(expr, args, kwargs, context):
                     "log" + str(len(topics)),
                     placeholder,
                     32,
-                ] + topics
-            ] , typ=None, pos=getpos(expr))
+                ] + topics], typ=None, pos=getpos(expr))
     if args[1].location == "memory":
         return LLLnode.from_list([
             "with", "_arr", args[1], [


### PR DESCRIPTION
### What I did
I found this was quite necessary in some cases. Also we need to start supporting the other uint* types, keep seeing them in the wild, and then I have to do hacks like mining function signature + raw_log + raw_call.

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://data.whicdn.com/images/246850644/original.jpg)
