### PR TITLE
Fix fornat typo

### DIFF
--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -192,7 +192,7 @@ def to_uint256(expr, args, kwargs, context):
                 pos=getpos(expr)
             )
         else:
-            raise InvalidLiteralException("Unknown numeric literal type: {}".fornat(in_arg))
+            raise InvalidLiteralException("Unknown numeric literal type: {}".format(in_arg))
 
     elif isinstance(in_arg, LLLnode) and input_type == 'int128':
         return LLLnode.from_list(


### PR DESCRIPTION
### What I did

Fixed #1725 

### How I did it

tiny edit to change `fornat` to `format`

### How to verify it

run code from #1725

### Description for the changelog

Fix typo in an error message for bad converts

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
