### PR TITLE
Added testcase from #1725

### DIFF
--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -60,6 +60,10 @@ def test(VAL: uint256):
     ("""
 VAL: constant(decimal) = 2e-8
     """, InvalidLiteralException),
+    ("""
+C1: constant(uint256) = block.number
+C2: constant(uint256) = convert(C1, uint256)
+    """, InvalidLiteralException),
 ]
 
 


### PR DESCRIPTION
### What I did
I added a snippet of the test case discovered in #1725 (which uncovered a separate spelling bug). I was curious why that particular path wasn't being hit, and was getting strange results in the error message, so I decided to add this test case failure to ensure it's always being tested in case a parsing change makes it work differently.

### Cute Animal Picture
![paranoid panda](https://mir-s3-cdn-cf.behance.net/project_modules/disp/55931953411211.56090d32254f1.jpg)